### PR TITLE
docs(released-cli): align released CLI documentation across entry and support guides

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,6 +13,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-05
 - TypeScript 6.0.0 (strict) with Bun 1.3.9 runtime; Node 22.14.0+ and npm 11.5.1+ for trusted publishing + Bun 1.3.9, `citty`, `simple-git`, `zod`, release-please, GitHub Actions, npm registry trusted publishing via OIDC (20260405-112827-bunx-release)
 - Markdown documentation plus TypeScript 6.0.0 repository contex + Existing repo toolchain only; authoritative research sources are official spec-kit documentation and the `github/spec-kit` repository (20260405-195011-speckit-dev-docs)
 - Repository-hosted Markdown files under `README.md`, `docs/`, `.github/`, and `.specify/` as referenced documentation sources (20260405-195011-speckit-dev-docs)
+- Markdown documentation plus TypeScript 6.x and Bun 1.3.9 repository contex + Existing repo toolchain only; no new runtime or documentation dependencies (20260405-213451-released-cli-docs)
+- Repository-hosted Markdown files and feature-planning artifacts only (20260405-213451-released-cli-docs)
 
 - TypeScript 5.8+ (strict mode; `any` forbidden — use `unknown` + Zod) + `bun:test` (built-in), `age-encryption ^0.3.0`, `simple-git ^3.27.0`, `tar ^7.4.0`, `zod ^3.23.8`, `@iarna/toml ^2.2.5` (001-initial-function-testing)
 
@@ -32,9 +34,9 @@ npm test && npm run lint
 TypeScript 5.8+ (strict mode; `any` forbidden — use `unknown` + Zod): Follow standard conventions
 
 ## Recent Changes
+- 20260405-213451-released-cli-docs: Added Markdown documentation plus TypeScript 6.x and Bun 1.3.9 repository contex + Existing repo toolchain only; no new runtime or documentation dependencies
 - 20260405-195011-speckit-dev-docs: Added Markdown documentation plus TypeScript 6.0.0 repository contex + Existing repo toolchain only; authoritative research sources are official spec-kit documentation and the `github/spec-kit` repository
 - 20260405-112827-bunx-release: Added TypeScript 6.0.0 (strict) with Bun 1.3.9 runtime; Node 22.14.0+ and npm 11.5.1+ for trusted publishing + Bun 1.3.9, `citty`, `simple-git`, `zod`, release-please, GitHub Actions, npm registry trusted publishing via OIDC
-- 20260405-112827-bunx-release: Added TypeScript 6.0.0 (strict) with Bun 1.3.9 runtime; Node 22.14.0+ and npm 11.5.1+ for npm trusted publishing + Bun 1.3.9, `citty`, `simple-git`, `zod`, release-please, GitHub Actions, npm registry trusted publishing via OIDC
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ It is for people who keep global agent configuration in tools like Claude, Curso
 
 Use the published package path only after a tagged GitHub Release and npm publish have both completed for the version you want.
 
+Use this path when you are evaluating or operating a published AgentSync release.
+If you are developing from a local clone or testing unreleased changes, use the contributor-from-source workflow instead.
+
 Prerequisites for the released CLI path:
 
 - Bun 1.3.9 or later
@@ -32,6 +35,28 @@ First-run verification command for the published CLI:
 
 ```bash
 bunx --package @chrisleekr/agentsync agentsync --version
+```
+
+Run the published CLI with `bunx` when you do not want a separate global install:
+
+```bash
+bunx --package @chrisleekr/agentsync agentsync <command> [options]
+```
+
+Common `bunx` examples:
+
+```bash
+# Verify the published CLI resolves correctly
+bunx --package @chrisleekr/agentsync agentsync --version
+
+# Initialize a vault from the published package
+bunx --package @chrisleekr/agentsync agentsync init --remote git@github.com:<you>/agentsync-vault.git --branch main
+
+# Push local agent config into the encrypted vault
+bunx --package @chrisleekr/agentsync agentsync push
+
+# Pull the latest vault state onto this machine
+bunx --package @chrisleekr/agentsync agentsync pull
 ```
 
 Use the GitHub Release record as the canonical place to see:
@@ -75,6 +100,9 @@ Not yet positioned as a full hosted service:
 ## Contributor setup from source
 
 This is the contributor workflow for developing from a clone of the repository. It is separate from the published CLI path above.
+
+Do not use this section when you are trying to run a published release from npm.
+For released usage, start with the released CLI path above and continue in [docs/command-reference.md](docs/command-reference.md).
 
 If your change follows the spec-kit workflow, start with [docs/speckit.md](docs/speckit.md).
 If you are maintaining the repo-local speckit setup itself, use

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -8,10 +8,19 @@ This guide is the concise lookup surface for supported AgentSync commands. Use i
 
 Use the published CLI path only after the version you want appears in both the npm package registry and the GitHub Releases list.
 
+Use this guide when you are running a published release through `bunx`.
+If you are working from a local clone or testing unreleased changes, use the source-based commands in [development.md](development.md) instead.
+
 Released CLI verification command:
 
 ```bash
 bunx --package @chrisleekr/agentsync agentsync --version
+```
+
+Published command pattern:
+
+```bash
+bunx --package @chrisleekr/agentsync agentsync <command> [options]
 ```
 
 Use the GitHub Release record as the canonical source for:
@@ -37,7 +46,7 @@ If you are running from a local clone instead of the published package, use the 
 **Typical usage**:
 
 ```bash
-agentsync init --remote <git-url> --branch main
+bunx --package @chrisleekr/agentsync agentsync init --remote <git-url> --branch main
 ```
 
 **Needs**: remote URL, optional branch, writable local runtime directory.
@@ -56,8 +65,8 @@ agentsync init --remote <git-url> --branch main
 **Typical usage**:
 
 ```bash
-agentsync push
-agentsync push --agent claude
+bunx --package @chrisleekr/agentsync agentsync push
+bunx --package @chrisleekr/agentsync agentsync push --agent claude
 ```
 
 **Needs**: initialized vault, configured recipients, readable local agent config.
@@ -77,8 +86,8 @@ agentsync push --agent claude
 **Typical usage**:
 
 ```bash
-agentsync pull
-agentsync pull --agent cursor
+bunx --package @chrisleekr/agentsync agentsync pull
+bunx --package @chrisleekr/agentsync agentsync pull --agent cursor
 ```
 
 **Needs**: initialized vault, readable private key, reachable Git remote.
