### PR TITLE
docs(speckit): add contributor and local development guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-05
 - TypeScript 6.0.0 (strict) with Bun 1.3.9 runtime; Node 22.14.0+ and npm 11.5.1+ for npm trusted publishing + Bun 1.3.9, `citty`, `simple-git`, `zod`, release-please, GitHub Actions, npm registry trusted publishing via OIDC (20260405-112827-bunx-release)
 - N/A for runtime data; repository files, GitHub Releases, and npm registry package metadata (20260405-112827-bunx-release)
 - TypeScript 6.0.0 (strict) with Bun 1.3.9 runtime; Node 22.14.0+ and npm 11.5.1+ for trusted publishing + Bun 1.3.9, `citty`, `simple-git`, `zod`, release-please, GitHub Actions, npm registry trusted publishing via OIDC (20260405-112827-bunx-release)
+- Markdown documentation plus TypeScript 6.0.0 repository contex + Existing repo toolchain only; authoritative research sources are official spec-kit documentation and the `github/spec-kit` repository (20260405-195011-speckit-dev-docs)
+- Repository-hosted Markdown files under `README.md`, `docs/`, `.github/`, and `.specify/` as referenced documentation sources (20260405-195011-speckit-dev-docs)
 
 - TypeScript 5.8+ (strict mode; `any` forbidden — use `unknown` + Zod) + `bun:test` (built-in), `age-encryption ^0.3.0`, `simple-git ^3.27.0`, `tar ^7.4.0`, `zod ^3.23.8`, `@iarna/toml ^2.2.5` (001-initial-function-testing)
 
@@ -30,9 +32,9 @@ npm test && npm run lint
 TypeScript 5.8+ (strict mode; `any` forbidden — use `unknown` + Zod): Follow standard conventions
 
 ## Recent Changes
+- 20260405-195011-speckit-dev-docs: Added Markdown documentation plus TypeScript 6.0.0 repository contex + Existing repo toolchain only; authoritative research sources are official spec-kit documentation and the `github/spec-kit` repository
 - 20260405-112827-bunx-release: Added TypeScript 6.0.0 (strict) with Bun 1.3.9 runtime; Node 22.14.0+ and npm 11.5.1+ for trusted publishing + Bun 1.3.9, `citty`, `simple-git`, `zod`, release-please, GitHub Actions, npm registry trusted publishing via OIDC
 - 20260405-112827-bunx-release: Added TypeScript 6.0.0 (strict) with Bun 1.3.9 runtime; Node 22.14.0+ and npm 11.5.1+ for npm trusted publishing + Bun 1.3.9, `citty`, `simple-git`, `zod`, release-please, GitHub Actions, npm registry trusted publishing via OIDC
-- 20260405-091845-improve-project-docs: Added TypeScript 6.x (strict mode) plus Markdown documentation + Bun 1.3.9, `citty ^0.2.2`, `@clack/prompts ^1.2.0`, `simple-git ^3.27.0`, `zod ^4.0.0`
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,21 +1,24 @@
 <!-- Sync Impact Report
-  Version change: 1.1.0 → 1.2.0
+  Version change: 1.3.0 → 1.4.0
   Modified principles:
-    - None renamed
+    - II. Test Coverage (NON-NEGOTIABLE) → II. Test Coverage (NON-NEGOTIABLE)
   Added sections: None
   Modified sections:
-    - Development Workflow: Branch strategy bullet expanded to mandate
-      timestamp naming (YYYYMMDD-HHMMSS-<slug>) and prohibit sequential
-      numeric prefixes for new branches.
+    - Principle II expanded with a narrow documentation-only exception to the
+      automated test-case requirement when all changed files are limited to
+      repository-hosted documentation and feature-planning artifacts and the
+      change does not affect runtime source, exported symbols, configuration
+      schemas, packaging logic, CI automation, or generated workflow scripts.
+    - Principle II now requires documentation-only exceptions to preserve the
+      `bun run check` merge gate, Mermaid validation, and manual walkthrough
+      validation steps in the relevant feature artifacts.
   Removed sections: None
   Templates requiring updates:
-    - .specify/templates/plan-template.md ✅ updated ([###-feature-name] → [YYYYMMDD-HHMMSS-feature-name])
-    - .specify/templates/spec-template.md ✅ updated ([###-feature-name] → [YYYYMMDD-HHMMSS-feature-name])
-    - .specify/templates/tasks-template.md ✅ updated ([###-feature-name] → [YYYYMMDD-HHMMSS-feature-name])
-    - .specify/init-options.json ⚠️ pending: "branch_numbering" should be changed from "sequential" to "timestamp"
-  Follow-up TODOs:
-    - TODO(INIT_OPTIONS): Update .specify/init-options.json "branch_numbering" from "sequential" to "timestamp"
-      so new project scaffolding respects this convention by default.
+    - .specify/templates/plan-template.md ✅ updated
+    - .specify/templates/spec-template.md ✅ updated
+    - .specify/templates/tasks-template.md ✅ updated
+    - docs/maintenance.md ✅ updated
+  Follow-up TODOs: None
 -->
 
 # AgentSync Constitution
@@ -54,6 +57,16 @@ its sole test runner.
 - All other modules MUST maintain ≥70% line coverage.
 - New features MUST include tests that exercise both the success path
   and at least one error/edge-case path before the PR is mergeable.
+- Documentation-only features are exempt from the automated test-case
+  requirement above only when all changed files are limited to
+  repository-hosted documentation and feature-planning artifacts, and
+  the change does not alter runtime source files, exported symbols,
+  configuration schemas, packaging logic, CI automation, or generated
+  workflow scripts. These features MUST still:
+  1. run `bun run check` before merge,
+  2. validate any introduced or modified Mermaid diagrams, and
+  3. define manual walkthrough validation steps in the relevant feature
+     artifacts.
 - Test files MUST be placed in a `__tests__/` subdirectory within the
   same directory as the module they test, using the `*.test.ts` naming
   convention (e.g. `src/core/__tests__/git.test.ts` for `src/core/git.ts`).
@@ -98,12 +111,15 @@ formatting tools MUST NOT be added to the project.
   (Biome v2 path; v1 `organizeImports` section is removed); manual
   import sorting MUST NOT be performed.
 
-### V. JSDoc Documentation Standards
+### V. Documentation Standards
 
 All exported functions, classes, interfaces, and types MUST have JSDoc
-comments. Documentation MUST be concise — a single sentence stating
-_what_ the symbol does — and MUST explain _why_ it exists and any
-non-obvious behaviour or constraints.
+comments. Repository-hosted explanatory documentation MUST use Mermaid
+diagrams when a visual explanation materially improves reader
+comprehension of a flow, structure, lifecycle, or interaction compared
+with prose alone. Documentation MUST stay concise, must explain _what_
+exists and _why_ it matters, and MUST avoid decorative diagrams that do
+not add explanatory value.
 
 - `@param`, `@returns`, and `@throws` tags MUST be present for public
   API functions that have multiple parameters, non-void return values,
@@ -113,6 +129,17 @@ non-obvious behaviour or constraints.
 - Documentation MUST be updated in the same commit as any change that
   alters a symbol's observable behaviour, signature, or semantics.
   Stale JSDoc is treated as a documentation defect.
+- Repository docs that describe architecture, workflow, state changes,
+  command flow, review flow, or other decision-heavy interactions MUST
+  include a Mermaid diagram when that diagram makes the explanation
+  faster or less ambiguous for readers.
+- Mermaid diagrams MUST be authored for comprehension, not decoration.
+  They MUST reflect the documented behavior accurately, use labels that
+  stand on their own, and remain small enough to review without
+  reverse-engineering the surrounding prose.
+- Every Mermaid diagram introduced or modified in repository-hosted docs
+  MUST be validated before merge. Invalid Mermaid syntax is treated as a
+  documentation defect.
 - Auto-derived types (e.g., `z.infer<typeof Schema>`) are exempt from
   inline JSDoc but MUST have a one-line comment at the declaration site
   identifying the source schema.
@@ -160,8 +187,12 @@ non-obvious behaviour or constraints.
 - **Documentation gate**: Every PR that adds or modifies an exported
   symbol MUST include up-to-date JSDoc for those symbols (Principle V).
   Reviewers MUST reject PRs where JSDoc is absent or describes outdated
-  behaviour. Documentation updates MUST land in the same commit as the
-  implementation change — not as a follow-up.
+  behaviour. When a documentation page explains a workflow, structure,
+  lifecycle, or interaction that is materially clearer as a diagram,
+  the PR MUST include or update the Mermaid diagram in the same change
+  and MUST validate that diagram before merge. Documentation updates
+  MUST land in the same commit as the implementation change — not as a
+  follow-up.
 
 ## Governance
 
@@ -182,4 +213,4 @@ review MUST verify compliance with the principles above.
   constitution, the constitution takes precedence. The conflicting
   artifact MUST be amended to align.
 
-**Version**: 1.2.0 | **Ratified**: 2026-04-04 | **Last Amended**: 2026-04-04
+**Version**: 1.4.0 | **Ratified**: 2026-04-04 | **Last Amended**: 2026-04-05

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -33,6 +33,23 @@
 
 [Gates determined based on constitution file]
 
+- Test coverage impact: Default to automated test tasks for new feature
+  work. Only treat the feature as documentation-only when all changed
+  files are limited to repository-hosted documentation and
+  feature-planning artifacts and the change does not affect runtime
+  source files, exported symbols, configuration schemas, packaging
+  logic, CI automation, or generated workflow scripts.
+- Documentation impact: If the feature changes or adds explanatory docs,
+  identify whether a Mermaid diagram is required to explain workflow,
+  structure, lifecycle, or interaction behavior more clearly than prose.
+- Documentation-only validation impact: If the feature qualifies for the
+  documentation-only exception, record the manual walkthrough validation
+  steps and name the spec, plan, or quickstart artifact that will carry
+  them.
+- Diagram validation impact: If Mermaid is required, name the target doc
+  surfaces and include validation as part of the implementation and
+  review plan.
+
 ## Project Structure
 
 ### Documentation (this feature)
@@ -99,6 +116,6 @@ directories captured above]
 > **Fill ONLY if Constitution Check has violations that must be justified**
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |
-|-----------|------------|-------------------------------------|
+| --------- | ---------- | ----------------------------------- |
 | [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
 | [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -18,6 +18,13 @@
   - Tested independently
   - Deployed independently
   - Demonstrated to users independently
+
+  Default expectation: new features require automated tests that cover
+  the success path and at least one error or edge-case path. A feature
+  may omit automated test cases only when it qualifies as
+  documentation-only under the constitution and instead defines manual
+  walkthrough validation steps in this spec or the linked plan or
+  quickstart artifact.
 -->
 
 ### User Story 1 - [Brief Title] (Priority: P1)
@@ -80,6 +87,10 @@
 <!--
   ACTION REQUIRED: The content in this section represents placeholders.
   Fill them out with the right functional requirements.
+
+  If reader understanding depends on explaining a workflow, structure,
+  lifecycle, or interaction, add a functional requirement for a Mermaid
+  diagram rather than leaving that need implicit.
 -->
 
 ### Functional Requirements
@@ -126,3 +137,23 @@
 - [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
 - [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
 - [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]
+
+## Documentation Impact
+
+<!--
+  OPTIONAL: Include this section when the feature changes repository-hosted
+  documentation or when readers would benefit from a Mermaid diagram.
+
+  Example prompts for this section:
+  - Which docs must change?
+  - Does the feature qualify for the documentation-only testing
+    exception? If yes, explain why the changed files are limited to
+    repository-hosted docs and feature-planning artifacts and confirm no
+    runtime source, exported symbol, configuration schema, packaging,
+    CI, or generated workflow script behavior changes.
+  - Does the feature require a Mermaid diagram to explain flow, structure,
+    lifecycle, or interaction clearly?
+  - What manual walkthrough steps must reviewers validate in the spec,
+    plan, or quickstart artifacts?
+  - What must reviewers validate in those docs?
+-->

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -8,7 +8,13 @@ description: "Task list template for feature implementation"
 **Input**: Design documents from `/specs/[YYYYMMDD-HHMMSS-feature-name]/`
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
-**Tests**: The examples below include test tasks. Tests are OPTIONAL - only include them if explicitly requested in the feature specification.
+**Tests**: The examples below include test tasks. Automated tests are the
+default requirement for new features and MUST be included unless the
+feature explicitly qualifies for the constitution's documentation-only
+exception. Documentation-only features may omit automated test tasks
+only when the spec or plan records the exception rationale and the work
+still includes `bun run check`, Mermaid validation where applicable, and
+manual walkthrough validation tasks.
 
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
 
@@ -79,9 +85,13 @@ Examples of foundational tasks (adjust based on your project):
 
 **Independent Test**: [How to verify this story works on its own]
 
-### Tests for User Story 1 (OPTIONAL - only if tests requested) ⚠️
+### Tests for User Story 1 (REQUIRED unless documentation-only exception applies) ⚠️
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+> **Documentation-only exception**: Remove automated test tasks only
+> when the feature is limited to repository-hosted documentation and
+> feature-planning artifacts, does not alter runtime behavior or release
+> surfaces, and includes manual walkthrough validation plus `bun run check`.
 
 - [ ] T010 [P] [US1] Contract test for [endpoint] in tests/contract/test_[name].py
 - [ ] T011 [P] [US1] Integration test for [user journey] in tests/integration/test_[name].py
@@ -105,7 +115,7 @@ Examples of foundational tasks (adjust based on your project):
 
 **Independent Test**: [How to verify this story works on its own]
 
-### Tests for User Story 2 (OPTIONAL - only if tests requested) ⚠️
+### Tests for User Story 2 (REQUIRED unless documentation-only exception applies) ⚠️
 
 - [ ] T018 [P] [US2] Contract test for [endpoint] in tests/contract/test_[name].py
 - [ ] T019 [P] [US2] Integration test for [user journey] in tests/integration/test_[name].py
@@ -127,7 +137,7 @@ Examples of foundational tasks (adjust based on your project):
 
 **Independent Test**: [How to verify this story works on its own]
 
-### Tests for User Story 3 (OPTIONAL - only if tests requested) ⚠️
+### Tests for User Story 3 (REQUIRED unless documentation-only exception applies) ⚠️
 
 - [ ] T024 [P] [US3] Contract test for [endpoint] in tests/contract/test_[name].py
 - [ ] T025 [P] [US3] Integration test for [user journey] in tests/integration/test_[name].py
@@ -151,6 +161,10 @@ Examples of foundational tasks (adjust based on your project):
 **Purpose**: Improvements that affect multiple user stories
 
 - [ ] TXXX [P] Documentation updates in docs/
+- [ ] TXXX [P] Mermaid diagram authoring or updates in docs/ when required by spec.md or plan.md
+- [ ] TXXX Validate Mermaid diagrams changed by the feature before final review
+- [ ] TXXX Run `bun run check` before final review
+- [ ] TXXX Execute the manual walkthrough validation steps captured in spec.md, plan.md, or quickstart.md when using the documentation-only exception
 - [ ] TXXX Code cleanup and refactoring
 - [ ] TXXX Performance optimization across all stories
 - [ ] TXXX [P] Additional unit tests (if requested) in tests/unit/
@@ -178,7 +192,8 @@ Examples of foundational tasks (adjust based on your project):
 
 ### Within Each User Story
 
-- Tests (if included) MUST be written and FAIL before implementation
+- Tests for non-documentation-only features MUST be written and FAIL
+  before implementation
 - Models before services
 - Services before endpoints
 - Core implementation before integration
@@ -198,7 +213,7 @@ Examples of foundational tasks (adjust based on your project):
 ## Parallel Example: User Story 1
 
 ```bash
-# Launch all tests for User Story 1 together (if tests requested):
+# Launch all tests for User Story 1 together when automated tests apply:
 Task: "Contract test for [endpoint] in tests/contract/test_[name].py"
 Task: "Integration test for [user journey] in tests/integration/test_[name].py"
 
@@ -245,6 +260,9 @@ With multiple developers:
 - [P] tasks = different files, no dependencies
 - [Story] label maps task to specific user story for traceability
 - Each user story should be independently completable and testable
+- Documentation-only task lists MUST still include `bun run check`,
+  Mermaid validation when diagrams change, and manual walkthrough
+  validation steps in the relevant feature artifacts
 - Verify tests fail before implementing
 - Commit after each task or logical group
 - Stop at any checkpoint to validate story independently

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Not yet positioned as a full hosted service:
 
 This is the contributor workflow for developing from a clone of the repository. It is separate from the published CLI path above.
 
+If your change follows the spec-kit workflow, start with [docs/speckit.md](docs/speckit.md).
+If you are maintaining the repo-local speckit setup itself, use
+[docs/speckit-local-development.md](docs/speckit-local-development.md).
+
 Install dependencies and verify the repo first:
 
 ```bash
@@ -115,6 +119,8 @@ bun run src/cli.ts pull
 
 ## Documentation
 
+- [Speckit guide](docs/speckit.md): start or continue feature work through the repo's spec-kit workflow
+- [Speckit local development guide](docs/speckit-local-development.md): prompt-file locations, active-feature detection, timestamp branches, and workflow upkeep rules
 - [Development guide](docs/development.md): contributor setup, local workflow, and verification steps
 - [Architecture guide](docs/architecture.md): module map, sync flow, security boundaries, and daemon design
 - [Maintenance guide](docs/maintenance.md): release upkeep, OIDC-only publish rules, and documentation/JSDoc change policy
@@ -131,5 +137,6 @@ bun run src/cli.ts pull
 
 If you are evaluating the released CLI path, start with the [latest release](https://github.com/chrisleekr/agentsync/releases/latest) and then [docs/command-reference.md](docs/command-reference.md).
 If you are developing from source, start with [docs/development.md](docs/development.md).
+If you are doing feature planning or workflow work through spec-kit, start with [docs/speckit.md](docs/speckit.md).
 If you want the system model before changing code, read [docs/architecture.md](docs/architecture.md).
 If you are modifying commands or agent integrations, read [docs/maintenance.md](docs/maintenance.md) before opening a PR.

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,6 +41,15 @@ bun run pack:dry-run
 4. Inspect drift with `bun run src/cli.ts status`.
 5. Run diagnostics with `bun run src/cli.ts doctor` when setup looks wrong.
 
+## Speckit workflow
+
+Use [speckit.md](speckit.md) when the change starts as feature planning or documentation through
+the spec-kit workflow rather than as direct source edits.
+
+Use [speckit-local-development.md](speckit-local-development.md) when you need the local details
+behind prompt files, agent files, `.specify/` scripts, active-feature detection, or timestamp
+branch naming.
+
 ## Common contributor loop
 
 ```bash
@@ -72,6 +81,8 @@ The exact resolved paths live in `src/config/paths.ts`. Use that module as the s
 
 ## When to branch into deeper docs
 
+- Use [speckit.md](speckit.md) when you need the command order, artifact map, or next-step logic for a spec-kit feature.
+- Use [speckit-local-development.md](speckit-local-development.md) when you need repo-local speckit behavior, maintenance rules, or recovery guidance.
 - Use [architecture.md](architecture.md) when a code change touches sync flow, daemon behavior, or security boundaries.
 - Use [command-reference.md](command-reference.md) when a released command contract or install path changes.
 - Use [troubleshooting.md](troubleshooting.md) when reproducing setup, key, or remote failures.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -8,6 +8,8 @@ Use this guide when a change affects user-facing behavior, exported symbols, syn
 
 - `README.md` is the entry point, not the full manual.
 - `docs/development.md` owns contributor setup and local workflow.
+- `docs/speckit.md` owns contributor-facing spec-kit workflow order, command usage, artifact expectations, and Mermaid-backed stage flow.
+- `docs/speckit-local-development.md` owns prompt-file locations, active-feature detection, timestamp branch mapping, repo-local recovery guidance, and speckit upkeep triggers.
 - `docs/architecture.md` owns system structure, flow, and security boundaries.
 - `docs/command-reference.md` owns command contracts and support-state notes.
 - `docs/troubleshooting.md` owns failure cases and next diagnostic steps.
@@ -35,12 +37,15 @@ Before merging a release-surface change, verify:
 
 Update repository docs in the same change when you:
 
+- change prompt files, agent files, `.specify/` scripts, or other repo-local spec-kit workflow assets
 - add or remove a CLI command or subcommand
 - change required inputs, defaults, or outcomes for an existing workflow
 - change how the released CLI is installed or how release notes are surfaced
 - alter agent support, path resolution, daemon behavior, or vault semantics
 - introduce a new platform-specific caveat
 - change secret-handling or recipient expectations
+- add or change a workflow, architecture, lifecycle, or interaction explanation
+  that is materially clearer as a Mermaid diagram than as prose alone
 
 ## JSDoc expectations
 
@@ -50,18 +55,43 @@ Update repository docs in the same change when you:
 - Use `@param`, `@returns`, and `@throws` when they add signal rather than noise.
 - Treat stale JSDoc as a defect, not as optional cleanup.
 
+## Mermaid expectations
+
+- Use Mermaid in repository-hosted docs when it makes a workflow, structure,
+  lifecycle, or interaction easier to understand than prose alone.
+- Do not add decorative diagrams that repeat surrounding text without improving clarity.
+- Keep diagram labels self-explanatory so the chart is still useful when skimmed quickly.
+- Validate every new or changed Mermaid diagram before merge.
+
+## Documentation-only feature exception
+
+- A feature may skip automated test-case additions only when every changed
+  file is limited to repository-hosted documentation or feature-planning
+  artifacts and the change does not alter runtime source files, exported
+  symbols, configuration schemas, packaging logic, CI automation, or
+  generated workflow scripts.
+- Documentation-only features still need `bun run check` before merge.
+- Documentation-only features still need Mermaid validation for every new
+  or changed diagram.
+- Documentation-only features still need manual walkthrough validation
+  steps recorded in the relevant spec, plan, or quickstart artifact.
+
 ## Review checklist
 
 Before merging, verify:
 
 1. README still routes readers to the right guide within one screenful.
-2. Command changes are reflected in `docs/command-reference.md`.
-3. Setup or recovery changes are reflected in `docs/development.md` or `docs/troubleshooting.md`.
-4. Architecture-sensitive changes are reflected in `docs/architecture.md`.
-5. Exported production symbols changed by the PR have updated JSDoc.
-6. Support-state wording is explicit where behavior is partial, planned, or unsupported.
-7. `README.md` and `docs/command-reference.md` still point to the canonical GitHub Release record for release notes.
-8. `bun run check` still passes.
+2. Spec-kit workflow changes are reflected in `docs/speckit.md` and, when local workflow behavior changed, in `docs/speckit-local-development.md`.
+3. Command changes are reflected in `docs/command-reference.md`.
+4. Setup or recovery changes are reflected in `docs/development.md`, `docs/speckit-local-development.md`, or `docs/troubleshooting.md`.
+5. Architecture-sensitive changes are reflected in `docs/architecture.md`.
+6. Exported production symbols changed by the PR have updated JSDoc.
+7. Any required Mermaid diagrams were added or updated and validated successfully.
+8. Documentation-only PRs that skip automated test additions record why
+  the exception applies and include manual walkthrough validation steps.
+9. Support-state wording is explicit where behavior is partial, planned, or unsupported.
+10. `README.md` and `docs/command-reference.md` still point to the canonical GitHub Release record for release notes.
+11. `bun run check` still passes.
 
 ## Terminology guardrails
 
@@ -79,6 +109,8 @@ Before merging, verify:
 
 ## Related docs
 
+- [speckit.md](speckit.md)
+- [speckit-local-development.md](speckit-local-development.md)
 - [architecture.md](architecture.md)
 - [development.md](development.md)
 - [command-reference.md](command-reference.md)

--- a/docs/speckit-local-development.md
+++ b/docs/speckit-local-development.md
@@ -1,0 +1,169 @@
+# Speckit Local Development Guide
+
+## Purpose
+
+Use this guide when you are maintaining AgentSync's spec-kit setup itself. It covers where the
+repo-local workflow assets live, how active feature detection works, how timestamp branches map
+to feature directories, and what must change when workflow rules drift.
+
+## Repo-local surface map
+
+| Path | Owns | Why it matters |
+| ---- | ---- | -------------- |
+| `.github/prompts/` | GitHub Copilot slash-command prompt files such as `speckit.plan.prompt.md` | This is the user-facing command surface for speckit commands in this repo |
+| `.github/agents/` | Agent descriptors such as `speckit.plan.agent.md` | These pair with the prompt files and keep command naming consistent |
+| `.specify/init-options.json` | Local initialization defaults | Confirms timestamp branch numbering, current-directory init, integration target, and spec-kit version |
+| `.specify/integration.json` | Integration-specific hooks | Shows which script updates agent context after planning |
+| `.specify/memory/constitution.md` | Repo principles and governance rules | This is the local source of truth for workflow gates and documentation rules |
+| `.specify/scripts/bash/` | Shell workflow helpers such as `check-prerequisites.sh` and `create-new-feature.sh` | These scripts implement branch validation, feature-path resolution, and task prerequisites |
+| `.vscode/settings.json` | Editor recommendations and terminal auto-approval | Shows which speckit prompts are recommended and which scripts are auto-approved in the terminal |
+| `specs/` | Feature directories and planning artifacts | Each active feature lives under `specs/<feature-branch>/` |
+
+## How active feature detection works
+
+The bash helpers under `.specify/scripts/bash/` resolve the active feature in this order:
+
+1. If `SPECIFY_FEATURE` is set, that value wins.
+2. Otherwise the scripts use the current git branch from the repo root.
+3. If git is unavailable, they fall back to the newest `specs/` directory by timestamp, with a
+   numeric-prefix fallback for older layouts.
+4. The branch or override is mapped to a feature directory by shared prefix, not only exact name.
+   A branch like `20260405-195011-speckit-dev-docs` resolves to `specs/20260405-195011-speckit-dev-docs/`.
+5. If multiple feature directories share the same prefix, the scripts stop with an error instead
+   of guessing.
+
+Use these commands when you need to inspect the current context:
+
+```bash
+.specify/scripts/bash/check-prerequisites.sh --paths-only
+.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
+```
+
+Use `--paths-only` when you want the resolved branch and feature paths quickly.
+Use `--json --require-tasks --include-tasks` when you are about to analyze or implement and want
+to confirm that the planning artifacts exist.
+
+## Timestamp branches and feature directories
+
+AgentSync uses timestamp branches for new feature work.
+
+- Required format: `YYYYMMDD-HHMMSS-slug`
+- Example: `20260405-195011-speckit-dev-docs`
+- The repo default is recorded in `.specify/init-options.json`
+- The branch rule is enforced by `.specify/memory/constitution.md`
+
+This differs from many upstream examples that still show sequential prefixes. The local rule here
+is more important than the example style in upstream screenshots.
+
+When creating a fresh feature through the shell helpers, use the timestamp option:
+
+```bash
+.specify/scripts/bash/create-new-feature.sh --timestamp "Improve documentation to guide speckit development"
+```
+
+Sequential prefixes still appear in compatibility logic, but new AgentSync work should use the
+timestamp format.
+
+## Resume or inspect an in-progress feature safely
+
+1. Resolve the active feature paths:
+
+```bash
+.specify/scripts/bash/check-prerequisites.sh --paths-only
+```
+
+1. Open the current artifact set in this order:
+
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+
+1. Choose the next command based on what already exists:
+
+- Spec exists, but no plan: `/speckit.plan`
+- Plan exists, but no tasks: `/speckit.tasks`
+- Tasks exist, but the artifacts feel inconsistent: `/speckit.analyze`
+- Tasks are approved and implementation should start: `/speckit.implement`
+
+1. If your shell is not on the matching feature branch, switch branches before running the next
+   command. Use `SPECIFY_FEATURE` only when you need an explicit override for tooling or editor
+   context.
+
+## Validate doc changes against official behavior
+
+Use these sources as the order of truth:
+
+1. Official spec-kit docs and repository:
+   - installation
+   - quickstart
+   - local development
+   - `github/spec-kit` and `spec-driven.md`
+2. AgentSync-local workflow surfaces:
+   - `.specify/`
+   - `.github/prompts/`
+   - `.github/agents/`
+   - `.vscode/settings.json`
+
+Before merge:
+
+1. Re-check the local statement against the upstream source.
+2. Validate any Mermaid changes.
+3. Run `bun run check`.
+4. Re-run the manual walkthroughs captured in the active feature quickstart when the change is
+   documentation-only.
+
+## Ownership and update triggers
+
+The contributor who changes the workflow surface owns the documentation updates in the same
+change. Reviewers use [maintenance.md](maintenance.md) to enforce that rule.
+
+Update the speckit docs when you change any of the following:
+
+| Change type | Update at least | Why |
+| ----------- | --------------- | --- |
+| Prompt or agent command surface in `.github/` | `docs/speckit.md`, this guide | Command names and examples must stay real |
+| Workflow scripts or active-feature resolution in `.specify/scripts/` | this guide | Resume and recovery guidance depends on script behavior |
+| Constitution or governance rules | `docs/speckit.md`, `docs/maintenance.md`, this guide | Readers need the updated gates and ownership rules |
+| Workflow order or artifact expectations | `docs/speckit.md`, Mermaid diagram, `docs/maintenance.md` | The canonical guide must stay aligned with the real process |
+| Repeated contributor confusion around feature recovery | this guide and, if useful, `docs/troubleshooting.md` | Recovery steps should not stay tribal knowledge |
+
+## Common local recovery scenarios
+
+### The feature directory does not match the branch you expected
+
+Run:
+
+```bash
+.specify/scripts/bash/check-prerequisites.sh --paths-only
+```
+
+If the branch prefix does not resolve to the right `specs/` directory, switch to the correct
+feature branch first. If the branch context cannot be used, set `SPECIFY_FEATURE` deliberately
+for the session instead of editing scripts.
+
+### You are unsure whether a stage can be re-run
+
+- Re-running `/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`, or `/speckit.analyze` is
+  fine when the current artifacts are the right input and you want a better output.
+- Re-check the affected artifacts after each rerun instead of assuming earlier conclusions still
+  hold.
+- If the rerun changes workflow meaning, update the documentation in the same change.
+
+### `.specify/extensions.yml` is absent
+
+That is the normal AgentSync state today. Do not invent extension-specific steps in the default
+workflow docs. Treat extensions and presets as advanced layers that need their own explicit docs
+once they exist.
+
+### Official docs and local docs seem to drift
+
+Prefer the official workflow order first, then layer AgentSync-specific notes on top. If the repo
+intentionally diverges, document the local reason and point to the exact repo file that now owns
+the difference.
+
+## Related docs
+
+- [speckit.md](speckit.md)
+- [development.md](development.md)
+- [maintenance.md](maintenance.md)
+- [troubleshooting.md](troubleshooting.md)

--- a/docs/speckit.md
+++ b/docs/speckit.md
@@ -1,0 +1,207 @@
+# Speckit Guide
+
+## Purpose
+
+Use this guide when you are defining or continuing feature work in AgentSync through the
+spec-kit workflow. It explains what to run, when to run it, which artifacts should appear, and
+how to decide the next stage without reading prompt files or shell scripts first.
+
+## Start here
+
+AgentSync already contains a spec-kit installation. For normal feature work in this repository,
+do not run `specify init` again.
+
+Start with:
+
+- `/speckit.specify` for most new feature work
+- `/speckit.constitution` only when repository principles or governance rules need to change
+- [speckit-local-development.md](speckit-local-development.md) when you are maintaining the
+  repo-local speckit setup itself
+
+Use `specify init` only when you are bootstrapping a different repository or deliberately
+re-initializing a fresh spec-kit installation outside the current AgentSync clone.
+
+## Setup modes
+
+| Mode | Use when | First step | Notes |
+| ---- | -------- | ---------- | ----- |
+| Existing AgentSync feature work | You are adding or changing a feature in this repo | `/speckit.specify` | This is the default path for daily work here |
+| Constitution change | Repo principles, review gates, or governance rules need to change | `/speckit.constitution` | Only use this before feature work when the rules themselves must move |
+| Repo-local speckit maintenance | Prompt files, agent files, scripts, or local workflow docs are changing | [speckit-local-development.md](speckit-local-development.md) | Start there before editing `.github/` or `.specify/` |
+| New repository bootstrap | You are setting up spec-kit in some other repo | `specify init` | Not part of normal AgentSync contributor flow |
+
+## Official workflow at a glance
+
+```mermaid
+flowchart TD
+    classDef step fill:#2c3e50,color:#ffffff,stroke:#1a252f,stroke-width:1px;
+    classDef optional fill:#ecf0f1,color:#2c3e50,stroke:#7f8c8d,stroke-width:1px;
+
+    installStep["Install or init<br/>specify init"]:::step --> constitutionStep["Set project principles<br/>/speckit.constitution"]:::step
+    constitutionStep --> specifyStep["Create feature specification<br/>/speckit.specify"]:::step
+    specifyStep --> clarifyStep["Refine the specification<br/>/speckit.clarify"]:::step
+    clarifyStep --> planStep["Create implementation plan<br/>/speckit.plan"]:::step
+    clarifyStep -.-> checklistStep["Validate specification<br/>/speckit.checklist optional"]:::optional
+    checklistStep -.-> planStep
+    planStep --> tasksStep["Generate actionable tasks<br/>/speckit.tasks"]:::step
+    tasksStep --> implementStep["Execute implementation<br/>/speckit.implement"]:::step
+    tasksStep -.-> analyzeStep["Analyze spec plan task consistency<br/>/speckit.analyze optional"]:::optional
+    analyzeStep -.-> implementStep
+```
+
+This is the official quickstart order. In AgentSync, `specify init` and the constitution are
+already present, so most feature work begins at `/speckit.specify`. The diagram still shows the
+full upstream flow so you can compare repo-local behavior to the source material directly.
+
+## Standard AgentSync path
+
+1. Confirm whether the current constitution still fits the work. If not, update it first with
+   `/speckit.constitution`.
+2. Run `/speckit.specify` to create or update the feature specification.
+3. Use `/speckit.clarify` when the spec still has open questions or weak acceptance criteria.
+4. Use `/speckit.checklist` only when you want an explicit validation pass before planning.
+5. Run `/speckit.plan` to produce the implementation plan and supporting design artifacts.
+6. Run `/speckit.tasks` to break the plan into executable work.
+7. Use `/speckit.analyze` when you want a consistency review across spec, plan, and tasks before
+   implementation.
+8. Run `/speckit.implement` once the tasks are approved and the feature is ready to execute.
+
+## Command guide
+
+| Command | Use when | Provide | Expected output | Next likely step |
+| ------- | -------- | ------- | --------------- | ---------------- |
+| `specify init` | Bootstrapping spec-kit in a repo that does not already have it | Installation choice and target repo | `.specify/`, prompt files, agent files, and base workflow assets | `/speckit.constitution` |
+| `/speckit.constitution` | Repository principles or governance rules need to change | The principle changes and their impact | Updated `.specify/memory/constitution.md` and any dependent workflow expectations | `/speckit.specify` or re-review of existing plans |
+| `/speckit.specify` | Starting a new feature or replacing a weak feature description | The user problem, scope, and expected outcome | A feature branch and `specs/<feature>/spec.md` | `/speckit.clarify` or `/speckit.plan` |
+| `/speckit.clarify` | The spec still has gaps, conflicts, or weak scenarios | Answers to focused clarification questions | A tighter `spec.md` with clearer requirements and success criteria | `/speckit.checklist` or `/speckit.plan` |
+| `/speckit.checklist` | You want an explicit quality pass before planning | The current feature spec and any special review focus | Checklist guidance or updated checklist state | `/speckit.plan` |
+| `/speckit.plan` | The spec is stable enough for implementation design | The approved spec and any repo constraints | `plan.md`, `research.md`, `data-model.md`, `contracts/`, and `quickstart.md` | `/speckit.tasks` |
+| `/speckit.tasks` | The plan is ready to become executable work | The plan, spec, contracts, and supporting artifacts | `tasks.md` with ordered, file-scoped tasks | `/speckit.analyze` or `/speckit.implement` |
+| `/speckit.analyze` | You want a consistency check before implementation | The current spec, plan, tasks, and constitution | A consistency report with gaps, conflicts, or confirmation | Artifact fixes or `/speckit.implement` |
+| `/speckit.implement` | The tasks are approved and you are ready to do the work | The current task plan and repository state | Documentation or code changes plus task progress updates | Validation and review |
+
+## Feature artifact map
+
+| Artifact | Produced by | Answers | Ready when |
+| -------- | ----------- | ------- | ---------- |
+| `spec.md` | `/speckit.specify` and `/speckit.clarify` | What are we changing, for whom, and how will we know it worked? | User stories, requirements, edge cases, and success criteria are complete |
+| `plan.md` | `/speckit.plan` | What technical approach fits this repo and why? | Technical context, phases, constraints, and structure are clear |
+| `research.md` | `/speckit.plan` | Which decisions were made and what sources justify them? | Key decisions and authoritative references are recorded |
+| `data-model.md` | `/speckit.plan` | Which entities, states, or conceptual surfaces matter? | Core entities and validation rules are explicit |
+| `contracts/` | `/speckit.plan` | What interfaces or documentation surfaces must exist? | Surface requirements are concrete enough to implement |
+| `quickstart.md` | `/speckit.plan` | How should the implementation be executed and checked? | Validation scenarios and final checks are actionable |
+| `tasks.md` | `/speckit.tasks` | What work needs to happen, in what order, and in which files? | Tasks are ordered, file-scoped, and mapped to user stories |
+
+## Readiness signals
+
+| Stage | Ready to move on when | Evidence |
+| ----- | --------------------- | -------- |
+| Constitution | Principles match the intended change and any governance deltas are explicit | `.specify/memory/constitution.md` |
+| Specify | Requirements, user stories, edge cases, and success criteria are concrete | `spec.md` |
+| Clarify | No critical open ambiguities remain | `spec.md` and checklist results |
+| Plan | Approach, constraints, artifacts, and validation steps are explicit | `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md` |
+| Tasks | Each story has independent validation and file-scoped work items | `tasks.md` |
+| Analyze | No blocking consistency issues remain | Analysis report plus updated artifacts |
+| Implement | The right task slice is approved and the repo state is ready for edits | `tasks.md` and current working tree |
+
+## AgentSync example
+
+Use a feature like the one that produced this guide as the mental model.
+
+1. Start the feature:
+
+```text
+/speckit.specify Improve documentation to guide speckit development.
+```
+
+Expected result:
+
+- a timestamp feature branch such as `20260405-195011-speckit-dev-docs`
+- `specs/20260405-195011-speckit-dev-docs/spec.md`
+
+1. Tighten the specification if needed:
+
+```text
+/speckit.clarify
+```
+
+Expected result:
+
+- stronger scenarios, clearer requirements, and fewer review-time questions
+
+1. Build the implementation design:
+
+```text
+/speckit.plan
+```
+
+Expected result:
+
+- `plan.md`
+- `research.md`
+- `data-model.md`
+- `contracts/`
+- `quickstart.md`
+
+1. Turn the design into work:
+
+```text
+/speckit.tasks
+```
+
+Expected result:
+
+- `tasks.md` with story-scoped tasks and validation steps
+
+1. Optionally analyze before implementation:
+
+```text
+/speckit.analyze
+```
+
+1. Implement once the task list is ready:
+
+```text
+/speckit.implement
+```
+
+## Continue an existing feature
+
+When a feature already exists, work from the branch and artifact state instead of restarting from
+scratch.
+
+1. Confirm the active feature paths:
+
+```bash
+.specify/scripts/bash/check-prerequisites.sh --paths-only
+```
+
+1. Inspect the current artifact set:
+
+- `spec.md` only: run `/speckit.plan`
+- `plan.md` exists but `tasks.md` does not: run `/speckit.tasks`
+- `tasks.md` exists and you want a review gate: run `/speckit.analyze`
+- `tasks.md` exists and the plan is approved: run `/speckit.implement`
+
+1. If the current shell context is not on the right feature branch, switch to the matching branch
+   first. For special tooling cases, the scripts also honor `SPECIFY_FEATURE` as an explicit
+   override.
+
+## Baseline workflow versus extensions
+
+AgentSync currently has no `.specify/extensions.yml`. That means the baseline workflow above is
+the real default path, not a fallback.
+
+Upstream spec-kit supports extensions and presets, but in this repository they should be treated
+as advanced layers:
+
+- learn the baseline flow first
+- verify any local customization against `.specify/`, `.github/prompts/`, and `.github/agents/`
+- update the docs in the same change if extensions, prompts, agents, or workflow rules move
+
+## Related docs
+
+- [speckit-local-development.md](speckit-local-development.md)
+- [development.md](development.md)
+- [maintenance.md](maintenance.md)
+- [troubleshooting.md](troubleshooting.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -98,6 +98,15 @@ If the service is installed but not healthy, inspect platform logs:
 
 Do not guess file paths. Use the values defined in `src/config/paths.ts` as the source of truth.
 
+## Speckit workflow confusion
+
+Use [speckit.md](speckit.md) when the problem is command order, artifact expectations, or which
+workflow stage comes next.
+
+Use [speckit-local-development.md](speckit-local-development.md) when the problem is active
+feature detection, timestamp branch mapping, re-running a planning stage, or understanding why
+the baseline workflow has no `.specify/extensions.yml`.
+
 ## Unsupported or future-facing expectations
 
 If you expect a hosted admin surface, network API, or rich conflict-resolution UI, that is outside the current support surface. The supported model is the local CLI plus daemon workflow described in the command reference and architecture guide.

--- a/specs/20260405-195011-speckit-dev-docs/checklists/requirements.md
+++ b/specs/20260405-195011-speckit-dev-docs/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Improve Speckit Development Documentation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-05  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details languages, frameworks, or APIs
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic no implementation details
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed on 2026-04-05 against the generated specification; no clarification markers or template placeholders remain.

--- a/specs/20260405-195011-speckit-dev-docs/contracts/speckit-documentation-surface.md
+++ b/specs/20260405-195011-speckit-dev-docs/contracts/speckit-documentation-surface.md
@@ -1,0 +1,113 @@
+# Contract: Speckit Documentation Surface
+
+## Purpose
+
+Define the required documentation surfaces, section coverage, and quality rules for the speckit
+guidance added to AgentSync.
+
+## Required Surfaces
+
+### 1. README Navigation Entry
+
+- **Path**: `README.md`
+- **Audience**: First-time repository readers
+- **Must provide**:
+  - A short explanation that this repository uses spec-kit for feature workflow
+  - A direct link to the primary speckit guide
+  - A direct link to the local-development guide
+  - Enough context for readers to know which link to follow first
+
+### 2. Canonical Speckit Guide
+
+- **Path**: `docs/speckit.md`
+- **Audience**: Contributors starting or continuing feature work
+- **Must provide**:
+  - What spec-kit is and why it exists in this repo
+  - Prerequisites and initialization modes grounded in official docs
+  - A Mermaid workflow diagram that mirrors the official process order from installation through implementation
+  - The standard workflow sequence from constitution through implementation
+  - When and how to use each command
+  - When optional commands such as `clarify`, `checklist`, and `analyze` are useful
+  - A feature artifact map with expected outputs
+  - At least one AgentSync-specific end-to-end example
+  - Guidance for resuming work from an existing branch
+  - A short note on extensions and presets as advanced topics
+
+### 3. Speckit Local Development Guide
+
+- **Path**: `docs/speckit-local-development.md`
+- **Audience**: Maintainers and contributors updating speckit-related repo assets
+- **Must provide**:
+  - Where prompt files, agent files, and `.specify/` assets live
+  - How active feature context is derived from the branch
+  - How local timestamp branches map to feature directories
+  - How to inspect, resume, and validate in-progress features
+  - How to keep the docs current when upstream workflow or local conventions change
+  - Common local maintenance and recovery scenarios
+
+### 4. Existing Docs Integration
+
+- **Paths**: `docs/development.md`, `docs/maintenance.md`, optionally `docs/troubleshooting.md`
+- **Audience**: Contributors already navigating current docs
+- **Must provide**:
+  - Clear links to the new speckit guides where relevant
+  - No duplicated long-form workflow explanations that can drift
+  - Consistent terminology with the new guides
+
+## Command Coverage Contract
+
+The documentation set must cover these commands explicitly:
+
+- `specify init`
+- `/speckit.constitution`
+- `/speckit.specify`
+- `/speckit.clarify`
+- `/speckit.checklist`
+- `/speckit.plan`
+- `/speckit.tasks`
+- `/speckit.analyze`
+- `/speckit.implement`
+
+For each command, the docs must answer:
+
+- What the command is for
+- When to use it
+- What input the contributor should provide
+- What output or artifact should result
+- What the next likely step is
+
+## Mermaid Diagram Contract
+
+- The canonical speckit guide must include at least one Mermaid flowchart.
+- The mainline order in that flowchart must match the official quickstart sequence: `specify init`, `/speckit.constitution`, `/speckit.specify`, `/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement`.
+- `checklist` and `analyze` may appear only as optional validation paths, not as mandatory mainline stages.
+- The diagram must use labels that are understandable without prior knowledge of the repo.
+- The diagram must validate successfully with Mermaid syntax tooling before merge.
+
+## Example Quality Contract
+
+- Examples must be specific to AgentSync or to realistic maintenance of this repository.
+- Examples must avoid speculative workflow paths not present in official spec-kit docs.
+- Examples must prefer GitHub Copilot slash commands because this repo exposes `.github/prompts/` and `.github/agents/` surfaces for them.
+- Examples may mention upstream agent naming differences only as a short note, not the main path.
+- Examples must stay concise and explain why the example is useful.
+
+## Accuracy Contract
+
+- Official spec-kit installation, quickstart, and local-development docs are the source of truth for upstream workflow behavior.
+- Repo files under `.specify/`, `.github/prompts/`, `.github/agents/`, and `.vscode/settings.json` are the source of truth for AgentSync-local conventions.
+- The docs must explicitly note that this repo uses timestamp branch naming.
+- The docs must explain baseline workflow behavior even when no `.specify/extensions.yml` is present.
+- The Mermaid workflow diagram must reflect the official process before any repo-local notes are layered on top.
+
+## Navigation Contract
+
+- Readers must be able to go from `README.md` to the canonical speckit guide in one click.
+- Readers must be able to go from the canonical speckit guide to the local-development guide in one click.
+- Maintainer-facing docs must link back to the main guide instead of restating onboarding flow.
+
+## Review Contract
+
+- Reviewers must be able to check command coverage, artifact coverage, and example accuracy without reading source code.
+- Reviewers must be able to compare the Mermaid diagram against the official quickstart stages without inferring missing steps.
+- Terminology for `feature`, `stage`, `artifact`, `active feature`, and `readiness` must stay consistent across all updated pages.

--- a/specs/20260405-195011-speckit-dev-docs/data-model.md
+++ b/specs/20260405-195011-speckit-dev-docs/data-model.md
@@ -1,0 +1,107 @@
+# Data Model: Improve Speckit Development Documentation
+
+## Entities
+
+### Setup Mode
+
+- **Purpose**: Describes how a contributor gets spec-kit available for use or testing.
+- **Fields**:
+  - `name`: Human-readable label such as `Pinned uvx init`, `Current-directory init`, or `Repo-local development`
+  - `audience`: New contributor or maintainer
+  - `prerequisites`: Required tools or repo context
+  - `entry_command`: Primary example command
+  - `use_when`: Situation where this setup mode is appropriate
+  - `notes`: Caveats such as script selection or local testing behavior
+
+### Workflow Stage
+
+- **Purpose**: Represents a distinct step in the speckit development flow.
+- **Fields**:
+  - `name`: Stage name such as `Constitution`, `Specify`, `Clarify`, `Plan`, `Tasks`, `Analyze`, `Implement`
+  - `command`: Primary command invocation
+  - `required`: Whether the stage is part of the baseline path
+  - `input_context`: Information the contributor should provide
+  - `output_artifacts`: Files or outcomes created by the stage
+  - `use_when`: Decision signal for entering the stage
+  - `do_not_use_when`: Situations where another stage is more appropriate
+  - `example`: Repo-specific sample prompt or invocation
+
+### Feature Artifact
+
+- **Purpose**: Captures a generated document inside a feature directory.
+- **Fields**:
+  - `name`: Artifact name such as `spec.md` or `tasks.md`
+  - `producer_stage`: Workflow stage that creates it
+  - `consumer_stage`: Next stage or reviewer who depends on it
+  - `question_answered`: What the artifact explains
+  - `readiness_signal`: How a contributor knows the artifact is complete enough
+  - `common_failure`: Typical confusion or omission related to the artifact
+
+### Readiness Signal
+
+- **Purpose**: Gives a contributor a concrete reason to move to the next stage.
+- **Fields**:
+  - `stage`: Stage being completed
+  - `observable_condition`: User-visible sign of readiness
+  - `evidence_location`: File or output where the sign appears
+  - `next_action`: Recommended next step
+
+### Command Example
+
+- **Purpose**: Shows a good, repo-relevant example for how to use a stage.
+- **Fields**:
+  - `scenario`: Short description of the contributor goal
+  - `command_text`: Example invocation or slash command
+  - `why_it_is_good`: What the example demonstrates
+  - `expected_result`: Artifact or decision that should follow
+
+### Mermaid Diagram
+
+- **Purpose**: Represents a visual explanation of the workflow that lets readers identify the mainline process and optional validation steps quickly.
+- **Fields**:
+  - `title`: Diagram title
+  - `diagram_type`: `flowchart`
+  - `mainline_stages`: Ordered list of official quickstart stages
+  - `optional_paths`: Supplemental validation paths such as `checklist` and `analyze`
+  - `source_of_truth`: Official doc section that defines the order
+  - `validation_status`: Whether the Mermaid syntax has been validated successfully
+
+### Troubleshooting Entry
+
+- **Purpose**: Explains a common workflow failure or confusion point.
+- **Fields**:
+  - `symptom`: What the contributor experiences
+  - `likely_cause`: Most probable explanation
+  - `recovery_steps`: Ordered next actions
+  - `related_stage`: Workflow stage involved
+  - `related_artifact`: Artifact or file to inspect
+
+### Documentation Surface
+
+- **Purpose**: Defines one user-facing document in the final docs set.
+- **Fields**:
+  - `path`: Target file path such as `docs/speckit.md`
+  - `audience`: New contributor, maintainer, or both
+  - `goal`: Primary user outcome for the page
+  - `required_sections`: Sections the page must contain
+  - `navigation_sources`: Pages that should link to it
+  - `authoritative_sources`: Upstream docs or repo files that ground its claims
+
+## Relationships
+
+- A `Setup Mode` prepares a contributor to enter one or more `Workflow Stage` entities.
+- Each `Workflow Stage` creates or consumes one or more `Feature Artifact` entities.
+- A `Readiness Signal` is attached to a `Workflow Stage` and often points to a `Feature Artifact`.
+- A `Command Example` illustrates one `Workflow Stage` in a specific `Setup Mode`.
+- A `Mermaid Diagram` visualizes the relationships among `Workflow Stage` entities for a `Documentation Surface`.
+- A `Troubleshooting Entry` resolves confusion around a `Workflow Stage` or `Feature Artifact`.
+- A `Documentation Surface` groups related `Setup Mode`, `Workflow Stage`, `Feature Artifact`, and `Troubleshooting Entry` information for a target audience.
+
+## Validation Rules
+
+- Every baseline `Workflow Stage` must have at least one `Command Example`.
+- Every `Feature Artifact` must name its producing stage and the question it answers.
+- Every required `Documentation Surface` must define both audience and goal.
+- Every `Mermaid Diagram` must identify its official source of truth and distinguish mainline stages from optional paths.
+- At least one `Troubleshooting Entry` must exist for stage selection confusion, missing artifacts, and resuming work on an existing branch.
+- Repo-specific facts must cite repository files, while general workflow facts must cite official spec-kit documentation.

--- a/specs/20260405-195011-speckit-dev-docs/plan.md
+++ b/specs/20260405-195011-speckit-dev-docs/plan.md
@@ -1,0 +1,270 @@
+# Implementation Plan: Improve Speckit Development Documentation
+
+**Branch**: `20260405-195011-speckit-dev-docs` | **Date**: 2026-04-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/20260405-195011-speckit-dev-docs/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Create a documentation system that teaches contributors how to start using spec-kit in this
+repository, when and how to use each workflow command, how the generated artifacts relate to one
+another, and how to continue or maintain speckit-driven work locally. The design follows the
+official spec-kit installation, quickstart, and local-development guidance while adapting it to
+AgentSync's repo-specific conventions: GitHub Copilot prompt files, generated agent definitions,
+timestamp-based feature branches, a Mermaid workflow diagram that mirrors the official process,
+and a baseline workflow with no configured `.specify/extensions.yml`.
+
+## Technical Context
+
+**Language/Version**: Markdown documentation plus TypeScript 6.0.0 repository context  
+**Primary Dependencies**: Existing repo toolchain only; authoritative research sources are official spec-kit documentation and the `github/spec-kit` repository  
+**Storage**: Repository-hosted Markdown files under `README.md`, `docs/`, `.github/`, and `.specify/` as referenced documentation sources  
+**Testing**: Manual documentation walkthroughs plus repository validation via `bun run check` when final edits are complete  
+**Target Platform**: GitHub repository readers and local contributors on macOS, Linux, or Windows using spec-kit with GitHub Copilot in this repository
+**Project Type**: Bun-based CLI repository with embedded speckit workflow documentation  
+**Performance Goals**: A new contributor can identify how to start within 2 minutes and reach a usable speckit workflow path within 15 minutes using docs alone  
+**Constraints**: Keep docs concise and reasoning-led; align with official spec-kit workflow; include a validated Mermaid flowchart that matches the official process order; document timestamp branch naming instead of upstream sequential examples; explain baseline workflow first and extensions second; avoid runtime behavior changes  
+**Scale/Scope**: Documentation-only changes across `README.md`, current `docs/` pages, and new speckit-focused guides with examples for initialization, commands, artifacts, and repo-local development
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### Principle I — Security-First Credential Handling
+
+**Status: PASS** — This feature adds documentation only. It does not alter key handling,
+encryption, vault writes, or sanitization behavior. Documentation can improve accuracy around
+safe workflow usage without touching protected code paths.
+
+### Principle II — Test Coverage
+
+**Status: PASS** — No runtime behavior or security-sensitive modules are being changed. The plan
+still uses repository validation as the final regression gate because documentation updates may
+touch command references or contributor instructions that must remain consistent with the codebase.
+
+### Principle III — Cross-Platform Daemon Reliability
+
+**Status: PASS** — The feature documents cross-platform workflow and setup behavior but does not
+modify daemon, IPC, or installer implementations.
+
+### Principle IV — Code Quality with Biome
+
+**Status: PASS** — No new tooling is introduced. Documentation changes remain inside the current
+repo structure and use the existing validation command.
+
+### Principle V — JSDoc Documentation Standards
+
+**Status: PASS** — This feature may update maintainer-facing guidance about documentation
+ownership, but it does not require changing exported symbol behavior or introducing stale API
+docs.
+
+### Post-Design Re-check
+
+The Phase 1 design stays within constitutional limits. It adds documentation surfaces and review
+rules only, uses existing repository conventions, and introduces no new code, tools, or runtime
+abstractions.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/20260405-195011-speckit-dev-docs/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── speckit-documentation-surface.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+README.md                              # UPDATE: entry point for speckit guidance
+docs/
+├── development.md                     # UPDATE: cross-link speckit contributor workflow
+├── maintenance.md                     # UPDATE: speckit documentation ownership and upkeep
+├── speckit.md                         # NEW: canonical start/use/when-how guide
+├── speckit-local-development.md       # NEW: repo-local development and maintenance guide
+└── troubleshooting.md                 # UPDATE or cross-link: common workflow confusion if needed
+
+.github/
+├── prompts/                           # SOURCE: GitHub Copilot speckit prompt files already present
+└── agents/                            # SOURCE: speckit agent definitions already present
+
+.specify/
+├── init-options.json                  # SOURCE: timestamp branch numbering and init defaults
+├── memory/constitution.md             # SOURCE: repo-specific workflow and governance constraints
+└── scripts/bash/                      # SOURCE: generated workflow scripts used by plan/task flows
+```
+
+**Structure Decision**: Single-project repository. This feature should not add runtime modules.
+It should update the repository entry point and add two focused spec-kit guides: one for starting
+and using the workflow, and one for repo-local development and maintenance.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification required.
+
+---
+
+## Phase 0 — Research Summary
+
+All required research is complete. See [research.md](./research.md) for full decisions,
+rationale, alternatives, and source references.
+
+| Topic                      | Decision                                                                                                                     | Why                                                                                                            |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Canonical workflow         | Follow the official six-step quickstart and explicitly layer optional `clarify`, `checklist`, and `analyze` usage on top     | Aligns repo guidance with official spec-kit usage while covering real contributor decision points              |
+| Documentation split        | Separate the reader-facing start/use guide from the repo-local development guide                                             | Mirrors upstream separation between quickstart and local-development docs and prevents one oversized page      |
+| Example strategy           | Use AgentSync-specific examples for constitution, spec, plan, and review flows                                               | Generic examples teach the product, not this repository                                                        |
+| Workflow visualization     | Include a Mermaid flowchart that mirrors the official quickstart order and marks `checklist` and `analyze` as optional       | Gives readers a fast orientation aid without inventing a repo-specific workflow                                |
+| Branch naming              | Document timestamp branch names as the local repo convention even though upstream examples often show sequential feature IDs | Required by this repository's constitution and init defaults                                                   |
+| Extension coverage         | Document the core workflow first and describe extensions/presets as optional advanced layers                                 | This repo currently has no `.specify/extensions.yml`, so baseline behavior must stay understandable on its own |
+| Local contributor guidance | Include repo-specific pointers to `.github/prompts`, `.github/agents`, `.specify/`, and active-feature branch detection      | Necessary for future local maintenance and debugging of the speckit setup                                      |
+
+---
+
+## Phase 1 — Design
+
+### Interface Contracts
+
+See [contracts/speckit-documentation-surface.md](./contracts/speckit-documentation-surface.md).
+
+The contract defines:
+
+- Required documentation surfaces and their audiences
+- Required sections for the main speckit guide and the local-development guide
+- Command coverage expectations, including when and how to use each stage
+- Mermaid diagram requirements for the official process flow
+- Example quality rules and repo-specific accuracy rules
+- Cross-linking and maintenance expectations
+
+### Data Model
+
+See [data-model.md](./data-model.md).
+
+The design models setup modes, workflow stages, feature artifacts, readiness signals, examples,
+and troubleshooting entries so the documentation can be implemented as a coherent system rather
+than a loose collection of pages.
+
+### Quickstart
+
+See [quickstart.md](./quickstart.md) for implementation order and validation scenarios.
+
+---
+
+## Phase 2 — Implementation Plan
+
+### Overview
+
+Deliver the documentation in five focused phases so readers can discover the workflow first,
+understand the artifacts second, and maintain the setup locally without reading prompt or script
+files directly.
+
+### Official Workflow Diagram
+
+```mermaid
+flowchart TD
+    classDef step fill:#2c3e50,color:#ffffff,stroke:#1a252f,stroke-width:1px;
+    classDef optional fill:#ecf0f1,color:#2c3e50,stroke:#7f8c8d,stroke-width:1px;
+
+    installStep["Install or init<br/>specify init"]:::step --> constitutionStep["Set project principles<br/>/speckit.constitution"]:::step
+    constitutionStep --> specifyStep["Create feature specification<br/>/speckit.specify"]:::step
+    specifyStep --> clarifyStep["Refine the specification<br/>/speckit.clarify"]:::step
+    clarifyStep --> planStep["Create implementation plan<br/>/speckit.plan"]:::step
+    clarifyStep -.-> checklistStep["Validate specification<br/>/speckit.checklist optional"]:::optional
+    checklistStep -.-> planStep
+    planStep --> tasksStep["Generate actionable tasks<br/>/speckit.tasks"]:::step
+    tasksStep --> implementStep["Execute implementation<br/>/speckit.implement"]:::step
+    tasksStep -.-> analyzeStep["Analyze spec plan task consistency<br/>/speckit.analyze optional"]:::optional
+    analyzeStep -.-> implementStep
+```
+
+This diagram reflects the official quickstart flow: install or initialize spec-kit, set the
+constitution, create the spec, refine with `clarify`, plan, task, and implement. `checklist`
+and `analyze` are shown as optional validation paths because they appear as supplemental guidance
+in the official docs rather than mandatory mainline stages.
+
+```text
+Phase A: Audit repo-local speckit surfaces and examples
+Phase B: Create the canonical start/use guide
+Phase C: Create the local development and maintenance guide
+Phase D: Update README and existing docs navigation
+Phase E: Validate examples, terminology, and recovery guidance
+```
+
+### Phase A — Audit Repo-Local Speckit Surface
+
+**Goal**: Build an exact map of the local integration points that the docs must explain.
+
+**Actions**:
+
+1. Inventory the speckit prompt files under `.github/prompts/` and agent definitions under `.github/agents/`.
+2. Confirm repo defaults from `.specify/init-options.json`, `.specify/memory/constitution.md`, and `.specify/scripts/`.
+3. Capture the current gap: README and `docs/` have no speckit-oriented guidance today.
+4. Identify which existing docs should link into the new speckit guides rather than duplicating content.
+
+**Output**: Source-of-truth map for command names, workflow stages, repo conventions, and doc link points.
+
+### Phase B — Canonical Speckit Start And Use Guide
+
+**Goal**: Produce the single best entry document for contributors who need to start and use speckit in this repository.
+
+**Required sections**:
+
+1. What spec-kit is and why this repo uses it
+2. Prerequisites and initialization options with official-source alignment
+3. The standard feature workflow from constitution to implementation
+4. When to use each command and when not to use it
+5. A Mermaid workflow diagram that mirrors the official process order and labels optional validation steps clearly
+6. Artifact map explaining `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, and `tasks.md`
+7. AgentSync-specific examples for `/speckit.constitution`, `/speckit.specify`, `/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`, `/speckit.analyze`, and `/speckit.implement`
+8. Guidance for resuming an existing feature from its branch and artifacts
+9. Advanced note on extensions and presets without making them part of the default path
+
+**Design rule**: Optimize for a contributor who wants to ask, in order, "How do I start?",
+"What do I run next?", and "What file should I expect now?"
+
+### Phase C — Local Development And Maintenance Guide
+
+**Goal**: Document how maintainers and future contributors work on this repo's speckit setup locally.
+
+**Required sections**:
+
+1. Where the prompt files, agent files, and `.specify/` workflow assets live
+2. How active feature detection works from the current branch
+3. How timestamp branch naming differs from common upstream sequential examples
+4. How to resume or inspect an in-progress feature safely
+5. How to verify doc changes against official spec-kit behavior
+6. Ownership and update triggers for speckit guidance, including who must update the docs when templates, scripts, workflow rules, or governance change
+7. Common local confusion points and recovery steps
+
+**Design rule**: Keep implementation mechanics visible enough for maintainers, but do not force first-time readers through internal file layout before they understand the workflow.
+
+### Phase D — Navigation And Existing Docs Integration
+
+**Goal**: Make the new guidance discoverable from the repo entry points.
+
+**Actions**:
+
+1. Update `README.md` so a new contributor can reach the main speckit guide and local-development guide in one hop.
+2. Add cross-links from `docs/development.md` and `docs/maintenance.md` where speckit-specific details matter.
+3. Keep speckit-specific recovery guidance in `docs/speckit-local-development.md` so workflow reasoning stays in one canonical place; add a short pointer from `docs/troubleshooting.md` only if a repo-level troubleshooting index improves discoverability.
+4. Ensure all pages use the same terminology for workflow stages and artifacts.
+
+### Phase E — Validation And Consistency Review
+
+**Goal**: Confirm the docs teach the workflow accurately and can be followed without tribal knowledge.
+
+**Verification steps**:
+
+1. Follow the start guide as a first-time contributor and confirm it answers how to initialize and what to run next.
+2. Follow the local-development guide as a maintainer and confirm it explains where repo-local speckit assets live and how to work with them.
+3. Verify every command example against official spec-kit docs and repo-local conventions.
+4. Verify the Mermaid workflow diagram matches the official process order and labels optional validation steps correctly.
+5. Confirm the docs distinguish baseline workflow from optional extensions/presets.
+6. Run `bun run check` before merge to preserve the repo's standard validation gate.

--- a/specs/20260405-195011-speckit-dev-docs/quickstart.md
+++ b/specs/20260405-195011-speckit-dev-docs/quickstart.md
@@ -1,0 +1,64 @@
+# Quickstart: Implement Speckit Development Documentation
+
+## Goal
+
+Deliver a documentation set that lets a new contributor start using spec-kit in AgentSync quickly and lets a maintainer understand how the local speckit setup works without reverse-engineering repo files.
+
+## Implementation Order
+
+1. Review the official spec-kit sources used in [research.md](./research.md) and extract the canonical setup and workflow steps.
+2. Audit the repo-local speckit surfaces in `.github/prompts/`, `.github/agents/`, `.specify/`, and `.vscode/settings.json`.
+3. Draft `docs/speckit.md` as the canonical start/use/when-how guide.
+4. Add a Mermaid workflow diagram to `docs/speckit.md` that matches the official quickstart order and labels optional validation paths clearly.
+5. Draft `docs/speckit-local-development.md` as the local maintenance and contributor guide.
+6. Update `README.md` to route readers to the new docs.
+7. Update `docs/development.md` and `docs/maintenance.md` to cross-link rather than duplicate guidance.
+8. Run final consistency and validation checks.
+
+## Minimum Acceptable Output
+
+- A first-time reader can answer these questions without reading source code:
+  - How do I start using spec-kit in this repo?
+  - Which command should I use next?
+  - What files should appear after each stage?
+  - When should I use `clarify`, `checklist`, or `analyze`?
+  - How do I continue work on an existing feature?
+  - Does the workflow diagram match the official process and show optional steps clearly?
+- A maintainer can answer these questions without reading prompt files line by line:
+  - Where do the speckit commands come from in this repo?
+  - Which files define repo-local workflow behavior?
+  - How do branch names map to feature directories here?
+  - How do I validate that the documentation still matches upstream behavior?
+
+## Validation Scenarios
+
+### Scenario 1: New contributor start path
+
+1. Open `README.md`.
+2. Navigate to the canonical speckit guide.
+3. Identify prerequisites, starting command, and the first artifact expected.
+4. Confirm the Mermaid diagram shows the official stage order and optional validation paths correctly.
+5. Confirm the guide explains what to do after the spec is created.
+
+### Scenario 2: Existing feature continuation
+
+1. Open the canonical guide.
+2. Follow the instructions for resuming work on an existing feature branch.
+3. Identify the current stage from the existing artifacts.
+4. Use the Mermaid diagram to confirm the expected neighboring stages.
+5. Confirm the guide explains the next appropriate command.
+
+### Scenario 3: Local maintainer workflow
+
+1. Open the local-development guide.
+2. Locate the repo files that implement or configure the speckit workflow.
+3. Confirm timestamp branch naming and active-feature behavior are explained.
+4. Confirm the guide explains how to keep the docs current.
+
+## Final Checks
+
+1. Verify all command examples match official spec-kit documentation or clearly labeled repo-local behavior.
+2. Verify all repo-local claims map to real files in AgentSync.
+3. Verify the Mermaid diagram renders and matches the official quickstart stage order.
+4. Confirm no page duplicates large sections of another page.
+5. Run `bun run check` before merge.

--- a/specs/20260405-195011-speckit-dev-docs/research.md
+++ b/specs/20260405-195011-speckit-dev-docs/research.md
@@ -1,0 +1,156 @@
+# Research: Improve Speckit Development Documentation
+
+## Decision 1: Use the official six-step spec-kit workflow as the canonical backbone
+
+**Decision**: Structure the repo guidance around the upstream start sequence: install/init, constitution, specification, optional clarification, technical plan, tasks, optional analysis, and implementation.
+
+**Rationale**: The official quickstart and home page define the standard contributor mental model. Replacing that sequence with a repo-specific order would make the docs harder to trust and harder to compare with upstream guidance. The documentation should therefore preserve the official workflow and add repo-local notes where AgentSync differs.
+
+**Alternatives considered**:
+
+- Create a custom AgentSync-only workflow order. Rejected because it would drift from the official docs and make future maintenance harder.
+- Document only the commands used most often in this repo. Rejected because the user asked for thorough coverage, including when and how to use the workflow.
+
+**Sources**:
+
+- [Spec Kit Home](https://github.github.com/spec-kit/)
+- [Spec Kit Quick Start](https://github.github.com/spec-kit/quickstart.html)
+- [Specification-Driven Development](https://github.com/github/spec-kit/blob/main/spec-driven.md)
+
+## Decision 2: Split the docs into a start/use guide and a local-development guide
+
+**Decision**: Add one guide that teaches contributors how to start and use spec-kit in this repository, and a second guide that teaches maintainers how to work on the local speckit setup itself.
+
+**Rationale**: The upstream docs already separate quickstart concerns from local CLI development concerns. That split maps well to this repository: a new contributor needs commands, artifacts, and examples, while a maintainer needs prompt-file locations, generated agents, branch conventions, and workflow recovery behavior. Combining these into one page would make the entry path too dense.
+
+**Alternatives considered**:
+
+- Keep everything in `README.md`. Rejected because the resulting page would be too long and hard to scan.
+- Put all speckit guidance into `docs/development.md`. Rejected because that page is already about AgentSync development generally, not the spec-kit workflow specifically.
+
+**Sources**:
+
+- [Spec Kit Quick Start](https://github.github.com/spec-kit/quickstart.html)
+- [Spec Kit Local Development](https://github.github.com/spec-kit/local-development.html)
+
+## Decision 3: Use AgentSync-specific examples instead of generic product demos
+
+**Decision**: Use examples based on real AgentSync feature work, such as documentation changes, workflow maintenance, or feature planning in this repo, rather than photo albums or generic task apps.
+
+**Rationale**: Upstream examples prove how spec-kit works, but they do not teach how to use it effectively in this repository. AgentSync-specific prompts will reduce transfer effort and make contributors more confident when starting their own feature.
+
+**Alternatives considered**:
+
+- Reuse upstream examples verbatim. Rejected because they explain spec-kit generically, not how AgentSync contributors should operate.
+- Write abstract examples with no repo context. Rejected because they would not satisfy the user's request for good examples that make local development easy.
+
+**Sources**:
+
+- [Spec Kit Quick Start](https://github.github.com/spec-kit/quickstart.html)
+- [Specification-Driven Development](https://github.com/github/spec-kit/blob/main/spec-driven.md)
+- /Users/chrislee/srv/github/agent-sync/specs/20260405-195011-speckit-dev-docs/spec.md
+
+## Decision 4: Document timestamp branch naming explicitly as a repo-local override
+
+**Decision**: Explain that AgentSync uses timestamp feature branches such as `YYYYMMDD-HHMMSS-slug`, even though many upstream examples still show sequential feature numbers.
+
+**Rationale**: This repo's constitution requires timestamp branches, and `.specify/init-options.json` already sets `branch_numbering` to `timestamp`. Contributors need this called out explicitly because upstream quickstart material and methodology examples still show sequential naming in several examples.
+
+**Alternatives considered**:
+
+- Ignore branch naming differences. Rejected because it would create avoidable confusion when contributors compare repo behavior to official examples.
+- Rewrite docs as if upstream only used timestamp naming. Rejected because the docs should teach the real difference, not hide it.
+
+**Sources**:
+
+- [Spec Kit Installation](https://github.github.com/spec-kit/installation.html)
+- [Specification-Driven Development](https://github.com/github/spec-kit/blob/main/spec-driven.md)
+- /Users/chrislee/srv/github/agent-sync/.specify/init-options.json
+- /Users/chrislee/srv/github/agent-sync/.specify/memory/constitution.md
+
+## Decision 5: Teach setup modes separately from workflow stages
+
+**Decision**: Distinguish setup modes such as `uvx` initialization, current-directory initialization, and local development against repo files from the normal speckit command stages.
+
+**Rationale**: The official docs separate installation concerns from workflow usage and local CLI iteration. That distinction matters here because a reader may need to initialize spec-kit in a project, while a maintainer may instead need to understand how the already-installed prompt files and scripts work in AgentSync.
+
+**Alternatives considered**:
+
+- Collapse installation and workflow into a single list. Rejected because it blurs prerequisite actions with feature-development stages.
+- Skip local-development modes. Rejected because the user explicitly requested guidance for future local development.
+
+**Sources**:
+
+- [Spec Kit Installation](https://github.github.com/spec-kit/installation.html)
+- [Spec Kit Local Development](https://github.github.com/spec-kit/local-development.html)
+- [Spec Kit Quick Start](https://github.github.com/spec-kit/quickstart.html)
+
+## Decision 6: Treat extensions and presets as advanced, optional material
+
+**Decision**: Document core workflow behavior first, then add a short advanced section explaining when extensions and presets matter.
+
+**Rationale**: The upstream docs clearly support extensions and presets, but AgentSync currently has no `.specify/extensions.yml`. New contributors should not have to understand extension architecture before they can start a feature. Advanced customization should be visible without becoming part of the default path.
+
+**Alternatives considered**:
+
+- Omit extensions and presets entirely. Rejected because the spec requires guidance about baseline behavior when extensions are absent and how optional additions should be interpreted when present.
+- Lead with extensions and presets. Rejected because it would overload first-time readers.
+
+**Sources**:
+
+- [Spec Kit Home](https://github.github.com/spec-kit/)
+- [github/spec-kit Repository](https://github.com/github/spec-kit)
+- /Users/chrislee/srv/github/agent-sync/.specify/extensions.yml (not present in this repository)
+
+## Decision 7: Document the repo-local speckit surface as part of maintainer guidance
+
+**Decision**: The local-development guide should explain where speckit prompt files, agent files, and workflow assets live in this repository: `.github/prompts/`, `.github/agents/`, and `.specify/`.
+
+**Rationale**: There is currently no user-facing documentation for these assets, but they are essential for future maintenance. Contributors maintaining the speckit setup need to know where commands come from, which files are generated, and where repo defaults live.
+
+**Alternatives considered**:
+
+- Leave file-layout knowledge implicit. Rejected because that preserves the current tribal-knowledge problem.
+- Document every file in detail in the start guide. Rejected because it would distract first-time readers from the main workflow.
+
+**Sources**:
+
+- /Users/chrislee/srv/github/agent-sync/.github/prompts
+- /Users/chrislee/srv/github/agent-sync/.github/agents
+- /Users/chrislee/srv/github/agent-sync/.specify/integration.json
+- /Users/chrislee/srv/github/agent-sync/.vscode/settings.json
+
+## Decision 8: Keep examples optimized for GitHub Copilot while acknowledging upstream agent differences
+
+**Decision**: Use `/speckit.*` commands as the primary examples because this repository exposes GitHub Copilot prompt files and agent definitions for those commands, while briefly noting that upstream docs describe naming differences for some other agents.
+
+**Rationale**: Readers of this repository need the local command surface first. Upstream differences for Claude or Codex are useful context, but they are secondary to the actual developer experience in AgentSync.
+
+**Alternatives considered**:
+
+- Document every agent variant equally. Rejected because it adds noise to repo-focused guidance.
+- Ignore cross-agent differences entirely. Rejected because upstream docs explicitly call them out, and readers may compare notes across agents.
+
+**Sources**:
+
+- [Spec Kit Home](https://github.github.com/spec-kit/)
+- [Spec Kit Quick Start](https://github.github.com/spec-kit/quickstart.html)
+- /Users/chrislee/srv/github/agent-sync/.github/prompts/speckit.plan.prompt.md
+- /Users/chrislee/srv/github/agent-sync/.github/prompts/speckit.specify.prompt.md
+
+## Decision 9: Use a Mermaid flowchart to show the official process exactly
+
+**Decision**: Include a Mermaid flowchart in the final documentation that follows the official quickstart mainline order exactly, with `checklist` and `analyze` rendered as optional side paths rather than required stages.
+
+**Rationale**: The user explicitly asked for Mermaid diagrams to make the process easy to understand. A visual flowchart gives fast orientation, but it must not invent a repo-specific order. The official quickstart defines the mainline path clearly, while the official docs also show `checklist` and `analyze` as supplemental validation steps. Modeling the mainline and optional paths separately keeps the diagram accurate and easy to scan.
+
+**Alternatives considered**:
+
+- Omit diagrams and rely on prose. Rejected because it does not meet the user's request.
+- Put `checklist` and `analyze` into the mandatory mainline. Rejected because that would overstate their role in the official quickstart process.
+- Create a repository-specific custom flow. Rejected because the docs must reflect the official process first.
+
+**Sources**:
+
+- [Spec Kit Quick Start](https://github.github.com/spec-kit/quickstart.html)
+- [Specification-Driven Development](https://github.com/github/spec-kit/blob/main/spec-driven.md)

--- a/specs/20260405-195011-speckit-dev-docs/spec.md
+++ b/specs/20260405-195011-speckit-dev-docs/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Improve Speckit Development Documentation
+
+**Feature Branch**: `20260405-195011-speckit-dev-docs`  
+**Created**: 2026-04-05  
+**Status**: Draft  
+**Input**: User description: "Improve documentation to guide speckit development."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Start A Speckit Feature Confidently (Priority: P1)
+
+A contributor who wants to change AgentSync through the speckit workflow can find a single, clear path that explains how to start a feature, what each stage produces, and what they should do next at every step.
+
+**Why this priority**: If contributors cannot start or sequence the workflow correctly, the rest of the documentation has limited value because feature work will begin from guesswork and drift.
+
+**Independent Test**: Can be fully tested by asking a contributor who has not used speckit in this repository before to begin a new feature and reach a completed specification without reading source code or prior feature artifacts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor wants to start a new feature, **When** they open the speckit development guidance, **Then** they can identify the entry point, the first command to run, and the expected output of that step.
+2. **Given** a contributor has created a new feature branch and specification, **When** they read the workflow guide, **Then** they can tell which step comes next and what artifact should exist before moving on.
+3. **Given** a contributor finishes one workflow stage, **When** they look for next actions, **Then** the documentation routes them to the next stage without ambiguity.
+4. **Given** a contributor wants a quick overview before reading the full guide, **When** they inspect the workflow diagram, **Then** they can see the official stage order and the optional validation paths at a glance.
+
+---
+
+### User Story 2 - Understand Artifact Roles And Quality Gates (Priority: P2)
+
+A maintainer or reviewer can use the documentation to understand the purpose of each speckit artifact, the expected quality bar for each one, and how to evaluate whether a feature is ready to move from specification to planning, tasks, implementation, and review.
+
+**Why this priority**: Clear artifact expectations reduce review churn, prevent incomplete handoffs between workflow stages, and keep feature history understandable over time.
+
+**Independent Test**: Can be fully tested by giving a maintainer a feature directory and asking them to explain what each artifact is for, what good looks like, and whether the feature is ready for the next speckit command.
+
+**Acceptance Scenarios**:
+
+1. **Given** a maintainer is reviewing a feature directory, **When** they use the documentation, **Then** they can identify the role of the specification, plan, task list, and any supporting artifacts.
+2. **Given** a contributor is unsure whether a feature is ready for the next stage, **When** they consult the guidance, **Then** they can determine the required completion criteria before proceeding.
+3. **Given** a reviewer sees missing or stale feature artifacts, **When** they check the documentation, **Then** they can identify the correction path and the expected order of recovery.
+
+---
+
+### User Story 3 - Resolve Common Speckit Workflow Confusion (Priority: P3)
+
+A contributor who encounters a common workflow problem can use the documentation to diagnose what went wrong, understand the likely cause, and choose the correct recovery action without relying on tribal knowledge.
+
+**Why this priority**: Workflow documentation without troubleshooting turns routine friction into blocked work and encourages inconsistent local workarounds.
+
+**Independent Test**: Can be fully tested by presenting common workflow mistakes and confirming that a contributor can use the documentation alone to recover and continue.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor is unsure which speckit command applies to their current stage, **When** they read the troubleshooting or workflow guidance, **Then** they can identify the correct command and why the alternatives are not appropriate.
+2. **Given** a contributor cannot tell whether a workflow step can be re-run safely, **When** they consult the documentation, **Then** they can find the expected recovery behavior and any cautions before retrying.
+3. **Given** the repository uses optional or absent workflow extensions, **When** a contributor follows the documentation, **Then** they understand how the baseline workflow behaves with or without those extensions.
+
+### Edge Cases
+
+- What happens when a contributor joins the workflow at the middle of an existing feature rather than starting from scratch? The guidance must explain how to identify the current stage from the artifacts that already exist.
+- What happens when a contributor cannot tell whether a feature is ready for planning or still needs refinement? The documentation must describe explicit readiness signals for moving between stages.
+- What happens when workflow extensions are not configured? The baseline documentation must still be complete and must distinguish optional additions from the standard path.
+- What happens when a contributor re-runs a stage after partial progress? The guidance must explain whether the stage can be repeated safely and what should be reviewed afterward.
+- What happens when the artifact set is incomplete or inconsistent? The documentation must describe how to recover without inventing undocumented side paths.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The documentation MUST explain the purpose of the speckit workflow in this repository and the value it provides to contributors and maintainers.
+- **FR-002**: The documentation MUST provide a clear end-to-end path for feature work from initial specification through planning, task generation, implementation, and review.
+- **FR-003**: The documentation MUST explain when each workflow stage should be used, what outcome it is expected to produce, and what artifact or decision signals completion.
+- **FR-004**: The documentation MUST define the role of each core feature artifact so contributors can understand why it exists and how it supports the next stage.
+- **FR-005**: The documentation MUST explain the standard sequence of speckit development work and explicitly distinguish required steps from optional follow-up steps.
+- **FR-006**: The documentation MUST explain how contributors start a new feature and how they identify the active feature context after that feature already exists.
+- **FR-007**: The documentation MUST describe the repository conventions that materially affect speckit development, including branch naming expectations and documentation-quality obligations.
+- **FR-008**: The documentation MUST provide readiness criteria contributors can use to decide whether a feature is prepared to move to the next workflow stage.
+- **FR-009**: The documentation MUST provide troubleshooting guidance for common workflow confusion, missing artifacts, repeated steps, and incomplete feature context.
+- **FR-010**: The documentation MUST explain how baseline speckit behavior works when workflow extensions are absent and how optional workflow additions should be interpreted when present.
+- **FR-011**: The documentation MUST give maintainers and reviewers a lightweight rubric for checking feature artifact completeness and quality.
+- **FR-012**: The documentation MUST provide navigation that lets contributors move quickly between overview guidance, stage-by-stage instructions, artifact reference, and troubleshooting.
+- **FR-013**: The documentation MUST use consistent terminology for workflow stages, artifact names, readiness decisions, and contributor roles across all updated pages.
+- **FR-014**: The documentation MUST remain concise and reasoning-led so contributors can understand what to do and why it matters without reading excessive prose.
+- **FR-015**: The documentation MUST define ownership expectations for keeping speckit guidance current when the workflow, templates, or governance rules change.
+- **FR-016**: The documentation MUST include at least one Mermaid diagram that shows the official spec-kit workflow order from installation through implementation, with optional `checklist` and `analyze` steps clearly labeled as optional.
+
+### Key Entities _(include if feature involves data)_
+
+- **Workflow Stage**: A distinct phase of speckit-driven feature development with a clear goal, expected output, and transition condition.
+- **Feature Artifact**: A repository-hosted document that captures a specific stage of work and provides the context required for the next stage.
+- **Readiness Signal**: A user-observable condition that indicates a workflow stage is complete enough to continue.
+- **Workflow Guide**: The contributor-facing documentation that explains the standard path, decision points, and next actions for speckit development.
+- **Troubleshooting Entry**: A short recovery guide for a common workflow failure or confusion point.
+- **Review Rubric**: A concise set of checks maintainers can use to evaluate artifact quality and completeness.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: At least 90% of contributors unfamiliar with this repository can start a new speckit feature and produce a complete specification within 15 minutes using documentation alone.
+- **SC-002**: 100% of core speckit workflow stages are documented with their purpose, expected outcome, and transition signal.
+- **SC-003**: 100% of core feature artifacts are documented with their role and the question they answer for contributors or reviewers.
+- **SC-004**: Contributors can identify the correct next workflow stage for a sample feature scenario in under 2 minutes during documentation review.
+- **SC-005**: Documentation review finds zero contradictory descriptions of stage order, artifact purpose, or readiness expectations across the updated documentation set.
+- **SC-006**: Maintainers can evaluate a sample feature directory against the documented review rubric in under 10 minutes without consulting source code.
+- **SC-007**: Documentation review finds zero ordering mismatches between the Mermaid workflow diagram and the official spec-kit quickstart sequence, with optional validation commands marked as optional rather than required.
+
+## Assumptions
+
+- The primary audience is repository contributors and maintainers who need to use speckit to define and deliver features in AgentSync.
+- The feature scope is limited to improving repository-hosted documentation and does not require changing the underlying speckit workflow behavior.
+- The repository already contains the baseline workflow artifacts and commands that the updated documentation will explain.
+- Contributors benefit more from a canonical guided path and recovery guidance than from exhaustive reference material.
+- Existing repository governance and documentation standards remain authoritative and should be reflected by the updated speckit guidance rather than replaced.

--- a/specs/20260405-195011-speckit-dev-docs/tasks.md
+++ b/specs/20260405-195011-speckit-dev-docs/tasks.md
@@ -1,0 +1,188 @@
+# Tasks: Improve Speckit Development Documentation
+
+**Input**: Design documents from `/specs/20260405-195011-speckit-dev-docs/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: No new automated test tasks are required by the specification. Validation is handled through walkthrough checks, Mermaid validation, and repository-wide verification.
+
+**Organization**: Tasks are grouped by user story so each documentation outcome can be implemented and validated independently.
+
+## Phase 1: Setup
+
+**Purpose**: Create the target documentation files and shared working structure.
+
+- [x] T001 Create docs/speckit.md with contract-aligned section headings for prerequisites, workflow stages, Mermaid flow, artifacts, examples, and resume guidance
+- [x] T002 Create docs/speckit-local-development.md with contract-aligned section headings for repo surfaces, branch mapping, validation, and recovery guidance
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish shared navigation and terminology before user-story content is filled in.
+
+**⚠️ CRITICAL**: User story work should build on this shared navigation layer to avoid conflicting terminology and broken links.
+
+- [x] T003 Update README.md to add entry-point navigation for docs/speckit.md and docs/speckit-local-development.md
+- [x] T004 [P] Update docs/development.md and docs/maintenance.md to adopt shared speckit terminology and cross-links to docs/speckit.md and docs/speckit-local-development.md
+
+**Checkpoint**: The repo now has visible navigation targets and a shared vocabulary for the new guides.
+
+---
+
+## Phase 3: User Story 1 - Start A Speckit Feature Confidently (Priority: P1) 🎯 MVP
+
+**Goal**: Give first-time contributors a clear start path, command-by-command guidance, and an official-process Mermaid overview.
+
+**Independent Test**: Open README.md, follow the link to docs/speckit.md, identify the first command to run, the first artifact expected, the next step after specification, and confirm the Mermaid diagram matches the official quickstart order.
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] Write setup modes, prerequisites, and first-run guidance in docs/speckit.md from the official installation and quickstart sources
+- [x] T006 [US1] Document the mainline workflow stages and command-by-command when/how/next-step guidance in docs/speckit.md
+- [x] T007 [US1] Add and validate the official-process Mermaid workflow diagram in docs/speckit.md
+- [x] T008 [US1] Add AgentSync-specific constitution, specify, clarify, plan, tasks, analyze, and implement examples with expected artifacts in docs/speckit.md
+- [x] T009 [P] [US1] Refine README.md quick-start wording to surface the first command and first expected artifact from docs/speckit.md
+
+**Checkpoint**: A first-time contributor can discover the guide, understand how to start, and follow the official workflow visually and textually.
+
+---
+
+## Phase 4: User Story 2 - Understand Artifact Roles And Quality Gates (Priority: P2)
+
+**Goal**: Help maintainers and reviewers understand what each artifact does, when a stage is ready, and how to assess completeness.
+
+**Independent Test**: Open docs/speckit.md, docs/speckit-local-development.md, and docs/maintenance.md, then explain what `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, and `tasks.md` are for, when a feature is ready for the next stage, how `/speckit.checklist` and `/speckit.analyze` fit in, and who is expected to update the docs when workflow behavior changes.
+
+### Implementation for User Story 2
+
+- [x] T010 [US2] Add the feature artifact map for spec.md, plan.md, research.md, data-model.md, contracts/, quickstart.md, and tasks.md in docs/speckit.md
+- [x] T011 [US2] Add readiness signals and stage transition rules for specify, clarify, plan, tasks, analyze, and implement in docs/speckit.md
+- [x] T012 [P] [US2] Add a maintainer review rubric for artifact completeness and quality in docs/maintenance.md
+- [x] T013 [US2] Update docs/speckit.md and docs/maintenance.md to explain when to use optional /speckit.checklist and /speckit.analyze validation paths
+- [x] T014 [US2] Document ownership and update triggers in docs/maintenance.md and docs/speckit-local-development.md, including who updates speckit guidance, when workflow, template, or governance changes require doc updates, and how upstream spec-kit drift is checked
+
+**Checkpoint**: Reviewers can evaluate artifact purpose, readiness, and optional validation steps without reading source code.
+
+---
+
+## Phase 5: User Story 3 - Resolve Common Speckit Workflow Confusion (Priority: P3)
+
+**Goal**: Give contributors and maintainers clear recovery guidance for repo-local workflow confusion, resuming work, and advanced customization boundaries.
+
+**Independent Test**: Open docs/speckit-local-development.md and, if present, docs/troubleshooting.md, then identify how active feature detection works, how timestamp branches map to feature directories, how to resume an existing feature, and what to do when `.specify/extensions.yml` is absent.
+
+### Implementation for User Story 3
+
+- [x] T015 [US3] Write the repo-local surface map for .github/prompts, .github/agents, and .specify in docs/speckit-local-development.md
+- [x] T016 [US3] Add active-feature detection, timestamp branch mapping, and resume or rerun guidance in docs/speckit-local-development.md
+- [x] T017 [US3] Update docs/speckit.md and docs/speckit-local-development.md to explain baseline workflow versus extensions and presets when .specify/extensions.yml is absent
+- [x] T018 [US3] Add stage-selection, incomplete-artifact, and official-source drift recovery guidance in docs/speckit-local-development.md, and add a brief pointer in docs/troubleshooting.md if needed for discoverability
+
+**Checkpoint**: Contributors can recover from common workflow confusion and maintain the local speckit setup without tribal knowledge.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency review, walkthrough validation, and repo-wide verification.
+
+- [x] T019 [P] Review README.md, docs/speckit.md, docs/speckit-local-development.md, docs/development.md, docs/maintenance.md, and docs/troubleshooting.md for consistent terminology and cross-links
+- [x] T020 Validate the Mermaid flowchart in docs/speckit.md against the ordering documented in specs/20260405-195011-speckit-dev-docs/research.md
+- [x] T021 Run the walkthrough scenarios in specs/20260405-195011-speckit-dev-docs/quickstart.md against README.md, docs/speckit.md, and docs/speckit-local-development.md
+- [ ] T022 Run bun run check from package.json and fix any markdown or lint issues caused by README.md and docs/ updates
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion; establishes shared navigation and vocabulary.
+- **User Stories (Phases 3-5)**: Depend on Foundational completion.
+- **Polish (Phase 6)**: Depends on the desired user stories being complete.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Starts after Foundational completion and delivers the MVP documentation path.
+- **User Story 2 (P2)**: Starts after Foundational completion; touches docs/speckit.md and docs/maintenance.md, so in single-threaded execution it is safest after US1.
+- **User Story 3 (P3)**: Starts after Foundational completion; can run alongside later US1 or US2 work if file ownership is coordinated.
+
+### Within Each User Story
+
+- Core guide content before cross-file wording refinements.
+- Mermaid authoring before Mermaid validation.
+- Artifact explanations before readiness and rubric polishing.
+- Repo-local recovery guidance before troubleshooting polish.
+
+### Parallel Opportunities
+
+- T004 can run in parallel with T003 after the two new guide files exist.
+- T009 can run in parallel with late US1 guide drafting because it touches README.md instead of docs/speckit.md.
+- T012 can run in parallel with T010-T011 because it only touches docs/maintenance.md.
+- T019 can run in parallel with other late polish work if content is already stable.
+- No direct same-story parallel path remains in US3 because T015-T018 now converge on docs/speckit-local-development.md.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After the core guide structure exists, these can proceed in parallel:
+Task: "Refine README.md quick-start wording to surface the first command and first expected artifact from docs/speckit.md"
+Task: "Add AgentSync-specific constitution, specify, clarify, plan, tasks, analyze, and implement examples with expected artifacts in docs/speckit.md"
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# These can proceed in parallel once the shared terminology foundation is in place:
+Task: "Add a maintainer review rubric for artifact completeness and quality in docs/maintenance.md"
+Task: "Add the feature artifact map for spec.md, plan.md, research.md, data-model.md, contracts/, quickstart.md, and tasks.md in docs/speckit.md"
+```
+
+---
+
+## Parallel Example: User Story 3
+
+```bash
+# No direct same-story parallel pair remains after consolidating recovery guidance into docs/speckit-local-development.md:
+Task: "Write the repo-local surface map for .github/prompts, .github/agents, and .specify in docs/speckit-local-development.md"
+Task: "Then continue sequentially with active-feature, extensions, and recovery guidance in docs/speckit-local-development.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. Stop and validate that README.md and docs/speckit.md let a new contributor start confidently.
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational to establish the new documentation surfaces.
+2. Deliver User Story 1 as the onboarding MVP.
+3. Add User Story 2 to support reviewers and maintainers.
+4. Add User Story 3 to cover local maintenance and troubleshooting.
+5. Finish with Phase 6 walkthrough and repository validation.
+
+### Parallel Team Strategy
+
+1. One contributor establishes the two new guide files and README.md navigation.
+2. A second contributor can work on docs/maintenance.md while the main guide is being filled out.
+3. A third contributor can prepare a short docs/troubleshooting.md pointer after the local-development recovery guidance is stable.
+
+---
+
+## Notes
+
+- `[P]` tasks touch different files and can be coordinated safely in parallel.
+- `[US1]`, `[US2]`, and `[US3]` map directly to the user stories in spec.md.
+- The main guide must keep the official process order intact; do not promote optional validation commands into the mandatory mainline.
+- Use specs/20260405-195011-speckit-dev-docs/research.md as the source of truth when command wording or workflow order is in doubt.


### PR DESCRIPTION
## Summary

- Adds a canonical Speckit guide and a local-development guide so contributors can start, continue, and maintain spec-kit workflow in AgentSync without reading prompt files or shell scripts first.
- Codifies the related governance and template support for documentation-only workflow work, Mermaid validation, and repo-local upkeep expectations.
- See spec.md for full specification.

## Changes

- Documentation surfaces:
  - speckit.md: new contributor-facing guide for setup modes, official workflow, command usage, artifact map, readiness signals, examples, resume guidance, and extension boundaries.
  - speckit-local-development.md: new maintainer-facing guide for prompt locations, active-feature detection, timestamp branches, recovery guidance, and update triggers.
- Existing docs integration:
  - README.md: routes readers to the two new speckit guides.
  - development.md: points contributor workflow readers to the speckit docs.
  - maintenance.md: adds ownership rules, Mermaid expectations, and documentation-only exception guidance.
  - troubleshooting.md: points workflow confusion to the correct speckit docs.
- Governance and scaffolding:
  - constitution.md: adds the narrow documentation-only test-case exception and Mermaid/documentation gate language.
  - spec-template.md, plan-template.md, tasks-template.md: bake the new documentation-only and Mermaid requirements into future specs, plans, and task lists.
  - copilot-instructions.md: refreshes generated agent context for the new feature.
- Feature artifacts:
  - Adds spec.md, plan.md, research.md, data-model.md, `contracts/speckit-documentation-surface.md`, quickstart.md, tasks.md, and the requirements checklist under 20260405-195011-speckit-dev-docs.

### Architecture

### Before

```mermaid
flowchart LR
    classDef state fill:#ecf0f1,color:#2c3e50,stroke:#7f8c8d,stroke-width:1px;

    readmeNode["README<br/>general contributor entry"]:::state --> devNode["docs/development.md<br/>source workflow"]:::state
    readmeNode --> maintNode["docs/maintenance.md<br/>upkeep rules"]:::state
    readmeNode --> troubleNode["docs/troubleshooting.md<br/>failure cases"]:::state
    devNode --> gapNode["Speckit workflow knowledge<br/>spread across prompts and scripts"]:::state
```

### After

```mermaid
flowchart LR
    classDef state fill:#2c3e50,color:#ffffff,stroke:#1a252f,stroke-width:1px;
    classDef aux fill:#ecf0f1,color:#2c3e50,stroke:#7f8c8d,stroke-width:1px;

    readmeNode["README<br/>entry point"]:::state --> speckitNode["docs/speckit.md<br/>workflow and artifacts"]:::state
    readmeNode --> localNode["docs/speckit-local-development.md<br/>repo-local maintenance"]:::state
    speckitNode --> maintNode["docs/maintenance.md<br/>ownership and review rules"]:::aux
    localNode --> troubleNode["docs/troubleshooting.md<br/>optional recovery pointer"]:::aux
    speckitNode --> specsNode["specs feature artifacts<br/>spec plan research tasks"]:::aux
```

## Test Evidence

- `bun run check`
- `bun run typecheck`: passed
- `bun run lint`: passed
- `bun run test`: one failure in packaging.test.ts
- Failure detail: `package validation uses the pinned Node toolchain and minimum npm version` expected npm `11.5.1+`, but the local environment was Node `v22.14.0` with npm `10.9.2`
- Mermaid validation: the new workflow diagram in speckit.md validated successfully
- Task completion: 21 of 22 tasks are checked in tasks.md; the remaining unchecked item is the final repo gate rerun after the local npm toolchain is updated

## Risks / Follow-ups

- Local validation is still blocked by the machine npm version being `10.9.2`; rerun `bun run check` under npm `11.5.1+` to clear the remaining task.
- copilot-instructions.md was auto-updated as part of the planning workflow; keep it if generated context belongs in the PR, or regenerate/trim it if you want a narrower docs-only diff.
- No TODO or FIXME markers were introduced by this change set.

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Speckit workflow documentation including a canonical guide, local development guide, and integration across existing docs.
  * Introduced Mermaid diagrams to visualize workflow stages and decision paths.

* **Documentation**
  * Updated contributor guidelines to allow documentation-only changes with specific requirements (including Mermaid validation and manual verification steps).
  * Expanded troubleshooting and development guides with Speckit-specific guidance.

* **Chores**
  * Updated governance standards and contributor templates to reflect new documentation expectations and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->