@@ -97,8 +106,8 @@ agentsync pull --agent cursor
 **Typical usage**:
 
 ```bash
-agentsync status
-agentsync status --verbose
+bunx --package @chrisleekr/agentsync agentsync status
+bunx --package @chrisleekr/agentsync agentsync status --verbose
 ```
 
 **Outcome**: table of synced, local-only, vault-only, changed, or error states.
@@ -110,7 +119,7 @@ agentsync status --verbose
 **Typical usage**:
 
 ```bash
-agentsync doctor
+bunx --package @chrisleekr/agentsync agentsync doctor
 ```
 
 **Checks include**:
@@ -129,8 +138,8 @@ agentsync doctor
 **Typical usage**:
 
 ```bash
-agentsync daemon install
-agentsync daemon status
+bunx --package @chrisleekr/agentsync agentsync daemon install
+bunx --package @chrisleekr/agentsync agentsync daemon status
 ```
 
 **Outcome**: manages the OS-specific wrapper around `daemon _run`.
@@ -147,8 +156,8 @@ agentsync daemon status
 **Typical usage**:
 
 ```bash
-agentsync key add <name> <age-public-key>
-agentsync key rotate
+bunx --package @chrisleekr/agentsync agentsync key add <name> <age-public-key>
+bunx --package @chrisleekr/agentsync agentsync key rotate
 ```
 
 **Outcome**: the vault is re-encrypted for the updated recipient set.

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,6 +4,9 @@
 
 Use this guide when you need to run AgentSync locally, verify a change, or understand the contributor workflow without reading the source tree first.
 
+This guide is for contributor-from-source work from a local clone.
+If you want to run a published release, start in [../README.md](../README.md) and [command-reference.md](command-reference.md) instead.
+
 ## Prerequisites
 
 - Bun 1.3.9 or later
@@ -15,7 +18,7 @@ If you use `nvm`, run `nvm use` at the repo root.
 
 If you use Volta, the project pin in `package.json` should switch you to the expected Node version automatically.
 
-This guide is for contributor-from-source work. The published CLI path is documented separately in [../README.md](../README.md) and [command-reference.md](command-reference.md).
+This guide is for contributor-from-source work. Do not use `bun run src/cli.ts ...` as the default command path for a published release. The published CLI path is documented separately in [../README.md](../README.md) and [command-reference.md](command-reference.md).
 
 ## Install and verify
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -14,6 +14,7 @@ Use this guide when a change affects user-facing behavior, exported symbols, syn
 - `docs/command-reference.md` owns command contracts and support-state notes.
 - `docs/troubleshooting.md` owns failure cases and next diagnostic steps.
 - This page owns upkeep rules and review checkpoints.
+- The released CLI routing surface spans `README.md`, `docs/command-reference.md`, `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md`; when one of those pages changes the released-versus-source boundary, review all five for consistency.
 
 ## Release workflow ownership rules
 
@@ -21,6 +22,7 @@ Use this guide when a change affects user-facing behavior, exported symbols, syn
 - The npm publish path must use GitHub OIDC trusted publishing only.
 - Long-lived npm write tokens are not a supported normal-release credential model for this repo.
 - User-facing documentation must not present `bunx` installation as supported until release validation succeeds for that workflow.
+- When the released CLI path changes, `README.md`, `docs/command-reference.md`, `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` must stay aligned on installation, usage, when-to-use guidance, and the GitHub Releases source of truth.
 
 ## Publish workflow checklist
 
@@ -92,6 +94,7 @@ Before merging, verify:
 9. Support-state wording is explicit where behavior is partial, planned, or unsupported.
 10. `README.md` and `docs/command-reference.md` still point to the canonical GitHub Release record for release notes.
 11. `bun run check` still passes.
+12. `README.md`, `docs/command-reference.md`, `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` still agree on when to use the released CLI path versus contributor-from-source commands.
 
 ## Terminology guardrails
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,9 @@
 
 Use this guide when AgentSync setup or sync behavior fails and you need the next diagnostic step quickly, not a long theory dump.
 
+This guide primarily assumes contributor-from-source execution from a local clone.
+If you are using a published release, start in [../README.md](../README.md) and [command-reference.md](command-reference.md), then translate any `bun run src/cli.ts <command>` example here to `bunx --package @chrisleekr/agentsync agentsync <command>`.
+
 ## `init` failed or the vault did not push
 
 Check:

--- a/specs/20260405-213451-released-cli-docs/checklists/requirements.md
+++ b/specs/20260405-213451-released-cli-docs/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Released CLI Documentation Refresh
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-05  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details languages frameworks APIs
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic no implementation details
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated as a documentation-only feature. No clarification questions were required.
+- The spec keeps runtime, packaging, CI, and generated workflow behavior out of scope.

--- a/specs/20260405-213451-released-cli-docs/contracts/released-cli-documentation-surface.md
+++ b/specs/20260405-213451-released-cli-docs/contracts/released-cli-documentation-surface.md
@@ -1,0 +1,81 @@
+# Contract: Released CLI Documentation Surface
+
+**Branch**: `20260405-213451-released-cli-docs` | **Date**: 2026-04-05
+
+This contract defines the observable documentation behavior for the released CLI path: where readers learn how to install or invoke the published CLI, how they learn to use it, and how they decide whether they should follow the released path or the contributor-from-source path.
+
+---
+
+## Contract 1 — README Entry Experience
+
+### Required Elements
+
+| Element                | Requirement                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| Released path intro    | `README.md` must explain that the released CLI path depends on a published version                      |
+| Invocation pattern     | `README.md` must show the `bunx --package @chrisleekr/agentsync agentsync <command> [options]` pattern  |
+| First verification     | `README.md` must show a successful first verification command                                           |
+| When-to-use guidance   | `README.md` must say when to use the released path and when to use contributor-from-source docs instead |
+| Canonical release info | `README.md` must point readers to GitHub Releases for version and change information                    |
+
+### README Behavior
+
+- A first-time released user should be able to identify how to invoke the published CLI and where to confirm release details without opening source-oriented docs first.
+- The README must remain a navigation hub, not a full command manual.
+
+---
+
+## Contract 2 — Command Reference Usage Rules
+
+### Command Reference Required Behavior
+
+- `docs/command-reference.md` must describe the released CLI path as the supported path for published versions.
+- The page must teach how released command examples map to the published invocation pattern.
+- The page must keep support-state wording explicit when the released path depends on an actual published release.
+
+### Command Reference Prohibited Behavior
+
+- Bare command examples that appear to be directly runnable by released users without any invocation context.
+- Source-oriented execution guidance presented as the default released path.
+
+---
+
+## Contract 3 — Supporting Guide Boundaries
+
+### Required Pages
+
+| Path                      | Boundary Requirement                                                                                              |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `docs/development.md`     | Must state that it covers contributor-from-source workflow and redirect released users to released-path docs      |
+| `docs/maintenance.md`     | Must define which docs remain in sync when the released path changes                                              |
+| `docs/troubleshooting.md` | Must either use released-path troubleshooting commands or clearly state that its examples assume source execution |
+
+### Supporting Guide Behavior
+
+- Supporting guides should redirect readers between released and source paths instead of mixing both workflows inside one unlabeled section.
+- Any page that stays source-oriented must say so early enough that a released user does not follow the wrong command examples by accident.
+
+---
+
+## Contract 4 — Canonical Release Reference
+
+### Canonical Release Required Behavior
+
+- GitHub Releases is the canonical source for published version and change information.
+- Pages that teach the released CLI path must preserve or point back to that source.
+
+### Canonical Release Prohibited Behavior
+
+- Conflicting release-information sources across entry, command, maintenance, or troubleshooting docs.
+
+---
+
+## Contract 5 — Documentation-Only Validation
+
+Implementation is compliant when:
+
+1. `README.md` teaches installation or invocation, first verification, and when-to-use rules for the released CLI path.
+2. `docs/command-reference.md` teaches released command usage consistently.
+3. `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` keep the released-versus-source boundary explicit.
+4. All affected pages keep GitHub Releases as the canonical release-information source.
+5. `bun run check` passes and the manual walkthrough in the feature quickstart confirms no contradictory wording remains.

--- a/specs/20260405-213451-released-cli-docs/data-model.md
+++ b/specs/20260405-213451-released-cli-docs/data-model.md
@@ -1,0 +1,111 @@
+# Data Model: Released CLI Documentation Refresh
+
+**Branch**: `20260405-213451-released-cli-docs` | **Date**: 2026-04-05
+
+This feature is documentation-only, but it still has a concrete design model so coverage and consistency can be reviewed deliberately instead of by intuition.
+
+---
+
+## Entity 1 — Documentation Surface
+
+Represents a repository-hosted page that can guide the reader toward the released CLI path or the contributor-from-source path.
+
+### Documentation Surface Fields
+
+- **Path**: repository-relative Markdown path
+- **Primary Audience**: released user, contributor, maintainer, or mixed
+- **Primary Purpose**: installation, usage, maintenance, troubleshooting, or routing
+- **Execution Scope**: released path, source path, or explicit redirect between them
+- **Canonical Release Reference**: whether the page points to GitHub Releases
+- **Consistency Obligations**: the wording promises that must stay aligned with adjacent pages
+
+### Instances In Scope
+
+- `README.md`
+- `docs/command-reference.md`
+- `docs/development.md`
+- `docs/maintenance.md`
+- `docs/troubleshooting.md`
+
+---
+
+## Entity 2 — Reader Intent
+
+Represents the question a reader is trying to answer when they land in the documentation.
+
+### Reader Intent Fields
+
+- **Intent Name**: installation, first verification, command usage, source development, maintenance review, troubleshooting
+- **Preferred Entry Surface**: the page that should answer the question first
+- **Fallback Surface**: the page that should receive redirected readers
+- **Failure Mode**: the kind of confusion caused by incorrect routing
+
+### Intent Mapping
+
+- **Install released CLI** → `README.md`, then `docs/command-reference.md`
+- **Use released commands** → `docs/command-reference.md`
+- **Develop from source** → `docs/development.md`
+- **Maintain release-path docs** → `docs/maintenance.md`
+- **Troubleshoot command execution** → `docs/troubleshooting.md`
+
+---
+
+## Entity 3 — Execution Path
+
+Represents the command shape a page is describing.
+
+### Execution Path Fields
+
+- **Path Name**: released CLI path or contributor-from-source path
+- **Invocation Pattern**: command prefix used on the page
+- **When To Use**: the conditions that make this path correct
+- **Out-Of-Scope Rule**: what the page must not imply about the other path
+
+### Instances
+
+#### Released CLI Path
+
+- **Invocation Pattern**: `bunx --package @chrisleekr/agentsync agentsync <command> [options]`
+- **When To Use**: published versions that are available through npm and GitHub Releases
+- **Out-Of-Scope Rule**: must not imply contributor setup from a local clone
+
+#### Contributor-From-Source Path
+
+- **Invocation Pattern**: `bun run src/cli.ts <command> [options]`
+- **When To Use**: local development, unreleased work, and contributor verification
+- **Out-Of-Scope Rule**: must not be presented as the default path for released users
+
+---
+
+## Entity 4 — Canonical Release Reference
+
+Represents the single source of truth for released version and change information.
+
+### Canonical Release Reference Fields
+
+- **Surface**: GitHub Releases
+- **Purpose**: version lookup, release notes, release existence confirmation
+- **Linked From**: pages that reference the released CLI path
+
+### Rule
+
+Any page that tells readers how to install or use the released CLI must either link directly to GitHub Releases or direct readers to a page that does.
+
+---
+
+## Entity 5 — Manual Validation Step
+
+Represents a reviewer action required by the documentation-only exception.
+
+### Manual Validation Step Fields
+
+- **Target Surface**: page being reviewed
+- **Validation Goal**: what must be confirmed
+- **Expected Outcome**: wording or routing that should be visible
+
+### Required Steps
+
+1. Confirm `README.md` shows install or invocation, first verification, and when-to-use wording for the released CLI path.
+2. Confirm `docs/command-reference.md` teaches released command usage consistently.
+3. Confirm `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` preserve clear released-versus-source boundaries.
+4. Confirm all affected pages retain GitHub Releases as the canonical release-information source.

--- a/specs/20260405-213451-released-cli-docs/plan.md
+++ b/specs/20260405-213451-released-cli-docs/plan.md
@@ -1,0 +1,192 @@
+# Implementation Plan: Released CLI Documentation Refresh
+
+**Branch**: `20260405-213451-released-cli-docs` | **Date**: 2026-04-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/20260405-213451-released-cli-docs/spec.md`
+
+## Summary
+
+Align the repository documentation around the released CLI path so readers can tell how to install AgentSync with `bunx`, how to use the published command surface, and when they should prefer the released path over the contributor-from-source workflow. The implementation is documentation-only and will update every documentation surface that currently routes readers into install, command usage, maintenance expectations, or troubleshooting so the released path is taught consistently.
+
+## Technical Context
+
+**Language/Version**: Markdown documentation plus TypeScript 6.x and Bun 1.3.9 repository context  
+**Primary Dependencies**: Existing repo toolchain only; no new runtime or documentation dependencies  
+**Storage**: Repository-hosted Markdown files and feature-planning artifacts only  
+**Testing**: `bun run check` plus manual documentation walkthrough validation recorded in feature artifacts  
+**Target Platform**: GitHub-hosted repository documentation for released CLI users and contributors on macOS, Linux, and Windows
+**Project Type**: Bun-based CLI and daemon project with repository documentation  
+**Performance Goals**: Readers can identify install path, command path, and release-versus-source decision points within one document hop; reviewers can verify doc consistency across affected pages in under 5 minutes  
+**Constraints**: Documentation-only scope; no runtime, packaging, CI, exported symbol, or generated workflow changes; no Mermaid unless prose cannot explain the routing clearly enough  
+**Scale/Scope**: Five repository-hosted documentation surfaces plus planning artifacts: `README.md`, `docs/command-reference.md`, `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md`
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### Principle I — Security-First Credential Handling
+
+**Status: PASS** — The feature updates wording only. It does not change key handling, vault content, recipient behavior, or secret scanning rules.
+
+### Principle II — Test Coverage (NON-NEGOTIABLE)
+
+**Status: PASS** — This feature qualifies for the documentation-only exception because the planned changes are limited to repository-hosted documentation and feature-planning artifacts. The plan preserves the required `bun run check` merge gate and records manual walkthrough validation steps in [quickstart.md](./quickstart.md).
+
+### Principle III — Cross-Platform Daemon Reliability
+
+**Status: PASS** — No daemon, IPC, watcher, or installer behavior changes are planned. Documentation will clarify command routing only.
+
+### Principle IV — Code Quality with Biome
+
+**Status: PASS** — No code or tooling changes are introduced. Verification still includes the existing repository check command to catch accidental drift.
+
+### Principle V — Documentation Standards
+
+**Status: PASS** — The design keeps the docs concise, treats the GitHub Release record as the canonical release-information surface, and concludes that a Mermaid diagram is not required because the work is wording and routing clarification across existing pages rather than a workflow whose structure is materially clearer as a diagram.
+
+### Post-Design Re-check
+
+All constitution principles remain satisfied after Phase 1 design. The design keeps the feature documentation-only, preserves manual walkthrough validation in feature artifacts, and avoids introducing a diagram where prose remains clearer and lower maintenance.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/20260405-213451-released-cli-docs/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── released-cli-documentation-surface.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+README.md                     ← UPDATE: released CLI install, usage, and when-to-use routing
+docs/
+├── command-reference.md      ← UPDATE: released command examples and support-state wording
+├── development.md            ← UPDATE: source workflow boundary and redirect to released docs
+├── maintenance.md            ← UPDATE: documentation ownership and release-path consistency rules
+└── troubleshooting.md        ← UPDATE: released-versus-source troubleshooting command guidance
+```
+
+**Structure Decision**: Single-project repository with documentation-only changes. The implementation is confined to repo-hosted Markdown pages that influence installation, command usage, maintenance, and troubleshooting guidance for the released CLI path.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications required.
+
+---
+
+## Phase 0 — Research Summary
+
+All research is complete. See [research.md](./research.md) for full findings. Key decisions:
+
+| Topic                         | Decision                                                                                                                                 | Why                                                                                                     |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Entry-point guidance          | Keep `README.md` as the released-user entry point for install, first verification, and release lookup                                    | Readers start there first and need the released path before source details                              |
+| Command examples              | Use the published `bunx --package @chrisleekr/agentsync agentsync ...` shape wherever the page is describing a released command contract | Bare `agentsync ...` examples force readers to infer how the published CLI is actually invoked          |
+| Release-versus-source routing | Explicitly tell readers when to use released CLI docs versus contributor-from-source docs in every affected page                         | Prevents mixed guidance across README, command reference, development, maintenance, and troubleshooting |
+| Canonical release info        | Keep GitHub Releases as the single release-information source for version and change lookup                                              | Existing docs already anchor on this and it avoids duplicate sources of truth                           |
+| Diagram need                  | Do not add a Mermaid diagram for this feature                                                                                            | The work is wording alignment across docs, not a complex lifecycle that prose fails to explain          |
+
+---
+
+## Phase 1 — Design
+
+### Interface Contracts
+
+See [contracts/released-cli-documentation-surface.md](./contracts/released-cli-documentation-surface.md).
+
+This feature exposes a documentation contract rather than a runtime API. The contract defines:
+
+- Which pages must teach installation, usage, and when-to-use boundaries for the released CLI path
+- Which pages must redirect readers to contributor-from-source guidance instead of duplicating it
+- Which release-information source is canonical
+- Which troubleshooting pages must use or explicitly contextualize released command examples
+
+### Data Model
+
+See [data-model.md](./data-model.md) — the design models documentation surfaces, reader intents, execution paths, canonical release references, and manual validation steps so implementation can check coverage and consistency.
+
+### Quickstart
+
+See [quickstart.md](./quickstart.md) for the implementation order and manual validation workflow.
+
+---
+
+## Phase 2 — Implementation Plan
+
+### Overview
+
+Execute the documentation refresh in four phases so routing is defined before wording changes are spread across the docs set.
+
+```text
+Phase A: Audit released-path wording and contradictions
+Phase B: Update entry and command-reference guidance
+Phase C: Align contributor, maintenance, and troubleshooting docs
+Phase D: Run consistency review and validation
+```
+
+### Phase A — Audit Released-Path Coverage
+
+**Goal**: Establish the exact set of pages that currently teach, imply, or contradict the released CLI path.
+
+**Actions**:
+
+1. Review `README.md` for install, verification, and release-record routing.
+2. Review `docs/command-reference.md` for command examples that still assume bare `agentsync` execution without clarifying the released invocation path.
+3. Review `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` for source-only guidance that should either stay source-only with explicit labels or redirect released users elsewhere.
+4. Record the wording gaps for installation, how to use, and when to use the released path.
+
+**Output**: File-level wording map covering every affected documentation surface.
+
+### Phase B — Entry And Command Guidance
+
+**Goal**: Make the released path explicit where readers first decide how to install and run the CLI.
+
+**Files to update**:
+
+1. `README.md`
+   Purpose: show the install path, first verification command, common `bunx` usage pattern, and when the released path applies.
+
+2. `docs/command-reference.md`
+   Purpose: teach released command usage consistently, including the published invocation pattern and support-state wording for published versions.
+
+**Design rule**: If a reader is trying to install or run a released version, these two pages must answer the question without requiring source-based docs first.
+
+### Phase C — Supporting Documentation Alignment
+
+**Goal**: Keep adjacent documentation from contradicting or diluting the released CLI guidance.
+
+**Files to update**:
+
+1. `docs/development.md`
+   Purpose: keep source workflow guidance explicit and redirect released users to the correct pages.
+
+2. `docs/maintenance.md`
+   Purpose: define which docs must stay aligned whenever the released CLI path changes and preserve the GitHub Releases source-of-truth rule.
+
+3. `docs/troubleshooting.md`
+   Purpose: ensure troubleshooting commands either use released-path examples or clearly state that the page assumes contributor-from-source execution.
+
+**Design rule**: Supporting docs should redirect, not duplicate. Any page that remains source-oriented must say so early and point released users back to the released-path docs.
+
+### Phase D — Consistency Review And Validation
+
+**Goal**: Verify that installation, usage, and when-to-use guidance reads as one coherent documentation system.
+
+**Verification steps**:
+
+1. Run `bun run check`.
+2. Manually review `README.md` for released install, first verification, and when-to-use wording.
+3. Manually review `docs/command-reference.md` to confirm command examples and support-state wording match the released path.
+4. Manually review `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` to confirm the released-versus-source boundary is explicit and consistent.
+5. Confirm every affected page points readers to GitHub Releases for release version and change information.
+
+**Exit criteria**: No affected doc page leaves readers guessing how to install the released CLI, how to invoke it, or when to prefer the released path over the contributor workflow.
+
+<!-- End of implementation plan -->

--- a/specs/20260405-213451-released-cli-docs/quickstart.md
+++ b/specs/20260405-213451-released-cli-docs/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart: Released CLI Documentation Refresh
+
+**Branch**: `20260405-213451-released-cli-docs` | **Date**: 2026-04-05
+
+This quickstart gives the implementation order and manual validation sequence for aligning the released CLI documentation across every affected page.
+
+---
+
+## Prerequisites
+
+```sh
+git checkout 20260405-213451-released-cli-docs
+bun install
+```
+
+---
+
+## Step 1 — Audit Every Related Documentation Surface
+
+Review:
+
+1. `README.md`
+2. `docs/command-reference.md`
+3. `docs/development.md`
+4. `docs/maintenance.md`
+5. `docs/troubleshooting.md`
+
+Capture where each page currently answers or fails to answer:
+
+- how to invoke the released CLI
+- how to use it for common commands
+- when to use the released path instead of the contributor-from-source path
+- where to look up released version and change information
+
+Expected result: a concrete wording gap list rather than vague “docs need cleanup” conclusions.
+
+---
+
+## Step 2 — Fix The Released User Entry Path
+
+Update `README.md` so a first-time reader can answer these questions immediately:
+
+1. What is the released CLI path?
+2. How do I verify it resolves correctly?
+3. How do I run common commands through the published package?
+4. When should I use this path instead of the contributor docs?
+
+Expected result: the entry page becomes sufficient for installation and first use orientation.
+
+---
+
+## Step 3 — Align Command Usage And Supporting Guides
+
+Update:
+
+1. `docs/command-reference.md` to teach released command usage consistently.
+2. `docs/development.md` to keep source workflow guidance explicit and redirect released users.
+3. `docs/maintenance.md` to define the docs that must stay aligned when the released path changes.
+4. `docs/troubleshooting.md` to prevent source-only command examples from misleading released users.
+
+Expected result: no deep-linked doc page leaves the released-versus-source boundary implicit.
+
+---
+
+## Step 4 — Validate Documentation-Only Compliance
+
+Run:
+
+```sh
+bun run check
+```
+
+Then manually verify:
+
+1. `README.md` contains released install or invocation guidance, first verification, and when-to-use wording.
+2. `docs/command-reference.md` shows how to use the released command path and uses the published invocation pattern consistently.
+3. `docs/development.md` explicitly scopes itself to contributor-from-source workflow and redirects released users appropriately.
+4. `docs/maintenance.md` lists the released-path docs that must stay aligned and preserves GitHub Releases as the canonical release-information source.
+5. `docs/troubleshooting.md` clearly scopes its source-based command examples and tells released users how to translate or redirect those commands.
+6. No page implies that an unpublished version is available through the released path.
+
+Expected result: the feature remains documentation-only and reviewers can confirm the consistency manually in a few minutes.
+
+---
+
+## Completion Criteria
+
+- Every affected documentation surface gives consistent guidance for installation, usage, and when-to-use decisions around the released CLI path.
+- Released users are not forced into contributor-from-source commands by mistake.
+- The docs still use GitHub Releases as the single release-information source.
+- `bun run check` passes before merge.

--- a/specs/20260405-213451-released-cli-docs/research.md
+++ b/specs/20260405-213451-released-cli-docs/research.md
@@ -1,0 +1,82 @@
+# Research: Released CLI Documentation Refresh
+
+**Branch**: `20260405-213451-released-cli-docs` | **Date**: 2026-04-05
+
+---
+
+## Finding 1 — The README Must Answer Installation And First Use For Released Users
+
+### Evidence For README Scope
+
+`README.md` already contains a released CLI section, prerequisites, a verification command, and a general `bunx` pattern. That confirms the entry page is the intended starting point for released users.
+
+### Decision For README Scope
+
+- **Chosen**: Keep `README.md` as the primary released-user landing page and ensure it clearly answers three questions: how to install or invoke the released CLI, how to use it for first commands, and when readers should follow the released path instead of the contributor path.
+- **Rationale**: The entry documentation is where readers first decide whether the project is usable as a released CLI. That decision should not require scanning deeper docs.
+- **Alternatives considered**:
+  - _Move all released-path details into `docs/command-reference.md`_: Rejected because it forces first-time readers to leave the entry page before they even know the install and verification flow.
+  - _Keep only the version-check example in README_: Rejected because it proves resolution but does not fully explain how to use the published CLI.
+
+---
+
+## Finding 2 — The Command Reference Still Describes The Released Surface Incompletely
+
+### Evidence For Command Reference Scope
+
+`docs/command-reference.md` identifies the released CLI path and version-check command, but the per-command usage examples still use bare `agentsync ...` forms without showing the published invocation pattern.
+
+### Decision For Command Reference Scope
+
+- **Chosen**: Update the command reference so released usage examples teach the actual published invocation path, either directly in examples or through one explicit rule that applies to all examples on the page.
+- **Rationale**: Released users should not have to infer how bare command examples map onto `bunx --package @chrisleekr/agentsync agentsync ...`.
+- **Alternatives considered**:
+  - _Leave bare command examples and rely on one intro sentence_: Rejected because it is easy to miss and leaves the highest-frequency part of the page inconsistent with the released path.
+  - _Remove all examples_: Rejected because readers need quick operational copy points, not abstract contracts only.
+
+---
+
+## Finding 3 — Source-Oriented Guides Need Stronger Routing Boundaries
+
+### Evidence For Supporting Guide Boundaries
+
+`docs/development.md` correctly describes contributor-from-source work, but `docs/troubleshooting.md` still uses `bun run src/cli.ts ...` examples without early scope labeling for released users. `docs/maintenance.md` defines ownership rules but can still be tightened around which pages must stay aligned when the released path changes.
+
+### Decision For Supporting Guide Boundaries
+
+- **Chosen**: Make the released-versus-source boundary explicit near the top of every affected supporting page and use redirects rather than mixed guidance.
+- **Rationale**: Readers often enter through search, deep links, or a doc sidebar, not through README. Each page must be self-scoping enough to prevent mode confusion.
+- **Alternatives considered**:
+  - _Assume README routing is sufficient_: Rejected because deep-linked docs bypass README.
+  - _Duplicate the full released path in every page_: Rejected because it increases maintenance burden and raises the risk of drift.
+
+---
+
+## Finding 4 — GitHub Releases Should Remain The Single Release-Information Surface
+
+### Evidence For Release Source Of Truth
+
+Both `README.md` and `docs/command-reference.md` already point readers to GitHub Releases for version and change information.
+
+### Decision For Release Source Of Truth
+
+- **Chosen**: Preserve GitHub Releases as the canonical release-information source and ensure all affected docs keep referring to the same location.
+- **Rationale**: A single release-information surface avoids contradictions between repository docs and published release records.
+- **Alternatives considered**:
+  - _Repeat version or change summaries across multiple docs_: Rejected because it creates stale documentation risk.
+  - _Use npm registry pages as the primary change log surface_: Rejected because the repository already treats GitHub Releases as canonical.
+
+---
+
+## Finding 5 — A Mermaid Diagram Is Not Warranted For This Feature
+
+### Evidence For Diagram Need
+
+The feature changes wording and navigation across existing documentation pages. It does not introduce a new lifecycle, interaction graph, or system structure that becomes materially clearer when visualized.
+
+### Decision For Diagram Need
+
+- **Chosen**: Do not add a Mermaid diagram.
+- **Rationale**: The constitution requires diagrams only when they materially improve comprehension. For this feature, a diagram would add maintenance cost without explaining anything that short prose and cross-links cannot already explain more directly.
+- **Alternatives considered**:
+  - _Add a document-routing flowchart_: Rejected because the routing is simple and already expressed clearly through page purpose notes and “start here” links.

--- a/specs/20260405-213451-released-cli-docs/spec.md
+++ b/specs/20260405-213451-released-cli-docs/spec.md
@@ -1,0 +1,94 @@
+# Feature Specification: Released CLI Documentation Refresh
+
+**Feature Branch**: `20260405-213451-released-cli-docs`  
+**Created**: 2026-04-05  
+**Status**: Draft  
+**Input**: User description: "Update documentations with released CLI paht"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Released users find the published command path quickly (Priority: P1)
+
+Readers evaluating the released CLI need the entry documentation to show the published command path, the prerequisites for using it, and where to confirm which release they are reading about.
+
+**Why this priority**: This is the primary reader need. If the entry documentation does not show the released command path clearly, users either assume the product is source-only or must infer the right invocation from scattered docs.
+
+**Independent Test**: Open the entry documentation as a first-time released user and confirm it shows the published command path, a first verification step, and the canonical release-information source without needing any other doc first.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader opens the entry documentation to use a released version, **When** they scan the released CLI section, **Then** they can identify the published command path and the first verification command without reading source-only instructions.
+2. **Given** a reader wants to know which released version they should trust, **When** they follow the release guidance in the docs, **Then** they are directed to the canonical release record for version and change information.
+
+---
+
+### User Story 2 - Supporting docs keep released and source workflows distinct (Priority: P2)
+
+Contributors and operators need the supporting documentation surfaces to separate the released CLI workflow from the contributor-from-source workflow so users do not mix published usage with local development or troubleshooting commands.
+
+**Why this priority**: Once the released path is documented, ambiguity between released and source workflows becomes the main source of reader error.
+
+**Independent Test**: Review the supporting documentation pages that route readers into setup and troubleshooting and confirm each page makes the released-versus-source split explicit.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor reads the setup or troubleshooting docs, **When** they compare the released workflow and the contributor-from-source workflow, **Then** the docs describe which one applies in each context.
+2. **Given** a reader starts in the wrong guide for their goal, **When** they encounter the scope note for that page, **Then** they are redirected to the appropriate documentation surface.
+
+---
+
+### User Story 3 - Reviewers can validate the change as documentation-only (Priority: P3)
+
+Maintainers need to review the documentation refresh quickly and confirm that it changes repository-hosted documentation only, not product behavior.
+
+**Why this priority**: The documentation-only exception depends on the scope being explicit and reviewable.
+
+**Independent Test**: Review the changed files listed in the spec and verify they are documentation or planning artifacts only, with manual walkthrough validation steps recorded.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reviewer checks the planned scope, **When** they compare it against the spec, **Then** they can confirm that runtime source, packaging, CI, and generated workflow behavior remain unchanged.
+
+### Edge Cases
+
+- The docs must explain what readers should rely on when a released version exists but they still land in contributor-from-source documentation first.
+- The docs must not imply that an unpublished or unreleased version is available through the released CLI path.
+- The docs must stay consistent even if only one of the affected documentation pages is updated in a partial draft, so reviewers can spot remaining mismatches.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The entry documentation MUST describe the released CLI path in plain language, including what readers need before using it and how to verify they are invoking the published CLI successfully.
+- **FR-002**: The documentation set MUST distinguish the released CLI workflow from the contributor-from-source workflow wherever readers choose between those two paths.
+- **FR-003**: The command lookup documentation MUST describe the released command path as the supported path for published versions and must not require readers to infer it from source-based examples.
+- **FR-004**: The updated documentation MUST direct readers to the canonical release-information surface for release version and change details.
+- **FR-005**: The documentation MUST make the support-state boundary explicit when the released CLI path depends on a completed release being available.
+- **FR-006**: The feature MUST remain documentation-only, limited to repository-hosted documentation and feature-planning artifacts, with no changes to runtime source files, exported symbols, configuration schemas, packaging behavior, CI automation, or generated workflow scripts.
+- **FR-007**: The spec, plan, or quickstart artifacts MUST record manual walkthrough steps that reviewers can use to confirm the released CLI path and source workflow are documented consistently.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A first-time reader can identify the correct starting point for the released CLI workflow within 60 seconds of opening the entry documentation.
+- **SC-002**: A reviewer can verify, in under 5 minutes, that the affected documentation surfaces describe the released CLI path and contributor-from-source path without contradiction.
+- **SC-003**: All affected documentation surfaces use the same canonical release-information source for version and change lookup.
+- **SC-004**: The change can be reviewed and merged as documentation-only without requiring runtime, packaging, or workflow modifications.
+
+## Assumptions
+
+- A released CLI path already exists from earlier release-surface work and only needs clearer documentation coverage.
+- The scope of this feature is limited to repository-hosted documentation and feature-planning artifacts.
+- No new command behavior, release process, or support-state policy is being introduced beyond clarifying existing guidance.
+- Reviewers will validate this feature through documented manual walkthrough steps rather than new automated tests because the change qualifies for the documentation-only exception.
+
+## Documentation Impact
+
+- Expected documentation surfaces include `README.md`, `docs/command-reference.md`, `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` to keep released and source workflows aligned.
+- This feature qualifies for the documentation-only testing exception because the intended scope is limited to repository-hosted docs and feature-planning artifacts. Runtime source, exported symbols, configuration schemas, packaging logic, CI automation, and generated workflow behavior remain out of scope.
+- A Mermaid diagram is not required because the change clarifies routing and wording across existing docs rather than introducing a new workflow structure that prose cannot explain clearly.
+- Manual walkthrough validation for reviewers:
+  1. Open the entry documentation and confirm it shows the released CLI path, prerequisites, and first verification step.
+  2. Open the command lookup documentation and confirm it describes the released command path without forcing source-based commands as the default.
+  3. Open `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` and confirm they distinguish released usage from contributor-from-source workflow and preserve the canonical release-information source.

--- a/specs/20260405-213451-released-cli-docs/tasks.md
+++ b/specs/20260405-213451-released-cli-docs/tasks.md
@@ -1,0 +1,161 @@
+# Tasks: Released CLI Documentation Refresh
+
+**Input**: Design documents from `/specs/20260405-213451-released-cli-docs/`
+**Prerequisites**: plan.md required, spec.md required, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: This feature qualifies for the constitution's documentation-only exception. No automated test tasks are added because the scope is limited to repository-hosted documentation and feature-planning artifacts. Validation still requires `bun run check` and the manual walkthrough recorded in `specs/20260405-213451-released-cli-docs/quickstart.md`.
+
+**Organization**: Tasks are grouped by user story so each documentation outcome can be implemented and reviewed independently.
+
+## Phase 1: Setup
+
+**Purpose**: Review the feature contract and audit the current documentation surfaces before editing repository docs
+
+- [X] T001 Review released CLI requirements and acceptance scenarios in `specs/20260405-213451-released-cli-docs/spec.md`, `specs/20260405-213451-released-cli-docs/plan.md`, and `specs/20260405-213451-released-cli-docs/contracts/released-cli-documentation-surface.md`
+- [X] T002 Audit `README.md`, `docs/command-reference.md`, `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` against the released CLI contract to identify wording gaps for installation, usage, when-to-use routing, and canonical release references
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Confirm the shared validation rules that all documentation edits must satisfy
+
+**⚠️ CRITICAL**: No user story work should be treated as complete until this phase is in place
+
+- [X] T003 Review the documentation-only validation expectations in `specs/20260405-213451-released-cli-docs/quickstart.md` and the constitution exception recorded in `specs/20260405-213451-released-cli-docs/spec.md`
+- [X] T004 Confirm that GitHub Releases remains the canonical release-information source across the affected documentation surfaces before editing begins
+
+**Checkpoint**: Audit findings and shared validation rules are established
+
+---
+
+## Phase 3: User Story 1 - Released users find the published command path quickly (Priority: P1) 🎯 MVP
+
+**Goal**: Make the released CLI path clear for installation, first verification, and first use
+
+**Independent Test**: Open `README.md` and `docs/command-reference.md` as a first-time released user and confirm they show the published invocation path, the first verification command, and the canonical release-information source without requiring source-only docs first
+
+### Implementation for User Story 1
+
+- [X] T005 [P] [US1] Update `README.md` with released CLI prerequisites, installation or invocation guidance, and the first verification command
+- [X] T006 [P] [US1] Update `docs/command-reference.md` with the published `bunx --package @chrisleekr/agentsync agentsync ...` invocation rule and released support-state wording
+- [X] T007 [US1] Align `README.md` and `docs/command-reference.md` around when to use the released CLI path and where to find GitHub Releases
+
+**Checkpoint**: Released users can identify how to invoke the published CLI and where to confirm release details
+
+---
+
+## Phase 4: User Story 2 - Supporting docs keep released and source workflows distinct (Priority: P2)
+
+**Goal**: Make the released-versus-source workflow boundary explicit in contributor-facing and troubleshooting docs
+
+**Independent Test**: Open `docs/development.md` and `docs/troubleshooting.md` directly and confirm each page labels its workflow scope clearly and redirects released users before they follow source-only commands
+
+### Implementation for User Story 2
+
+- [X] T008 [P] [US2] Update `docs/development.md` with an explicit contributor-from-source scope note and redirect released users to `README.md` and `docs/command-reference.md`
+- [X] T009 [P] [US2] Update `docs/troubleshooting.md` so source-only command examples are scoped correctly and released users are redirected before following them
+- [X] T010 [US2] Align `docs/development.md` and `docs/troubleshooting.md` so the released-versus-source boundary and redirect wording are consistent
+
+**Checkpoint**: Deep-linked contributors and operators can tell whether they should use released or source-based commands
+
+---
+
+## Phase 5: User Story 3 - Reviewers can validate the change as documentation-only (Priority: P3)
+
+**Goal**: Make documentation-only review criteria explicit so maintainers can confirm scope and consistency quickly
+
+**Independent Test**: Open `docs/maintenance.md` and `specs/20260405-213451-released-cli-docs/quickstart.md` and confirm they define the same reviewer checks for documentation-only scope, affected docs, and canonical release-information validation
+
+### Implementation for User Story 3
+
+- [X] T011 [P] [US3] Update `docs/maintenance.md` release workflow ownership rules to list `README.md`, `docs/command-reference.md`, `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md` as the released-path docs that must stay aligned
+- [X] T012 [P] [US3] Update `specs/20260405-213451-released-cli-docs/quickstart.md` with the final reviewer-facing manual walkthrough order for the affected documentation surfaces
+- [X] T013 [US3] Align `docs/maintenance.md` and `specs/20260405-213451-released-cli-docs/quickstart.md` so documentation-only review criteria and canonical release checks match
+
+**Checkpoint**: Reviewers can verify the scope and consistency of the documentation-only change without inspecting runtime code
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification across all documentation surfaces
+
+- [X] T014 [P] Run `bun run check` before final review
+- [X] T015 Execute the manual walkthrough in `specs/20260405-213451-released-cli-docs/quickstart.md` against `README.md`, `docs/command-reference.md`, `docs/development.md`, `docs/maintenance.md`, and `docs/troubleshooting.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies and can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks story completion until shared rules and walkthrough expectations are set
+- **User Story 1 (Phase 3)**: Depends on Foundational completion and delivers the MVP released-user path
+- **User Story 2 (Phase 4)**: Depends on Foundational completion and can proceed independently of User Story 1 once shared rules are set
+- **User Story 3 (Phase 5)**: Depends on Foundational completion; its final alignment task should run after the reviewer-facing edits for the other stories have settled
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependency on other user stories after Foundational
+- **User Story 2 (P2)**: No dependency on User Story 1 after Foundational, but both stories must preserve matching terminology
+- **User Story 3 (P3)**: No dependency on runtime behavior changes because the feature is documentation-only, but its final review-alignment task depends on the documentation surfaces being up to date
+
+### Within Each User Story
+
+- Update the primary target files first
+- Reconcile cross-links and wording after the primary edits land
+- Confirm the story's independent test before moving on
+
+### Parallel Opportunities
+
+- `T005` and `T006` can run in parallel because they target different files
+- `T008` and `T009` can run in parallel because they target different files
+- `T011` and `T012` can run in parallel because they target different files
+- `T014` can run in parallel with final manual review preparation once all documentation edits are complete
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch the released-user documentation updates together:
+Task: "Update README.md with released CLI prerequisites, installation or invocation guidance, and the first verification command"
+Task: "Update docs/command-reference.md with the published bunx invocation rule and released support-state wording"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Confirm released users can identify install, invocation, and release lookup from `README.md` and `docs/command-reference.md`
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational to lock the documentation rules and walkthrough path
+2. Deliver User Story 1 and validate the released-user path
+3. Deliver User Story 2 and validate released-versus-source routing for contributors and operators
+4. Deliver User Story 3 and validate reviewer-facing documentation-only checks
+5. Finish with `bun run check` and the manual walkthrough
+
+### Parallel Team Strategy
+
+With multiple contributors:
+
+1. One contributor updates `README.md` while another updates `docs/command-reference.md`
+2. After User Story 1, split `docs/development.md` and `docs/troubleshooting.md` between contributors
+3. Finish by reconciling `docs/maintenance.md` and `specs/20260405-213451-released-cli-docs/quickstart.md` for reviewer validation
+
+---
+
+## Notes
+
+- `[P]` tasks target different files and do not depend on unfinished work in the same phase
+- No automated test tasks are included because the feature qualifies for the documentation-only exception recorded in the spec and plan


### PR DESCRIPTION
## Summary

This PR refreshes the released CLI documentation so readers can quickly find the published `bunx` invocation path, understand when to use it, and avoid falling into contributor-from-source commands by mistake. It also makes the documentation-only review contract explicit for maintainers.

See spec.md for full specification.

## Changes

- Entry and released usage guidance
  - README.md: clarifies when the published CLI path applies, adds the canonical `bunx --package @chrisleekr/agentsync agentsync <command> [options]` pattern, includes common published-command examples, and redirects source users to contributor docs.
  - command-reference.md: makes released usage explicit, adds the published invocation rule, and rewrites command examples to use the full published command path instead of bare `agentsync ...`.

- Source-versus-released workflow boundaries
  - development.md: scopes the page to contributor-from-source workflows and redirects released users back to the released-path docs.
  - troubleshooting.md: labels the page as source-oriented and tells released users how to translate source commands to the published `bunx` form.

- Reviewer and maintenance surfaces
  - maintenance.md: defines the five released-path docs that must stay aligned whenever the released CLI boundary changes and extends the review checklist accordingly.
  - copilot-instructions.md: records the new documentation-only feature in the generated repo guidance metadata.

- Feature artifacts
  - spec.md: defines the released CLI documentation refresh scope, acceptance scenarios, and documentation-only constraints.
  - plan.md: documents the implementation phases, validation approach, and affected surfaces.
  - tasks.md: tracks setup, implementation, and validation tasks; all tasks are marked complete.
  - research.md: captures the rationale for README ownership, published command examples, routing boundaries, and GitHub Releases as the canonical release source.
  - data-model.md: models the documentation surfaces, reader intents, execution paths, and manual validation steps.
  - quickstart.md: records the final manual walkthrough for reviewers.
  - released-cli-documentation-surface.md: defines the observable documentation contract for the released CLI path.
  - requirements.md: records the spec quality checklist outcome.

### Architecture

No architectural changes — see file diff for details.

## Test Evidence

```text
$ bun run check
$ bunx tsc --noEmit
$ bunx biome ci .
Checked 68 files in 30ms. No fixes applied.
$ bun test
197 pass
0 fail
346 expect() calls
Ran 197 tests across 24 files. [4.49s]
```

- Task completion: 15 / 15 tasks complete in tasks.md
- Manual validation completed per quickstart.md
- This feature uses the documentation-only exception; no new automated test cases were added because runtime, packaging, CI, and generated workflows were intentionally left unchanged

## Risks / Follow-ups

- The branch currently has working-tree changes only; `origin/main...HEAD` is empty, so this PR description is based on the current unstaged diff rather than committed branch history.
- README.md still contains pre-existing markdownlint warnings from the inline HTML hero block; they are unrelated to this feature and do not fail `bun run check`.

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for using the published CLI release via `bunx --package @chrisleekr/agentsync agentsync`
  * Updated all command examples to reflect the published invocation pattern
  * Added clear separation between released-user and contributor-from-source documentation paths
  * Established GitHub Releases as the canonical source for release information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->