### PR TITLE
feat(daemon): stabilise daemon process — SyncQueue, retry, failure tracking, shutdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# agent-sync Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-04-06
+
+## Active Technologies
+
+- TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x (20260406-094347-stabilise-daemon)
+
+## Project Structure
+
+```text
+src/
+tests/
+```
+
+## Commands
+
+npm test && npm run lint
+
+## Code Style
+
+TypeScript 6.x, strict mode (`"strict": true`): Follow standard conventions
+
+## Recent Changes
+
+- 20260406-094347-stabilise-daemon: Added TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ tests/
 
 ## Commands
 
-npm test && npm run lint
+bun run check
 
 ## Code Style
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -1,0 +1,45 @@
+# Daemon Lifecycle
+
+The AgentSync background daemon manages file watchers, periodic pulls, and IPC communication. Below is the state diagram showing all lifecycle transitions.
+
+```mermaid
+stateDiagram-v2
+    classDef active fill:#0D6EFD,color:#FFFFFF
+    classDef error fill:#DC3545,color:#FFFFFF
+    classDef idle fill:#198754,color:#FFFFFF
+    classDef stopped fill:#6C757D,color:#FFFFFF
+
+    [*] --> Validating:::active
+    Validating --> SecondInstanceCheck:::active : vault + key OK
+    Validating --> Stopped:::stopped : missing vault or key<br/>exit 1
+
+    SecondInstanceCheck --> BindingSocket:::active : no existing daemon
+    SecondInstanceCheck --> Stopped:::stopped : daemon already running<br/>exit 1
+    SecondInstanceCheck --> CleaningStaleSocket:::active : ECONNREFUSED<br/>stale socket
+
+    CleaningStaleSocket --> BindingSocket:::active : socket unlinked
+
+    BindingSocket --> Running:::idle : ipc.listen OK
+
+    Running --> Syncing:::active : push or pull triggered
+    Syncing --> Running:::idle : sync succeeded<br/>recordSuccess
+    Syncing --> RetryOnce:::error : first attempt failed
+
+    RetryOnce --> Running:::idle : retry succeeded<br/>recordSuccess
+    RetryOnce --> Running:::idle : retry failed<br/>recordFailure<br/>daemon stays alive
+
+    Running --> ShuttingDown:::active : SIGTERM or SIGINT
+
+    ShuttingDown --> Stopped:::stopped : clearInterval<br/>ipc.close<br/>queue.whenIdle<br/>watcher.close<br/>unlink socket<br/>exit 0
+```
+
+## Lifecycle Phases
+
+| Phase | Description |
+|-------|-------------|
+| **Validating** | Checks vault directory, config file, and encryption key are accessible. Exits immediately on failure (FR-006, FR-007, SC-006). |
+| **SecondInstanceCheck** | Sends IPC `status` ping to detect a running daemon. Exits if one responds (FR-009). Unlinks stale socket if ECONNREFUSED (FR-003). |
+| **Running** | IPC server is listening. File watchers and periodic pull timer are active. Status queries return `{pid, consecutiveFailures, lastError}`. |
+| **Syncing** | A push or pull operation is executing inside the `SyncQueue`. All sync operations are serialized — only one runs at a time (FR-015). |
+| **RetryOnce** | Automatic single retry after a transient failure (FR-014). If both attempts fail, the error is recorded but the daemon stays alive (SC-004). |
+| **ShuttingDown** | Drains the sync queue (10s hard timeout per FR-013), closes IPC, stops watchers, unlinks the socket file, then exits cleanly. |

--- a/specs/20260406-094347-stabilise-daemon/checklists/requirements.md
+++ b/specs/20260406-094347-stabilise-daemon/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Stabilise Daemon Process
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed. 5 clarification questions asked and integrated on 2026-04-06.
+- Sections updated: Edge Cases, Functional Requirements (FR-011–FR-015), Key Entities, Success Criteria (SC-007), User Story 3 acceptance scenarios, Assumptions.
+- Spec is ready for `/speckit.plan`.

--- a/specs/20260406-094347-stabilise-daemon/contracts/ipc-status.md
+++ b/specs/20260406-094347-stabilise-daemon/contracts/ipc-status.md
@@ -1,0 +1,69 @@
+# IPC Contract: `status` Command
+
+**Branch**: `20260406-094347-stabilise-daemon` | **Date**: 2026-04-06
+
+The `status` IPC command is the primary health-check interface between the CLI and the running daemon. This document defines the request/response contract after the daemon stabilisation changes.
+
+---
+
+## Request
+
+```jsonc
+// IpcRequest envelope (unchanged)
+{
+  "id": "<uuid-v4>",
+  "cmd": "status",
+  "args": {}   // no arguments required
+}
+```
+
+## Response (success — daemon running)
+
+```jsonc
+// IpcResponse envelope
+{
+  "id": "<uuid-v4>",      // echoes request id
+  "ok": true,
+  "data": {
+    "pid": 12345,                    // number — daemon process ID
+    "consecutiveFailures": 3,        // number (≥0) — failures since last success
+    "lastError": "remote: not found" // string | null — null if no recent failure
+  }
+}
+```
+
+**Zod schema** (source of truth in `src/config/schema.ts`):
+
+```typescript
+export const DaemonStatusSchema = z.object({
+  pid: z.number().int().positive(),
+  consecutiveFailures: z.number().int().min(0),
+  lastError: z.string().nullable(),
+});
+```
+
+## Response (error — command failed internally)
+
+```jsonc
+{
+  "id": "<uuid-v4>",
+  "ok": false,
+  "error": "descriptive error message"
+}
+```
+
+## Response (connection refused — daemon not running)
+
+The IpcClient `send()` call throws (socket `ECONNREFUSED`). The CLI catches this and displays "Daemon is not running."
+
+---
+
+## Backward Compatibility
+
+The `pid` field existed in the previous implementation (`{ ok: true, pid: number }`). The `consecutiveFailures` and `lastError` fields are **additive**. Existing callers that only read `pid` remain valid. New fields are validated via `DaemonStatusSchema` before use.
+
+---
+
+## `push` and `pull` Command Responses (unchanged contract)
+
+These commands return the existing `{ applied: number; errors: string[]; fatal: boolean }` shape. No change to this contract in this feature.

--- a/specs/20260406-094347-stabilise-daemon/data-model.md
+++ b/specs/20260406-094347-stabilise-daemon/data-model.md
@@ -1,0 +1,120 @@
+# Data Model: Stabilise Daemon Process
+
+**Branch**: `20260406-094347-stabilise-daemon` | **Date**: 2026-04-06
+
+---
+
+## Entities
+
+### DaemonState (in-memory, `daemon/index.ts`)
+
+Holds the daemon's runtime mutable state. Not persisted across restarts.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `consecutiveFailures` | `number` | Count of sync operations that have failed consecutively since the last success. Reset to `0` on any successful push or pull. |
+| `lastError` | `string \| null` | Human-readable message from the most recent sync failure. `null` if no failure has occurred since startup or since the last successful sync. |
+
+**Invariants**:
+- `consecutiveFailures >= 0`
+- If `consecutiveFailures === 0` then `lastError` is `null` (reset together)
+
+---
+
+### DaemonStatusResponse (IPC message, crosses trust boundary)
+
+Returned by the `status` IPC command handler. Validated with Zod schema `DaemonStatusSchema` in `src/config/schema.ts`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ok` | `true` | Always `true` for a successful status response (outer IPC envelope uses `ok: boolean`) |
+| `pid` | `number` | Process ID of the running daemon |
+| `consecutiveFailures` | `number` | From `DaemonState` |
+| `lastError` | `string \| null` | From `DaemonState` |
+
+**Zod schema** (to be added to `src/config/schema.ts`):
+```typescript
+export const DaemonStatusSchema = z.object({
+  pid: z.number().int().positive(),
+  consecutiveFailures: z.number().int().min(0),
+  lastError: z.string().nullable(),
+});
+export type DaemonStatus = z.infer<typeof DaemonStatusSchema>;
+```
+
+---
+
+### SyncOperation (in-flight, `core/sync-queue.ts`)
+
+Represents a single async operation enqueued in the `SyncQueue`. Not stored — exists only as a queued promise.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fn` | `() => Promise<T>` | The sync work to execute (push or pull) |
+| `result` | `Promise<T>` | Resolves when the operation completes; rejects on failure |
+
+**Lifecycle**: Enqueued → waiting → executing → settled (resolved or rejected).
+
+---
+
+### ExecutableArgs (installer input, `commands/daemon.ts`)
+
+Replaces the previous `string` return type of `getExecutablePath()`. Returned by `getExecutableArgs()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `args` | `string[]` | Ordered list: `args[0]` is the binary path; `args[1]` (if present) is the script path. Always length ≥ 1. |
+
+**Invariants**:
+- `args[0]` is an absolute path to a stable, persistent executable
+- If `args.length === 2`, `args[1]` is the script entrypoint passed to the interpreter
+- Neither element contains a path inside a temporary or session-scoped directory
+
+---
+
+## State Transitions
+
+### Daemon Lifecycle
+
+```
+[Startup]
+    │
+    ▼
+[Initialising] ──── config/vault missing ──→ [Exit non-zero: FR-006/FR-007]
+    │
+    ▼
+[Binding IPC socket] ─── stale socket ──→ [Remove stale socket → retry bind]
+    │
+    ▼
+[Running]
+    │
+    ├── file-change event ──→ [Syncing: push] ──→ success → reset failure record → [Running]
+    │                                          └→ failure → retry once → success → reset → [Running]
+    │                                                                  └→ failure → log + increment → [Running]
+    │
+    ├── pull interval tick ─→ [Syncing: pull] ──→ (same as push above)
+    │
+    ├── IPC: push ──────────→ [Syncing: push] ──→ (same as push above)
+    │
+    ├── IPC: pull ──────────→ [Syncing: pull] ──→ (same as pull above)
+    │
+    ├── IPC: status ─────────→ return { pid, consecutiveFailures, lastError } → [Running]
+    │
+    └── SIGTERM / SIGINT ───→ [Shutting Down]
+                                    │
+                                    ├── stop pull interval
+                                    ├── close IPC server
+                                    ├── drain sync queue (≤10s)
+                                    ├── close file watchers
+                                    ├── unlink IPC socket file
+                                    └── process.exit(0)
+```
+
+### SyncOperation Lifecycle
+
+```
+enqueue(fn) → [Waiting] → [Executing] → [Success: reset failure record]
+                                      → [Failure: retry once immediately]
+                                                    → [Success: reset failure record]
+                                                    → [Final failure: log + increment consecutiveFailures]
+```

--- a/specs/20260406-094347-stabilise-daemon/plan.md
+++ b/specs/20260406-094347-stabilise-daemon/plan.md
@@ -1,0 +1,378 @@
+# Implementation Plan: Stabilise Daemon Process
+
+**Branch**: `20260406-094347-stabilise-daemon` | **Date**: 2026-04-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/20260406-094347-stabilise-daemon/spec.md`
+
+---
+
+## Summary
+
+Fix three confirmed installer bugs (malformed `ProgramArguments` on macOS/Windows, ephemeral bunx path allowed through, non-idempotent re-install) and harden the daemon runtime (sync operation queue with serialisation and retry-once, failure tracking surfaced via IPC, clean shutdown that drains in-flight operations and removes the socket file). Add a `DaemonStatusSchema` Zod schema, a `SyncQueue` utility, updated platform installer contracts, a daemon lifecycle Mermaid diagram, and full test coverage for all new behaviours.
+
+---
+
+## Technical Context
+
+**Language/Version**: TypeScript 6.x, strict mode (`"strict": true`)
+**Runtime**: Bun 1.3.9 (Node.js compat layer for `node:fs`, `node:net`, `node:child_process`)
+**Primary Dependencies**: citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x
+**Storage**: File system only (plist, systemd unit, IPC socket)
+**Testing**: `bun test` (`bun:test`), `__tests__/*.test.ts` co-located with modules
+**Target Platform**: macOS (launchd), Linux (systemd user), Windows (Task Scheduler)
+**Project Type**: CLI tool + background daemon
+**Performance Goals**: Shutdown ≤10s (SC-001), daemon start ≤10s (SC-007), startup error ≤3s (SC-006)
+**Constraints**: No new runtime dependencies; Zod required for all IPC message shapes crossing trust boundaries (Constitution IV)
+
+---
+
+## Constitution Check
+
+*GATE: Must pass before implementation begins.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | PASS | No credential handling changes; age key paths not touched |
+| II. Test Coverage | REQUIRED — see below | All modified modules need updated/new tests |
+| III. Cross-Platform Daemon Reliability | DIRECTLY ADDRESSED | This feature fixes violations of this principle |
+| IV. Code Quality / Zod | REQUIRED | `DaemonStatusSchema` must be added; IPC status response validated with Zod |
+| V. Documentation / Mermaid | REQUIRED | `docs/daemon.md` with lifecycle state diagram (FR-010) |
+
+**Test coverage obligations (Principle II)**:
+
+- `src/core/sync-queue.ts` — new module, must have `__tests__/sync-queue.test.ts` covering success path + serialisation + drain
+- `src/daemon/index.ts` — existing tests must be updated to cover: queue serialisation, retry-once on failure, failure count increment/reset, socket cleanup on shutdown, drain-before-exit
+- `src/commands/daemon.ts` — `getExecutableArgs()` must be tested: compiled binary path, bun+script path, ephemeral path detection/rejection
+- `src/daemon/installer-macos.ts` — tests must cover: separate `<string>` elements in plist, bootout+bootstrap sequence, clean error surfacing from launchctl
+- `src/daemon/installer-linux.ts` — tests must cover: updated `string[]` signature, registration check in `startLinux`
+- `src/daemon/installer-windows.ts` — tests must cover: `<Command>` = binary only, `<Arguments>` = remaining args + daemon _run
+
+**Documentation gate (Principle V)**:
+
+- `docs/daemon.md` must include a Mermaid state diagram validated in GitHub Markdown preview before merge
+- Diagram validation is a blocker for PR approval (documented in quickstart.md Scenario 8)
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/20260406-094347-stabilise-daemon/
+├── plan.md           ← this file
+├── research.md       ← Phase 0 output
+├── data-model.md     ← Phase 1 output
+├── quickstart.md     ← Phase 1 output (manual validation steps)
+├── contracts/
+│   └── ipc-status.md ← IPC status command contract
+└── tasks.md          ← Phase 2 output (/speckit.tasks — not yet created)
+```
+
+### Source Code Changes
+
+```text
+src/
+├── commands/
+│   └── daemon.ts              MODIFY — getExecutableArgs(): string[], ephemeral check,
+│                                       isRegistered() per-platform, start timeout
+├── config/
+│   └── schema.ts              MODIFY — add DaemonStatusSchema + DaemonStatus type
+├── core/
+│   ├── sync-queue.ts          NEW    — SyncQueue class
+│   └── __tests__/
+│       └── sync-queue.test.ts NEW    — SyncQueue unit tests
+└── daemon/
+    ├── index.ts               MODIFY — queue, retry-once, failure tracking, clean shutdown
+    ├── installer-macos.ts     MODIFY — buildPlist(args: string[]), bootout→bootstrap,
+    │                                   launchctl print for isRegistered, clean errors
+    ├── installer-linux.ts     MODIFY — buildUnit(args: string[]), isRegistered via
+    │                                   systemctl is-enabled, clean errors
+    ├── installer-windows.ts   MODIFY — buildXml(args: string[]), split Command/Arguments
+    └── __tests__/
+        ├── index.test.ts      MODIFY — cover new behaviours
+        ├── installer-macos.test.ts    MODIFY
+        ├── installer-linux.test.ts    MODIFY
+        └── installer-windows.test.ts  MODIFY
+
+docs/
+└── daemon.md                  NEW    — daemon lifecycle Mermaid state diagram
+```
+
+---
+
+## Phase 0: Research Output
+
+Research complete. See [research.md](./research.md). All NEEDS CLARIFICATION resolved:
+
+| Topic | Decision | Reference |
+|-------|----------|-----------|
+| macOS ProgramArguments format | Each element = separate `<string>` | R-001, `launchd.plist(5)` |
+| Windows Command/Arguments split | `<Command>` = binary only | R-002, Task Scheduler XML schema |
+| Linux ExecStart | No change needed — systemd tokenises correctly | R-003, `systemd.service(5)` |
+| macOS idempotent re-install | `bootout` (ignore error) → write plist → `bootstrap` | R-004 |
+| Ephemeral path detection | `os.tmpdir()` comparison + `bunx-` guard | R-005 |
+| macOS bootstrap state check | `launchctl print gui/<uid>/<label>` | R-006 |
+| Linux registration check | `systemctl --user is-enabled agentsync` | R-007 |
+| Sync serialisation | `SyncQueue` promise-chain, no new dep | R-008 |
+| Retry-once wrapper | Local `withRetry(fn)` helper | R-009 |
+| Failure record | In-memory `{ consecutiveFailures, lastError }` | R-010 |
+| Shutdown drain | `queue.whenIdle()` + `ipc.close()` + `unlink(socket)` | R-011 |
+
+---
+
+## Phase 1: Design Details
+
+### 1.1 — `getExecutableArgs()` in `src/commands/daemon.ts`
+
+**Rename** `getExecutablePath(): string` → `getExecutableArgs(): string[]`.
+
+**Logic**:
+
+```typescript
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+function isEphemeralPath(filePath: string): boolean {
+  try {
+    const resolved = realpathSync(filePath);
+    const tmp = realpathSync(tmpdir());
+    return resolved.startsWith(tmp) || resolved.includes("bunx-");
+  } catch {
+    return false;
+  }
+}
+
+function getExecutableArgs(): string[] {
+  const isBun =
+    process.argv[0].endsWith("bun") || process.argv[0].endsWith("bun.exe");
+  if (isBun) {
+    if (isEphemeralPath(process.argv[1])) {
+      throw new Error(
+        "Executable is in a temporary directory. " +
+          "Install the package globally first: bun install -g @chrisleekr/agentsync"
+      );
+    }
+    return [process.argv[0], process.argv[1]];
+  }
+  return [process.execPath];
+}
+```
+
+**Callers** (`install` subcommand):
+
+```typescript
+const args = getExecutableArgs(); // string[]
+await installer.install(args);    // signature changes from (exe: string) to (args: string[])
+```
+
+---
+
+### 1.2 — `PlatformInstaller` interface update
+
+Two changes to the `PlatformInstaller` interface in `daemon.ts`:
+
+1. `install(exe: string)` → `install(args: string[])` — receives the full executable args array instead of a single concatenated string.
+2. Add `isRegistered(): Promise<boolean>` — each platform module implements this to check whether the service is currently registered with the OS service manager (`launchctl print`, `systemctl is-enabled`, `schtasks /Query`). The `daemon start` subcommand calls this before attempting to start; the `daemon install` subcommand does not (it always registers). Stub implementations returning `Promise.resolve(false)` are added first (Phase 2) so TypeScript compiles; real implementations follow in Phase 6 (T035, T039, T041).
+
+---
+
+### 1.3 — `src/daemon/installer-macos.ts`
+
+**`buildPlist(args: string[], logDir: string): string`**
+
+Replace the single `<string>${executablePath}</string>` with a loop:
+
+```typescript
+function buildPlist(args: string[], logDir: string): string {
+  const programArgs = [...args, "daemon", "_run"]
+    .map((a) => `    <string>${a}</string>`)
+    .join("\n");
+  // ... plist template with ${programArgs} in the <array> block
+}
+```
+
+**`installMacOs(args: string[]): Promise<void>`**
+
+```typescript
+export async function installMacOs(args: string[]): Promise<void> {
+  // 1. bootout existing service (ignore ENOENT / not-loaded errors)
+  try {
+    await execFileAsync("launchctl", ["bootout", `gui/${process.getuid?.() ?? 501}`, PLIST_PATH]);
+  } catch { /* not loaded — expected */ }
+
+  // 2. write plist
+  const plist = buildPlist(args, logDir);
+  await writeFile(PLIST_PATH, plist, "utf8");
+
+  // 3. bootstrap — surface clean error on failure
+  try {
+    await execFileAsync("launchctl", ["bootstrap", `gui/${process.getuid?.() ?? 501}`, PLIST_PATH]);
+  } catch (err) {
+    const msg = extractServiceManagerError(err);
+    throw new Error(`launchd bootstrap failed: ${msg}\nHint: Check that the executable path exists and is not in a temporary directory.`);
+  }
+  log.success(`Installed launchd service: ${PLIST_LABEL}`);
+}
+```
+
+**`extractServiceManagerError(err: unknown): string`** — a local helper that reads `(err as { stderr?: string }).stderr ?? String(err)` and strips internal stack frames. Returns only the service manager's stderr line.
+
+**`isRegisteredMacOs(): Promise<boolean>`** — runs `launchctl print gui/<uid>/com.agentsync.daemon` and returns `true` on exit code 0.
+
+**`startMacOs()`** — call `isRegisteredMacOs()` first; throw with actionable message if false. Wrap `kickstart` in `Promise.race` with a 10-second timeout.
+
+---
+
+### 1.4 — `src/daemon/installer-linux.ts`
+
+**`buildUnit(args: string[]): string`**
+
+```typescript
+// ExecStart uses space-separated tokens; systemd tokenises correctly
+const execStart = [...args, "daemon", "_run"].join(" ");
+return `[Unit]\nDescription=...\n[Service]\nType=simple\nExecStart=${execStart}\n...`;
+```
+
+**`isRegisteredLinux(): Promise<boolean>`** — runs `systemctl --user is-enabled agentsync`. Returns `true` if stdout is `enabled`; `false` if `not-found` or `disabled`.
+
+**`startLinux()`** — check `isRegisteredLinux()` first; throw with actionable message if false. Wrap `systemctl --user start` in a 10-second timeout.
+
+---
+
+### 1.5 — `src/daemon/installer-windows.ts`
+
+**`buildXml(args: string[]): string`**
+
+```typescript
+const command = escapeXml(args[0]);
+const scriptAndSubcmd = [...args.slice(1), "daemon", "_run"]
+  .map(escapeXml)
+  .join(" ");
+// <Command>${command}</Command>
+// <Arguments>${scriptAndSubcmd}</Arguments>
+```
+
+**`isInstalledWindows()`** — already queries `schtasks /Query`; this doubles as a registration check. **`startWindows()`** — check `isInstalledWindows()` first; wrap `schtasks /Run` in a 10-second timeout.
+
+---
+
+### 1.6 — `src/core/sync-queue.ts` (new file)
+
+```typescript
+/** Serialises async operations so only one runs at a time. */
+export class SyncQueue {
+  private tail: Promise<void> = Promise.resolve();
+
+  /** Enqueue fn; it will run only after any currently running operation settles. */
+  enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(fn);
+    this.tail = result.then(
+      () => {},
+      () => {},
+    );
+    return result;
+  }
+
+  /** Resolves when no operations are in progress or queued. */
+  whenIdle(): Promise<void> {
+    return this.tail;
+  }
+}
+```
+
+---
+
+### 1.7 — `src/config/schema.ts` — add `DaemonStatusSchema`
+
+```typescript
+export const DaemonStatusSchema = z.object({
+  pid: z.number().int().positive(),
+  consecutiveFailures: z.number().int().min(0),
+  lastError: z.string().nullable(),
+});
+export type DaemonStatus = z.infer<typeof DaemonStatusSchema>;
+```
+
+---
+
+### 1.8 — `src/daemon/index.ts` — runtime hardening
+
+**Key changes**:
+
+```typescript
+import { unlink } from "node:fs/promises";
+import { SyncQueue } from "../core/sync-queue";
+import { DaemonStatusSchema } from "../config/schema";
+
+// Failure record
+let consecutiveFailures = 0;
+let lastError: string | null = null;
+
+function recordSuccess(): void {
+  consecutiveFailures = 0;
+  lastError = null;
+}
+
+function recordFailure(err: string): void {
+  consecutiveFailures++;
+  lastError = err;
+}
+
+// Retry-once wrapper
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch {
+    return fn(); // second attempt; throws if it also fails
+  }
+}
+
+// Sync queue
+const queue = new SyncQueue();
+
+// Updated status handler
+ipc.on("status", async () =>
+  DaemonStatusSchema.parse({ pid: process.pid, consecutiveFailures, lastError })
+);
+
+// Wrap every push/pull call with queue + retry + record
+async function runSyncOp(op: () => Promise<SyncResult>): Promise<SyncResult> {
+  return queue.enqueue(async () => {
+    try {
+      const result = await withRetry(op);
+      if (!result.fatal) recordSuccess();
+      else recordFailure(result.errors.join("; "));
+      return result;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      recordFailure(msg);
+      throw err;
+    }
+  });
+}
+
+// Clean shutdown
+const shutdown = async () => {
+  clearInterval(pullTimer);
+  ipc.close();
+  // Drain in-flight ops, max 10s
+  await Promise.race([queue.whenIdle(), new Promise<void>((r) => setTimeout(r, 10_000))]);
+  await watcher.close();
+  try { await unlink(socketPath); } catch { /* already gone */ }
+  process.exit(0);
+};
+```
+
+---
+
+### 1.9 — `docs/daemon.md` (new file)
+
+Must include a GitHub-compatible Mermaid state diagram. High-contrast colour pairs per the global CLAUDE.md rules. See quickstart.md Scenario 8 for validation requirements.
+
+State diagram covers: `Starting` → `Running` → `Syncing` → `Running` (success) / `Error` (retry) → `Running`, and `Running` → `ShuttingDown` → `Stopped`.
+
+---
+
+## Complexity Tracking
+
+No constitution violations requiring justification. All changes are additions or fixes within the existing module structure. No new project, no repository pattern, no abstraction layers beyond `SyncQueue` (which is 12 lines and has zero dependencies).

--- a/specs/20260406-094347-stabilise-daemon/plan.md
+++ b/specs/20260406-094347-stabilise-daemon/plan.md
@@ -1,378 +1,121 @@
-# Implementation Plan: Stabilise Daemon Process
+# Implementation Plan: [FEATURE]
 
-**Branch**: `20260406-094347-stabilise-daemon` | **Date**: 2026-04-06 | **Spec**: [spec.md](./spec.md)
-**Input**: Feature specification from `/specs/20260406-094347-stabilise-daemon/spec.md`
+**Branch**: `[YYYYMMDD-HHMMSS-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[YYYYMMDD-HHMMSS-feature-name]/spec.md`
 
----
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
 
 ## Summary
 
-Fix three confirmed installer bugs (malformed `ProgramArguments` on macOS/Windows, ephemeral bunx path allowed through, non-idempotent re-install) and harden the daemon runtime (sync operation queue with serialisation and retry-once, failure tracking surfaced via IPC, clean shutdown that drains in-flight operations and removes the socket file). Add a `DaemonStatusSchema` Zod schema, a `SyncQueue` utility, updated platform installer contracts, a daemon lifecycle Mermaid diagram, and full test coverage for all new behaviours.
-
----
+[Extract from feature spec: primary requirement + technical approach from research]
 
 ## Technical Context
 
-**Language/Version**: TypeScript 6.x, strict mode (`"strict": true`)
-**Runtime**: Bun 1.3.9 (Node.js compat layer for `node:fs`, `node:net`, `node:child_process`)
-**Primary Dependencies**: citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x
-**Storage**: File system only (plist, systemd unit, IPC socket)
-**Testing**: `bun test` (`bun:test`), `__tests__/*.test.ts` co-located with modules
-**Target Platform**: macOS (launchd), Linux (systemd user), Windows (Task Scheduler)
-**Project Type**: CLI tool + background daemon
-**Performance Goals**: Shutdown ≤10s (SC-001), daemon start ≤10s (SC-007), startup error ≤3s (SC-006)
-**Constraints**: No new runtime dependencies; Zod required for all IPC message shapes crossing trust boundaries (Constitution IV)
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
 
----
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
 
 ## Constitution Check
 
-*GATE: Must pass before implementation begins.*
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-| Principle | Status | Notes |
-|-----------|--------|-------|
-| I. Security-First | PASS | No credential handling changes; age key paths not touched |
-| II. Test Coverage | REQUIRED — see below | All modified modules need updated/new tests |
-| III. Cross-Platform Daemon Reliability | DIRECTLY ADDRESSED | This feature fixes violations of this principle |
-| IV. Code Quality / Zod | REQUIRED | `DaemonStatusSchema` must be added; IPC status response validated with Zod |
-| V. Documentation / Mermaid | REQUIRED | `docs/daemon.md` with lifecycle state diagram (FR-010) |
+[Gates determined based on constitution file]
 
-**Test coverage obligations (Principle II)**:
-
-- `src/core/sync-queue.ts` — new module, must have `__tests__/sync-queue.test.ts` covering success path + serialisation + drain
-- `src/daemon/index.ts` — existing tests must be updated to cover: queue serialisation, retry-once on failure, failure count increment/reset, socket cleanup on shutdown, drain-before-exit
-- `src/commands/daemon.ts` — `getExecutableArgs()` must be tested: compiled binary path, bun+script path, ephemeral path detection/rejection
-- `src/daemon/installer-macos.ts` — tests must cover: separate `<string>` elements in plist, bootout+bootstrap sequence, clean error surfacing from launchctl
-- `src/daemon/installer-linux.ts` — tests must cover: updated `string[]` signature, registration check in `startLinux`
-- `src/daemon/installer-windows.ts` — tests must cover: `<Command>` = binary only, `<Arguments>` = remaining args + daemon _run
-
-**Documentation gate (Principle V)**:
-
-- `docs/daemon.md` must include a Mermaid state diagram validated in GitHub Markdown preview before merge
-- Diagram validation is a blocker for PR approval (documented in quickstart.md Scenario 8)
-
----
+- Test coverage impact: Default to automated test tasks for new feature
+  work. Only treat the feature as documentation-only when all changed
+  files are limited to repository-hosted documentation and
+  feature-planning artifacts and the change does not affect runtime
+  source files, exported symbols, configuration schemas, packaging
+  logic, CI automation, or generated workflow scripts.
+- Documentation impact: If the feature changes or adds explanatory docs,
+  identify whether a Mermaid diagram is required to explain workflow,
+  structure, lifecycle, or interaction behavior more clearly than prose.
+- Documentation-only validation impact: If the feature qualifies for the
+  documentation-only exception, record the manual walkthrough validation
+  steps and name the spec, plan, or quickstart artifact that will carry
+  them.
+- Diagram validation impact: If Mermaid is required, name the target doc
+  surfaces and include validation as part of the implementation and
+  review plan.
 
 ## Project Structure
 
 ### Documentation (this feature)
 
 ```text
-specs/20260406-094347-stabilise-daemon/
-├── plan.md           ← this file
-├── research.md       ← Phase 0 output
-├── data-model.md     ← Phase 1 output
-├── quickstart.md     ← Phase 1 output (manual validation steps)
-├── contracts/
-│   └── ipc-status.md ← IPC status command contract
-└── tasks.md          ← Phase 2 output (/speckit.tasks — not yet created)
+specs/[YYYYMMDD-HHMMSS-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
 ```
 
-### Source Code Changes
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
 
 ```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
 src/
-├── commands/
-│   └── daemon.ts              MODIFY — getExecutableArgs(): string[], ephemeral check,
-│                                       isRegistered() per-platform, start timeout
-├── config/
-│   └── schema.ts              MODIFY — add DaemonStatusSchema + DaemonStatus type
-├── core/
-│   ├── sync-queue.ts          NEW    — SyncQueue class
-│   └── __tests__/
-│       └── sync-queue.test.ts NEW    — SyncQueue unit tests
-└── daemon/
-    ├── index.ts               MODIFY — queue, retry-once, failure tracking, clean shutdown
-    ├── installer-macos.ts     MODIFY — buildPlist(args: string[]), bootout→bootstrap,
-    │                                   launchctl print for isRegistered, clean errors
-    ├── installer-linux.ts     MODIFY — buildUnit(args: string[]), isRegistered via
-    │                                   systemctl is-enabled, clean errors
-    ├── installer-windows.ts   MODIFY — buildXml(args: string[]), split Command/Arguments
-    └── __tests__/
-        ├── index.test.ts      MODIFY — cover new behaviours
-        ├── installer-macos.test.ts    MODIFY
-        ├── installer-linux.test.ts    MODIFY
-        └── installer-windows.test.ts  MODIFY
+├── models/
+├── services/
+├── cli/
+└── lib/
 
-docs/
-└── daemon.md                  NEW    — daemon lifecycle Mermaid state diagram
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
 ```
 
----
-
-## Phase 0: Research Output
-
-Research complete. See [research.md](./research.md). All NEEDS CLARIFICATION resolved:
-
-| Topic | Decision | Reference |
-|-------|----------|-----------|
-| macOS ProgramArguments format | Each element = separate `<string>` | R-001, `launchd.plist(5)` |
-| Windows Command/Arguments split | `<Command>` = binary only | R-002, Task Scheduler XML schema |
-| Linux ExecStart | No change needed — systemd tokenises correctly | R-003, `systemd.service(5)` |
-| macOS idempotent re-install | `bootout` (ignore error) → write plist → `bootstrap` | R-004 |
-| Ephemeral path detection | `os.tmpdir()` comparison + `bunx-` guard | R-005 |
-| macOS bootstrap state check | `launchctl print gui/<uid>/<label>` | R-006 |
-| Linux registration check | `systemctl --user is-enabled agentsync` | R-007 |
-| Sync serialisation | `SyncQueue` promise-chain, no new dep | R-008 |
-| Retry-once wrapper | Local `withRetry(fn)` helper | R-009 |
-| Failure record | In-memory `{ consecutiveFailures, lastError }` | R-010 |
-| Shutdown drain | `queue.whenIdle()` + `ipc.close()` + `unlink(socket)` | R-011 |
-
----
-
-## Phase 1: Design Details
-
-### 1.1 — `getExecutableArgs()` in `src/commands/daemon.ts`
-
-**Rename** `getExecutablePath(): string` → `getExecutableArgs(): string[]`.
-
-**Logic**:
-
-```typescript
-import { realpathSync } from "node:fs";
-import { tmpdir } from "node:os";
-
-function isEphemeralPath(filePath: string): boolean {
-  try {
-    const resolved = realpathSync(filePath);
-    const tmp = realpathSync(tmpdir());
-    return resolved.startsWith(tmp) || resolved.includes("bunx-");
-  } catch {
-    return false;
-  }
-}
-
-function getExecutableArgs(): string[] {
-  const isBun =
-    process.argv[0].endsWith("bun") || process.argv[0].endsWith("bun.exe");
-  if (isBun) {
-    if (isEphemeralPath(process.argv[1])) {
-      throw new Error(
-        "Executable is in a temporary directory. " +
-          "Install the package globally first: bun install -g @chrisleekr/agentsync"
-      );
-    }
-    return [process.argv[0], process.argv[1]];
-  }
-  return [process.execPath];
-}
-```
-
-**Callers** (`install` subcommand):
-
-```typescript
-const args = getExecutableArgs(); // string[]
-await installer.install(args);    // signature changes from (exe: string) to (args: string[])
-```
-
----
-
-### 1.2 — `PlatformInstaller` interface update
-
-Two changes to the `PlatformInstaller` interface in `daemon.ts`:
-
-1. `install(exe: string)` → `install(args: string[])` — receives the full executable args array instead of a single concatenated string.
-2. Add `isRegistered(): Promise<boolean>` — each platform module implements this to check whether the service is currently registered with the OS service manager (`launchctl print`, `systemctl is-enabled`, `schtasks /Query`). The `daemon start` subcommand calls this before attempting to start; the `daemon install` subcommand does not (it always registers). Stub implementations returning `Promise.resolve(false)` are added first (Phase 2) so TypeScript compiles; real implementations follow in Phase 6 (T035, T039, T041).
-
----
-
-### 1.3 — `src/daemon/installer-macos.ts`
-
-**`buildPlist(args: string[], logDir: string): string`**
-
-Replace the single `<string>${executablePath}</string>` with a loop:
-
-```typescript
-function buildPlist(args: string[], logDir: string): string {
-  const programArgs = [...args, "daemon", "_run"]
-    .map((a) => `    <string>${a}</string>`)
-    .join("\n");
-  // ... plist template with ${programArgs} in the <array> block
-}
-```
-
-**`installMacOs(args: string[]): Promise<void>`**
-
-```typescript
-export async function installMacOs(args: string[]): Promise<void> {
-  // 1. bootout existing service (ignore ENOENT / not-loaded errors)
-  try {
-    await execFileAsync("launchctl", ["bootout", `gui/${process.getuid?.() ?? 501}`, PLIST_PATH]);
-  } catch { /* not loaded — expected */ }
-
-  // 2. write plist
-  const plist = buildPlist(args, logDir);
-  await writeFile(PLIST_PATH, plist, "utf8");
-
-  // 3. bootstrap — surface clean error on failure
-  try {
-    await execFileAsync("launchctl", ["bootstrap", `gui/${process.getuid?.() ?? 501}`, PLIST_PATH]);
-  } catch (err) {
-    const msg = extractServiceManagerError(err);
-    throw new Error(`launchd bootstrap failed: ${msg}\nHint: Check that the executable path exists and is not in a temporary directory.`);
-  }
-  log.success(`Installed launchd service: ${PLIST_LABEL}`);
-}
-```
-
-**`extractServiceManagerError(err: unknown): string`** — a local helper that reads `(err as { stderr?: string }).stderr ?? String(err)` and strips internal stack frames. Returns only the service manager's stderr line.
-
-**`isRegisteredMacOs(): Promise<boolean>`** — runs `launchctl print gui/<uid>/com.agentsync.daemon` and returns `true` on exit code 0.
-
-**`startMacOs()`** — call `isRegisteredMacOs()` first; throw with actionable message if false. Wrap `kickstart` in `Promise.race` with a 10-second timeout.
-
----
-
-### 1.4 — `src/daemon/installer-linux.ts`
-
-**`buildUnit(args: string[]): string`**
-
-```typescript
-// ExecStart uses space-separated tokens; systemd tokenises correctly
-const execStart = [...args, "daemon", "_run"].join(" ");
-return `[Unit]\nDescription=...\n[Service]\nType=simple\nExecStart=${execStart}\n...`;
-```
-
-**`isRegisteredLinux(): Promise<boolean>`** — runs `systemctl --user is-enabled agentsync`. Returns `true` if stdout is `enabled`; `false` if `not-found` or `disabled`.
-
-**`startLinux()`** — check `isRegisteredLinux()` first; throw with actionable message if false. Wrap `systemctl --user start` in a 10-second timeout.
-
----
-
-### 1.5 — `src/daemon/installer-windows.ts`
-
-**`buildXml(args: string[]): string`**
-
-```typescript
-const command = escapeXml(args[0]);
-const scriptAndSubcmd = [...args.slice(1), "daemon", "_run"]
-  .map(escapeXml)
-  .join(" ");
-// <Command>${command}</Command>
-// <Arguments>${scriptAndSubcmd}</Arguments>
-```
-
-**`isInstalledWindows()`** — already queries `schtasks /Query`; this doubles as a registration check. **`startWindows()`** — check `isInstalledWindows()` first; wrap `schtasks /Run` in a 10-second timeout.
-
----
-
-### 1.6 — `src/core/sync-queue.ts` (new file)
-
-```typescript
-/** Serialises async operations so only one runs at a time. */
-export class SyncQueue {
-  private tail: Promise<void> = Promise.resolve();
-
-  /** Enqueue fn; it will run only after any currently running operation settles. */
-  enqueue<T>(fn: () => Promise<T>): Promise<T> {
-    const result = this.tail.then(fn);
-    this.tail = result.then(
-      () => {},
-      () => {},
-    );
-    return result;
-  }
-
-  /** Resolves when no operations are in progress or queued. */
-  whenIdle(): Promise<void> {
-    return this.tail;
-  }
-}
-```
-
----
-
-### 1.7 — `src/config/schema.ts` — add `DaemonStatusSchema`
-
-```typescript
-export const DaemonStatusSchema = z.object({
-  pid: z.number().int().positive(),
-  consecutiveFailures: z.number().int().min(0),
-  lastError: z.string().nullable(),
-});
-export type DaemonStatus = z.infer<typeof DaemonStatusSchema>;
-```
-
----
-
-### 1.8 — `src/daemon/index.ts` — runtime hardening
-
-**Key changes**:
-
-```typescript
-import { unlink } from "node:fs/promises";
-import { SyncQueue } from "../core/sync-queue";
-import { DaemonStatusSchema } from "../config/schema";
-
-// Failure record
-let consecutiveFailures = 0;
-let lastError: string | null = null;
-
-function recordSuccess(): void {
-  consecutiveFailures = 0;
-  lastError = null;
-}
-
-function recordFailure(err: string): void {
-  consecutiveFailures++;
-  lastError = err;
-}
-
-// Retry-once wrapper
-async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
-  try {
-    return await fn();
-  } catch {
-    return fn(); // second attempt; throws if it also fails
-  }
-}
-
-// Sync queue
-const queue = new SyncQueue();
-
-// Updated status handler
-ipc.on("status", async () =>
-  DaemonStatusSchema.parse({ pid: process.pid, consecutiveFailures, lastError })
-);
-
-// Wrap every push/pull call with queue + retry + record
-async function runSyncOp(op: () => Promise<SyncResult>): Promise<SyncResult> {
-  return queue.enqueue(async () => {
-    try {
-      const result = await withRetry(op);
-      if (!result.fatal) recordSuccess();
-      else recordFailure(result.errors.join("; "));
-      return result;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      recordFailure(msg);
-      throw err;
-    }
-  });
-}
-
-// Clean shutdown
-const shutdown = async () => {
-  clearInterval(pullTimer);
-  ipc.close();
-  // Drain in-flight ops, max 10s
-  await Promise.race([queue.whenIdle(), new Promise<void>((r) => setTimeout(r, 10_000))]);
-  await watcher.close();
-  try { await unlink(socketPath); } catch { /* already gone */ }
-  process.exit(0);
-};
-```
-
----
-
-### 1.9 — `docs/daemon.md` (new file)
-
-Must include a GitHub-compatible Mermaid state diagram. High-contrast colour pairs per the global CLAUDE.md rules. See quickstart.md Scenario 8 for validation requirements.
-
-State diagram covers: `Starting` → `Running` → `Syncing` → `Running` (success) / `Error` (retry) → `Running`, and `Running` → `ShuttingDown` → `Stopped`.
-
----
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
 
 ## Complexity Tracking
 
-No constitution violations requiring justification. All changes are additions or fixes within the existing module structure. No new project, no repository pattern, no abstraction layers beyond `SyncQueue` (which is 12 lines and has zero dependencies).
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ----------------------------------- |
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/20260406-094347-stabilise-daemon/quickstart.md
+++ b/specs/20260406-094347-stabilise-daemon/quickstart.md
@@ -1,0 +1,90 @@
+# Quickstart Validation: Stabilise Daemon Process
+
+**Branch**: `20260406-094347-stabilise-daemon` | **Date**: 2026-04-06
+
+This document defines the manual walkthrough steps reviewers must complete to validate this feature before merging.
+
+---
+
+## Testing Environment Guide
+
+| Test layer | Recommended environment | Notes |
+|------------|------------------------|-------|
+| Unit tests (mocked `execFile`) | Any machine — local, CI, container | No OS-specific calls; runs identically everywhere |
+| macOS integration (launchd) | Host macOS machine | Docker runs Linux containers — `launchd` does not exist inside them |
+| Linux integration (systemd) | GitHub Actions `ubuntu-latest` runner, or a local Linux VM (UTM / Lima) | `systemctl --user` is unreliable in unprivileged Docker containers |
+| Windows integration (Task Scheduler) | GitHub Actions `windows-latest` runner | `schtasks.exe` is present; no VM needed |
+
+**Docker is not recommended for installer integration tests.** It does not provide launchd, and systemd user services require a privileged init that complicates containers without adding reliability.
+
+---
+
+## Prerequisites
+
+- AgentSync installed globally: `bun install -g @chrisleekr/agentsync`
+- A working vault (`agentsync init` completed, remote configured)
+- macOS (for launchd scenarios), or adapt steps for Linux/systemd
+
+---
+
+## Scenario 1 — Fresh Install and Clean Status
+
+1. Run `agentsync daemon install`
+   - **Expect**: Success message. No stack trace. No "Bootstrap failed" error.
+2. Run `agentsync daemon status`
+   - **Expect**: "Daemon is running (pid: XXXXX)" with `consecutiveFailures: 0`
+3. Run `launchctl print gui/$(id -u)/com.agentsync.daemon` (macOS)
+   - **Expect**: `state = running` or `state = waiting`. `last exit code` should NOT be 78.
+
+## Scenario 2 — Idempotent Re-install
+
+1. With daemon already installed, run `agentsync daemon install` again
+   - **Expect**: Success message. No "Bootstrap failed: 5" error.
+2. Run `agentsync daemon status`
+   - **Expect**: Daemon is running with a new PID.
+
+## Scenario 3 — Install via Ephemeral Path is Blocked
+
+1. Run `bunx --package @chrisleekr/agentsync@latest agentsync daemon install`
+   - **Expect**: Error message: "Executable is in a temporary directory. Install the package globally first: `bun install -g @chrisleekr/agentsync`"
+   - **Expect**: Non-zero exit code. No plist written.
+
+## Scenario 4 — `daemon start` Does Not Hang
+
+1. If daemon is not registered (no plist), run `agentsync daemon start`
+   - **Expect**: Error within 2 seconds: "Service not bootstrapped — run `agentsync daemon install` first."
+2. If daemon IS registered but the process is already running, run `agentsync daemon start`
+   - **Expect**: Returns within 10 seconds.
+
+## Scenario 5 — Graceful Shutdown Leaves No Stale Socket
+
+1. Confirm daemon is running: `agentsync daemon status`
+2. Run `agentsync daemon stop`
+3. Check socket path: `ls $(agentsync daemon _socket-path 2>/dev/null || echo ~/.agentsync/daemon.sock)`
+   - **Expect**: Socket file does NOT exist.
+4. Run `agentsync daemon install` (fresh start)
+   - **Expect**: Success — no "address already in use" error.
+
+## Scenario 6 — Sync Errors Are Visible
+
+1. Temporarily break the remote URL in `agentsync.toml` (e.g., `url = "file:///nonexistent"`)
+2. Wait for one pull interval (or trigger via `agentsync push`)
+3. Run `agentsync daemon status`
+   - **Expect**: `consecutiveFailures >= 1`, `lastError` contains a non-empty message.
+4. Restore the remote URL
+5. Trigger a sync (change any agent config file)
+   - **Expect**: Next `agentsync daemon status` shows `consecutiveFailures: 0`, `lastError: null`.
+
+## Scenario 7 — `bun run check` Passes
+
+Run `bun run check` on the branch with all changes applied.
+
+- **Expect**: Typecheck, lint, and all tests pass with zero errors.
+- **Expect**: Coverage ≥70% for all modified modules; ≥90% for security-critical modules (unchanged).
+
+## Scenario 8 — Mermaid Diagram Renders Correctly
+
+Open `docs/daemon.md` in a Markdown renderer that supports Mermaid (e.g., GitHub preview).
+
+- **Expect**: The lifecycle state diagram renders without errors.
+- **Expect**: All states (starting, running, syncing, error, shutting down, stopped) are visible.

--- a/specs/20260406-094347-stabilise-daemon/research.md
+++ b/specs/20260406-094347-stabilise-daemon/research.md
@@ -1,0 +1,128 @@
+# Research: Stabilise Daemon Process
+
+**Branch**: `20260406-094347-stabilise-daemon` | **Date**: 2026-04-06
+
+---
+
+## R-001: macOS launchd ProgramArguments Format
+
+**Decision**: Each element of `ProgramArguments` must be a separate `<string>` XML node. The first element is used as the binary path passed to `execv()`; there is no automatic shell tokenisation.
+
+**Rationale**: Confirmed from `launchd.plist(5)` man page and live evidence (`last exit code = 78: EX_CONFIG`). The current `buildPlist()` puts `"bun /path/cli.js"` into one `<string>`, so `execv()` is called with a path containing a literal space — no such file exists.
+
+**Fix**: `getExecutablePath()` must return `string[]`. `buildPlist()` must emit one `<string>` per element.
+
+**Reference**: `man launchd.plist` — "ProgramArguments: This key maps to the first argument of execv(3)."
+
+---
+
+## R-002: Windows Task Scheduler Command/Arguments Split
+
+**Decision**: The `<Command>` XML element holds the binary path only; `<Arguments>` holds all subsequent tokens space-separated. Combining both into `<Command>` causes `CreateProcess` to look for a binary at a path with spaces.
+
+**Rationale**: Windows Task Scheduler XML schema separates binary from arguments. The current `buildXml()` puts `"bun /path/cli.js"` into `<Command>`, which fails identically to the macOS bug.
+
+**Fix**: `buildXml(args: string[])` should use `args[0]` as `<Command>` and join `[...args.slice(1), "daemon", "_run"]` as `<Arguments>`.
+
+**Reference**: Microsoft Task Scheduler XML schema — `Exec.Command` element holds the application name; `Exec.Arguments` holds the command-line arguments.
+
+---
+
+## R-003: Linux systemd ExecStart (No Change Required)
+
+**Decision**: Linux is not affected by the executable path format bug. No change to path handling is needed for Linux.
+
+**Rationale**: systemd's `ExecStart` uses shell-like space tokenisation. `ExecStart=/path/to/bun /path/to/cli.js daemon _run` correctly resolves to binary=`/path/to/bun`, args=`["/path/to/cli.js", "daemon", "_run"]`. Confirmed by reading `systemd.service(5)` man page.
+
+**Alternatives considered**: Migrating Linux to `string[]` for interface consistency — accepted as a minor refactor but not required for correctness.
+
+**Reference**: `man systemd.service` — "ExecStart: Takes a command line, which are split by whitespace."
+
+---
+
+## R-004: macOS launchctl Idempotent Re-install Pattern
+
+**Decision**: Use `bootout` (ignoring error if service not loaded) → write plist → `bootstrap`. This makes `daemon install` idempotent.
+
+**Rationale**: `launchctl bootstrap` on an already-registered service returns error code 5 ("Bootstrap failed: Input/output error"). The correct re-install sequence is `bootout` first. `launchctl bootout` returns a non-zero code if the service isn't loaded, which must be swallowed.
+
+**Reference**: Apple developer docs on launchd — `launchctl bootout` removes a service from the bootstrap namespace; `launchctl bootstrap` adds it.
+
+---
+
+## R-005: Detecting Ephemeral / Temp Executable Paths
+
+**Decision**: Compare the resolved script path against `os.tmpdir()` (after `fs.realpathSync`) to detect bunx temp directories. Also check for `bunx-` in the path as a belt-and-suspenders guard.
+
+**Rationale**: On macOS, `os.tmpdir()` returns the user-scoped temp dir (`/var/folders/{x}/{hash}/T`), which is exactly the bunx cache location. `process.argv[1]` when running via `bunx` is always inside this directory.
+
+**Fix**: In `getExecutablePath()` (renamed `getExecutableArgs()`), after detecting the bun case, call `isEphemeralPath(process.argv[1])`. If true, throw an error directing the user to install globally: `bun install -g @chrisleekr/agentsync`.
+
+---
+
+## R-006: macOS launchctl Bootstrap State Check for `daemon start`
+
+**Decision**: Run `launchctl print gui/<uid>/com.agentsync.daemon` to check registration state before calling `kickstart`. A non-zero exit code means the service is not registered.
+
+**Rationale**: `isInstalledMacOs()` currently only checks whether the plist file exists on disk — not whether launchd has the service registered. A plist file can exist from a failed install. Querying `launchctl print` is the authoritative check.
+
+**Reference**: `launchctl print gui/<uid>/<label>` exits non-zero if the service is not in the bootstrap namespace.
+
+---
+
+## R-007: Linux systemd Registration Check for `daemon start`
+
+**Decision**: Run `systemctl --user is-enabled agentsync` before calling `systemctl --user start`. A result of `not-found` means unregistered.
+
+**Rationale**: `isInstalledLinux()` only checks file presence. `systemctl is-enabled` queries the live systemd state.
+
+**Reference**: `man systemctl` — `is-enabled`: "Checks whether any of the specified unit files are enabled." Outputs `enabled`, `disabled`, or `not-found`.
+
+---
+
+## R-008: SyncQueue — Promise Serialisation Without New Dependencies
+
+**Decision**: Implement a minimal `SyncQueue` class in `src/core/sync-queue.ts` using a promise chain. No new runtime dependency needed.
+
+**Rationale**: The requirement is to serialise push and pull operations so only one runs at a time. A simple `tail: Promise<void>` that each new enqueue appends to is the standard pattern. The class also exposes a `whenIdle()` promise for graceful shutdown drain.
+
+**Pattern**:
+```typescript
+class SyncQueue {
+  private tail: Promise<void> = Promise.resolve();
+  enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(fn);
+    this.tail = result.then(() => {}, () => {});
+    return result;
+  }
+  whenIdle(): Promise<void> { return this.tail; }
+}
+```
+
+**Alternatives considered**: Using a third-party queue library (rejected — adds a dependency for trivial logic); using a mutex semaphore (more complex, same outcome).
+
+---
+
+## R-009: Retry-Once Wrapper
+
+**Decision**: Implement a local `withRetry(fn)` helper inside `daemon/index.ts` that calls `fn()` once, and on failure calls `fn()` again before re-throwing.
+
+**Rationale**: The retry policy (FR-014) is "retry exactly once immediately, then give up until next trigger." A standalone helper is cleaner than duplicating try/catch at every call site.
+
+---
+
+## R-010: Failure Record in Daemon State
+
+**Decision**: Maintain `{ consecutiveFailures: number; lastError: string | null }` in module scope in `daemon/index.ts`. Reset to `{ consecutiveFailures: 0, lastError: null }` on any successful sync. Expose via `status` IPC handler.
+
+**Rationale**: In-memory is sufficient — the spec says the counter resets on restart (implicit from "in memory"). No persistence layer needed.
+
+**Schema (FR-004, Constitution Principle IV)**: The `status` IPC response crosses a trust boundary, so it must be validated with Zod. Add `DaemonStatusSchema` to `src/config/schema.ts`.
+
+---
+
+## R-011: Shutdown — Wait for In-Flight Operations Before Exit
+
+**Decision**: In the `shutdown` handler, call `queue.whenIdle()` before `process.exit(0)`, with a 10-second max wait (matching SC-001). Also call `ipc.close()` and `unlink(socketPath)` (swallowing ENOENT).
+
+**Rationale**: `process.exit(0)` is called synchronously in the current shutdown handler, terminating any running push/pull mid-write. `queue.whenIdle()` returns a promise that resolves only when all queued operations have settled.

--- a/specs/20260406-094347-stabilise-daemon/spec.md
+++ b/specs/20260406-094347-stabilise-daemon/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Stabilise Daemon Process
+
+**Feature Branch**: `20260406-094347-stabilise-daemon`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: User description: "Stabilise daemon process"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Daemon Shuts Down Cleanly Without Data Loss (Priority: P1)
+
+A developer or CI operator sends a stop signal (e.g. via `agentsync daemon stop` or system shutdown) to the background daemon. Any sync operation that is already in progress completes before the process exits. No partial writes are left behind, and the connection socket is removed so that subsequent start attempts do not hit stale-socket errors.
+
+**Why this priority**: Unclean shutdown is the most common source of data corruption and "already in use" startup failures. Fixing this unblocks reliable restarts and service-manager integration.
+
+**Independent Test**: Install the daemon, trigger a sync, immediately send SIGTERM, confirm the sync completed (or was safely abandoned), and confirm the socket path no longer exists and the next `daemon start` succeeds without error.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon is running and a push is in progress, **When** SIGTERM is received, **Then** the push completes before the process exits and no partial commit is left in the vault.
+2. **Given** the daemon is running, **When** SIGTERM or SIGINT is received, **Then** the IPC socket file is removed from disk before the process exits.
+3. **Given** the daemon has previously crashed (leaving a stale socket), **When** the daemon is started again, **Then** it starts successfully without any manual cleanup required.
+
+---
+
+### User Story 2 - Sync Errors Are Visible and Actionable (Priority: P2)
+
+An operator notices that syncs have been silently failing (no files updated across machines) and wants to diagnose the problem without having to read raw log files or attach a debugger. Each sync failure must be recorded with enough context to identify whether the root cause is a network issue, a conflict, or a configuration problem.
+
+**Why this priority**: Silent failures erode user trust and make the daemon appear to work while no syncing is actually happening. Visible, actionable errors let operators self-diagnose.
+
+**Independent Test**: Introduce a broken remote URL, run the daemon for one pull interval, check that `agentsync daemon status` or the log output reflects the failure, and confirm the daemon is still running for the next interval.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon is running and the remote is unreachable, **When** the periodic pull fires, **Then** an error message is logged that includes the time, reason, and that the daemon remains alive for the next interval.
+2. **Given** the daemon is running and a push triggered by a file-watch event fails, **Then** the error is logged with the affected path and the daemon continues watching for future changes.
+3. **Given** multiple consecutive sync failures, **When** an operator queries daemon status, **Then** the response includes the count of recent failures and the most recent error message.
+
+---
+
+### User Story 3 - Daemon Recovers After a Transient Failure (Priority: P3)
+
+A developer's machine temporarily loses network connectivity while the daemon is running. Once connectivity is restored, the daemon resumes syncing without requiring a manual restart.
+
+**Why this priority**: Automatic recovery prevents a common "daemon is installed but not syncing" support scenario caused by laptops sleeping, network changes, or brief remote outages.
+
+**Independent Test**: Start the daemon, simulate a network outage for two pull intervals, restore connectivity, and confirm the next pull interval succeeds and agent configs are up to date.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon is running and the remote is temporarily unreachable, **When** the periodic pull fires and fails, **Then** the daemon retries the pull once immediately; if that also fails, it waits for the next scheduled interval and tries again.
+2. **Given** the daemon is running and a file-watch push fails due to a transient error, **When** the push fails, **Then** the daemon retries the push once immediately; if that also fails, it logs the error and waits for the next file-change event.
+3. **Given** the remote becomes reachable again after multiple failed intervals, **When** the next pull interval or file-change fires, **Then** the sync succeeds without a manual restart.
+
+---
+
+### User Story 4 - Daemon Startup Failures Are Clearly Reported (Priority: P4)
+
+An operator runs `agentsync daemon install` on a new machine with an incomplete configuration (missing vault, missing encryption key). Instead of the daemon silently crashing or hanging, the failure is reported immediately with a clear message indicating what is wrong.
+
+**Why this priority**: Silent startup failures lead to ghost services that appear installed but never sync. Clear startup errors reduce onboarding friction.
+
+**Independent Test**: Install the daemon with a missing vault directory, check the service logs, and confirm an actionable error message is present within 5 seconds of start.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon is started with a missing vault directory, **When** startup runs, **Then** the process exits with a non-zero code and logs a message identifying the missing vault.
+2. **Given** the daemon is started with a missing or unreadable encryption key, **When** startup runs, **Then** the process exits with a non-zero code and logs a message identifying the key issue.
+3. **Given** a valid configuration, **When** the daemon starts successfully, **Then** a "daemon started" message is logged within 2 seconds.
+
+---
+
+### Edge Cases
+
+- What happens when a second daemon instance is started while one is already running (same socket path)?
+- How does the daemon behave when the vault directory is deleted while it is running?
+- When a push and a pull are triggered simultaneously, the second operation waits in a queue until the first completes (serialised — never concurrent).
+- What happens when the daemon receives SIGKILL (unhandled, cannot be caught) — is the socket left behind?
+- What happens when disk is full and a push cannot write the commit?
+- What happens when the OS service manager (launchd/systemd) rejects the bootstrap registration during `daemon install`? (Confirmed cause: malformed ProgramArguments — executable and script path must be separate entries, not one space-joined string.)
+- What happens when `daemon install` is run via `bunx` and the executable path is inside a session-scoped temp directory? The daemon will appear installed but fail silently after the temp directory is cleaned up.
+- What happens when `daemon install` is run a second time on an already-registered service? (Confirmed cause: `launchctl bootstrap` on an already-loaded service returns error code 5; the fix is `bootout` then `bootstrap`.)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The daemon MUST complete any in-progress push or pull operation before exiting in response to a shutdown signal.
+- **FR-002**: The daemon MUST remove its IPC socket file from disk as part of its shutdown sequence.
+- **FR-003**: The daemon MUST start successfully when the IPC socket path already exists (stale from a previous crash), by removing it at startup.
+- **FR-004**: The daemon MUST log each sync error with a timestamp, a human-readable error message, and the operation type (push or pull).
+- **FR-005**: The daemon MUST remain running after a failed sync operation and continue processing future sync events and intervals.
+- **FR-006**: The daemon MUST exit with a non-zero status code and log a descriptive error message when it cannot load its required configuration at startup.
+- **FR-007**: The daemon MUST exit with a non-zero status code and log a descriptive error message when the vault directory or encryption key is missing or inaccessible at startup.
+- **FR-008**: The `daemon status` IPC response MUST include the count of consecutive sync failures (reset to zero after any successful push or pull) and the most recent error message in addition to the process identifier.
+- **FR-009**: The daemon MUST prevent a second instance from starting on the same socket path and report an "already running" error to the caller.
+- **FR-010**: The daemon lifecycle MUST be documented with a Mermaid state diagram covering: starting, running, syncing, error, shutting down, and stopped states.
+- **FR-011**: When `daemon install` fails because the OS service manager rejects bootstrap registration, the command MUST surface only the service manager's error message (not an internal stack trace), exit with a non-zero code, and print a short platform-specific hint to the operator (e.g. "Check that the executable path is valid" or "Try re-running with elevated privileges").
+- **FR-012**: `daemon start` MUST verify that the service is registered with the OS service manager before attempting to start it; if not registered, the command MUST exit immediately with a non-zero code and the message "Service not bootstrapped — run `agentsync daemon install` first."
+- **FR-013**: `daemon start` MUST apply a hard timeout (10 seconds) to the service manager start call; if the call does not return within that window, the command MUST kill the call, exit non-zero, and report "Service manager start timed out."
+- **FR-014**: After any failed sync operation (push or pull), the daemon MUST retry that operation exactly once immediately before logging the failure and resuming its normal trigger cadence.
+- **FR-015**: The daemon MUST serialise all sync operations through a single queue so that at most one push or pull executes at any given time; any operation triggered while another is running MUST wait until the running operation completes.
+- **FR-016**: The installer MUST write the executable path and each of its arguments as **separate entries** in the service definition's program arguments list; combining the executable and arguments into a single space-separated string is not permitted, as the OS service manager (launchd/systemd) treats the first entry as the literal binary path. *(Root cause of the confirmed install failure: `ProgramArguments[0]` contained `"bun /path/cli.js"` instead of two separate entries.)*
+- **FR-017**: Before writing the service definition, `daemon install` MUST verify that the resolved executable path refers to a file that exists and is executable at a stable, persistent location. If the path is inside a temporary or session-scoped directory, the command MUST abort with an error message explaining the issue and suggesting the user install the package globally instead.
+- **FR-018**: `daemon install` MUST first remove any existing service registration before writing a new service definition and re-registering, so that re-running `daemon install` on an already-installed daemon never produces a "service already registered" error.
+
+### Key Entities
+
+- **Daemon Process**: The long-running background process responsible for watching agent config directories, executing periodic pulls, and responding to IPC commands. Tracks its own lifecycle state and error history.
+- **IPC Socket**: The communication channel between the daemon and CLI commands. Created at startup, removed at shutdown. Path is deterministic per user account.
+- **Sync Operation**: A single push or pull execution triggered either by a file-watch event, a periodic interval, or an explicit IPC command. Has a start time, completion status, and optional error message.
+- **Failure Record**: A count of consecutive sync failures maintained in memory by the daemon since the last successful sync operation (push or pull). Resets to zero on any successful sync. Surfaced via the `status` IPC command along with the most recent error message.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The daemon shuts down cleanly (no stale socket, no partial commit) within 10 seconds of receiving a stop signal in 100% of observed cases.
+- **SC-002**: After a clean shutdown and restart, `agentsync daemon status` returns a running response within 5 seconds in 100% of observed cases.
+- **SC-003**: Every sync error is logged within 1 second of occurrence and includes enough information for an operator to identify the root cause without consulting source code.
+- **SC-004**: The daemon continues running for at least 10 consecutive failed sync intervals without requiring a manual restart.
+- **SC-005**: A second daemon start attempt on an already-running instance reports an "already running" error within 2 seconds and does not corrupt the running daemon's state.
+- **SC-006**: Startup configuration errors are reported and the process exits within 3 seconds, with a log message that identifies the specific missing or invalid resource.
+- **SC-007**: `daemon start` either succeeds or exits with an error within 10 seconds in 100% of observed cases — it MUST NOT block indefinitely.
+
+## Assumptions
+
+- The daemon runs under a single user account; multi-user or root-escalated installs are out of scope.
+- The system service manager (launchd, systemd, NSSM) is responsible for automatic restart after an unrecoverable crash; the daemon itself only handles graceful shutdown and transient error recovery.
+- Network connectivity is expected to be intermittent on developer machines; retry logic should not require any new configuration.
+- The IPC socket path is fixed per user and does not need to be configurable in this feature.
+- All sync operations (push and pull) are serialised through a queue; concurrent execution is explicitly not supported. Merge conflict resolution within a single operation is unchanged from the existing implementation.
+- Windows named-pipe behaviour may differ from Unix socket behaviour in cleanup; platform-specific handling is acceptable as long as the observable outcomes match the acceptance scenarios.
+
+## Clarifications
+
+### Session 2026-04-06
+
+- Q: When `daemon install` fails because the OS service manager rejects bootstrap registration, what should the command do? → A: Extract service manager stderr only, exit non-zero, and print a short platform-specific hint line (no internal stack trace).
+- Q: What should `daemon start` do when the service manager call does not return promptly? → A: Check bootstrap registration state first (error immediately if not registered), then apply a hard timeout as a safety net on the kickstart/start call itself.
+- Q: How should the daemon handle retries after a sync failure? → A: Retry immediately once after failure; if the retry also fails, wait for the next natural trigger (scheduled interval or file-change event).
+- Q: When should the consecutive failure counter reset to zero? → A: Reset on any successful sync operation (push or pull).
+- Q: When a push and pull are triggered at the same time, should they run concurrently or be serialised? → A: Serialise all sync operations — only one push or pull runs at a time.
+
+### Investigation 2026-04-06 — Confirmed Root Causes from Live System
+
+Three concrete bugs were confirmed by inspecting the installed plist, `launchctl print`, and system state:
+
+1. **Malformed ProgramArguments** (`daemon.ts:10`, `installer-macos.ts:35`): `getExecutablePath()` returns `"bun /path/to/cli.js"` as a single concatenated string. `buildPlist()` places that entire string into one `<string>` XML element. launchd uses `ProgramArguments[0]` as the binary path; because no file exists at a path containing a space, every spawn attempt exits with `EX_CONFIG (78)`. Both log files are 0 bytes — the process never started. **Official requirement** (`launchd.plist(5)`): each element must be a separate `<string>` entry. Captured in FR-016.
+
+2. **Ephemeral bunx temp path**: The installed plist references `/private/var/folders/.../T/bunx-501-.../node_modules/.../cli.js` — a session-scoped temp directory that bunx creates at runtime. This path is not persistent across OS restarts or temp-directory cleanups, making the daemon silently non-functional after reboot even if the plist format is corrected. Captured in FR-017.
+
+3. **Re-bootstrap of already-registered service**: `installMacOs` calls `launchctl bootstrap` unconditionally. If the service is already registered, launchctl returns "Bootstrap failed: 5: Input/output error" with no distinction from a genuine failure. The correct pattern is `bootout` → write plist → `bootstrap`. Captured in FR-018.
+
+## Documentation Impact
+
+The daemon lifecycle is non-obvious to new contributors and operators. A Mermaid state diagram covering startup, running, syncing, error, graceful shutdown, and stopped states should be added to `docs/daemon.md` (or created if it does not exist) as part of this feature. The diagram must use GitHub-compatible Mermaid syntax.
+
+Manual walkthrough reviewers should validate:
+1. `agentsync daemon install && agentsync daemon stop` leaves no stale socket on disk.
+2. Introducing a bad remote URL results in visible error logs and a still-running daemon after one pull interval.
+3. `agentsync daemon status` output includes failure count after one failed pull.

--- a/specs/20260406-094347-stabilise-daemon/tasks.md
+++ b/specs/20260406-094347-stabilise-daemon/tasks.md
@@ -275,6 +275,11 @@ T010  →  src/core/sync-queue.ts         (fill SyncQueue body)
 - [x] T072 [P] Add `isRegisteredWindows: mockIsRegistered` to Windows mock in `src/commands/__tests__/daemon.test.ts` line 98–104
 - [x] T073 [P] Replace `expect(signalHandlers.has("SIGTERM")).toBe(true)` with `expect(exitCode).toBeNull()` in `src/daemon/__tests__/index.test.ts` retry logic test (line 368)
 
+### Fix 6: Windows backslash escaping (CodeQL + CodeRabbit round 2)
+
+- [x] T074a [P] [US4] Update `src/daemon/__tests__/installer-windows.test.ts` — add test for `quoteWinArg` with trailing backslash (e.g. `C:\path\` → `"C:\\path\\"`) and backslash-before-quote (TDD: write test first)
+- [x] T074b [US4] Fix `quoteWinArg()` in `src/daemon/installer-windows.ts` — escape backslashes before quotes and trailing backslashes per `CommandLineToArgvW` conventions using `(\\*)("|$)` regex
+
 **Checkpoint**: All PR review findings addressed. Run `bun run check` to validate.
 
 ---

--- a/specs/20260406-094347-stabilise-daemon/tasks.md
+++ b/specs/20260406-094347-stabilise-daemon/tasks.md
@@ -1,0 +1,245 @@
+# Tasks: Stabilise Daemon Process
+
+**Input**: Design documents from `/specs/20260406-094347-stabilise-daemon/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/ipc-status.md, quickstart.md
+
+**Tests**: Automated tests are required for all modified and new modules per Constitution Principle II. Tests are written before implementation (TDD) and must fail before the implementation task is started.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1–US4, maps to spec.md priorities P1–P4)
+- Exact file paths are included in every description
+
+---
+
+## Phase 1: Setup (New Files)
+
+**Purpose**: Create new source files and test files so that all later tasks have a concrete target to fill in. Start with empty/stub implementations so TypeScript compiles from the beginning.
+
+- [ ] T001 Create stub `src/core/sync-queue.ts` exporting an empty `SyncQueue` class with `enqueue` and `whenIdle` method signatures
+- [ ] T002 Create stub `src/core/__tests__/sync-queue.test.ts` with a `describe("SyncQueue")` block and a single failing placeholder test
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Interface and schema changes that EVERY user story depends on. No user story work can begin until this phase is complete.
+
+**⚠️ CRITICAL**: The `getExecutableArgs(): string[]` rename and installer `install(args: string[])` signature change are breaking — all call sites and tests must compile before Phase 3 can start.
+
+- [ ] T003 Add `DaemonStatusSchema` and `DaemonStatus` type to `src/config/schema.ts` using Zod: fields `pid` (positive int), `consecutiveFailures` (non-negative int), `lastError` (string or null)
+- [ ] T004 Rename `getExecutablePath(): string` to `getExecutableArgs(): string[]` in `src/commands/daemon.ts`; implement ephemeral-path detection using `os.tmpdir()` comparison and `bunx-` guard; throw with "Install the package globally first: `bun install -g @chrisleekr/agentsync`" if the script path is in a temp directory
+- [ ] T004a ⚠️ Write tests in `src/commands/__tests__/daemon.test.ts` for `getExecutableArgs()`: (1) when `process.argv[0]` does not end with `bun`/`bun.exe`, returns single-element array containing `process.execPath`; (2) when running as bun with a non-ephemeral script path, returns `[process.argv[0], process.argv[1]]`; (3) when the script path is inside `os.tmpdir()` or contains `bunx-`, throws an `Error` whose message includes "Install the package globally first" — verifies Constitution Principle II coverage for the new ephemeral-path branch (C3)
+- [ ] T005 Update `PlatformInstaller` interface in `src/commands/daemon.ts`: change `install(exe: string)` to `install(args: string[])`; update the `install` subcommand to call `getExecutableArgs()` and pass the result to `installer.install(args)`
+- [ ] T005a Extend `PlatformInstaller` interface in `src/commands/daemon.ts` to add `isRegistered(): Promise<boolean>`; add stub implementations that return `Promise.resolve(false)` in `installer-macos.ts`, `installer-linux.ts`, and `installer-windows.ts` so TypeScript compiles; the real implementations will replace the stubs in T035 (macOS), T039 (Linux), and the existing `isInstalledWindows` alias in T041 — resolves I1 (T042 references this method but no prior task defined it)
+- [ ] T006 Update `buildPlist` signature to `buildPlist(args: string[], logDir: string)` in `src/daemon/installer-macos.ts`; emit one `<string>` XML element per entry in `[...args, "daemon", "_run"]` (fixes Bug 1 — confirmed root cause of `EX_CONFIG 78`)
+- [ ] T007 Update `installMacOs(args: string[])` signature in `src/daemon/installer-macos.ts`; add bootout step before writing plist: call `launchctl bootout gui/<uid> <PLIST_PATH>` and swallow errors (fixes Bug 3 — idempotent re-install)
+- [ ] T008 [P] Update `buildUnit` signature to `buildUnit(args: string[])` and `installLinux(args: string[])` in `src/daemon/installer-linux.ts`; construct `ExecStart` as `[...args, "daemon", "_run"].join(" ")` (systemd tokenises correctly; this is for interface consistency)
+- [ ] T009 [P] Update `buildXml` signature to `buildXml(args: string[])` and `installWindows(args: string[])` in `src/daemon/installer-windows.ts`; put `args[0]` in `<Command>` and join `[...args.slice(1), "daemon", "_run"]` into `<Arguments>` (fixes Bug 1 for Windows)
+- [ ] T010 Implement the full `SyncQueue` class body in `src/core/sync-queue.ts`: `tail: Promise<void>` chain, `enqueue<T>(fn: () => Promise<T>): Promise<T>`, and `whenIdle(): Promise<void>` returning the current tail
+- [ ] T010a ⚠️ Write test in `src/daemon/__tests__/index.test.ts`: when `startDaemon()` is called and a running daemon is already listening on the socket path, the startup code attempts an IPC health-ping and receives a valid response; it then logs a message containing "already running" and calls `process.exit(1)` without disrupting the running daemon — covers FR-009 and SC-005 (C2)
+- [ ] T010b Implement second-instance detection in `src/daemon/index.ts`: at the top of the startup sequence, before calling `ipc.listen()`, attempt a `status` command via `IpcClient` on the existing socket path; if a valid response is received, log `"Daemon is already running (pid: X)"` and call `process.exit(1)`; if `ECONNREFUSED` is caught (stale socket — file exists but no server), call `unlink(socketPath)` to remove it before proceeding to `ipc.listen()` (satisfies FR-003); if `ENOENT` is caught (no socket file), continue directly — this is the clean-start path
+
+**Checkpoint**: `bun run typecheck` must pass with zero errors before proceeding to Phase 3.
+
+---
+
+## Phase 3: User Story 1 — Clean Shutdown Without Data Loss (Priority: P1) 🎯 MVP
+
+**Goal**: SIGTERM/SIGINT causes the daemon to drain in-flight sync operations, close the IPC server, remove the socket file, then exit — leaving no partial commits and no stale socket for the next start.
+
+**Independent Test**: Install daemon, trigger a push, immediately send SIGTERM; verify push completes, socket file absent, next `daemon start` succeeds without "address in use" error.
+
+### Tests for User Story 1 ⚠️ Write first — verify they FAIL before implementation
+
+- [ ] T011 [US1] Write test in `src/daemon/__tests__/index.test.ts`: given SIGTERM received while queue is busy, `ipc.close()` is called before `process.exit(0)`
+- [ ] T012 [US1] Write test in `src/daemon/__tests__/index.test.ts`: given SIGTERM received, the IPC socket path is unlinked (spy on `unlink`) before `process.exit(0)`
+- [ ] T013 [US1] Write test in `src/core/__tests__/sync-queue.test.ts`: two enqueued operations run serially (second starts only after first resolves)
+- [ ] T014 [US1] Write test in `src/core/__tests__/sync-queue.test.ts`: `whenIdle()` resolves only after all enqueued work settles
+
+### Implementation for User Story 1
+
+- [ ] T015 [US1] Integrate `SyncQueue` into `src/daemon/index.ts`: import `SyncQueue`, create a module-level `queue` instance, wrap every `performPush()` and `runPull()` call so they are enqueued rather than called directly
+- [ ] T016 [US1] Update the `shutdown` function in `src/daemon/index.ts`: (1) call `ipc.close()`; (2) await `Promise.race([queue.whenIdle(), delay(10_000)])`; (3) await `watcher.close()`; (4) call `unlink(socketPath)` and swallow ENOENT; (5) then call `process.exit(0)`
+- [ ] T017 [US1] Update the existing shutdown test in `src/daemon/__tests__/index.test.ts` to confirm `watcherClosed`, `clearedIntervalToken`, IPC close, and socket unlink all occur before `exitCode === 0`
+
+**Checkpoint**: `bun test src/daemon/__tests__/index.test.ts` and `bun test src/core/__tests__/sync-queue.test.ts` pass. `bun run typecheck` clean.
+
+---
+
+## Phase 4: User Story 2 — Sync Errors Are Visible and Actionable (Priority: P2)
+
+**Goal**: Every sync failure is logged with timestamp and operation type. `daemon status` returns `consecutiveFailures` (resets on success) and `lastError` so operators can self-diagnose without reading raw logs.
+
+**Independent Test**: Break remote URL, wait one pull interval, run `agentsync daemon status`; expect `consecutiveFailures >= 1` and `lastError` is a non-empty string. Restore URL, trigger sync, verify status resets to `consecutiveFailures: 0, lastError: null`.
+
+### Tests for User Story 2 ⚠️ Write first — verify they FAIL before implementation
+
+- [ ] T018 [US2] Write test in `src/daemon/__tests__/index.test.ts`: after a failed pull, `consecutiveFailures` increments to 1 and `lastError` is non-null
+- [ ] T019 [US2] Write test in `src/daemon/__tests__/index.test.ts`: after a successful pull following a failure, `consecutiveFailures` resets to 0 and `lastError` is null
+- [ ] T020 [US2] Write test in `src/daemon/__tests__/index.test.ts`: `status` IPC handler returns an object matching `DaemonStatusSchema` with current `consecutiveFailures` and `lastError`
+
+### Implementation for User Story 2
+
+- [ ] T021 [US2] Add module-level failure state to `src/daemon/index.ts`: `let consecutiveFailures = 0; let lastError: string | null = null;` and helper functions `recordSuccess()` (resets both) and `recordFailure(op: "push" | "pull", msg: string)` (increments count, sets `lastError` to `"[push] msg"` or `"[pull] msg"` so that the operation type is always present in the stored error per FR-004 — U1 fix)
+- [ ] T022 [US2] Update the queued push/pull wrappers in `src/daemon/index.ts` to call `recordSuccess()` when the operation completes without a fatal error; call `recordFailure("push", msg)` in the push wrapper and `recordFailure("pull", msg)` in the pull wrapper when either fails or returns `fatal: true`; the literal string `"push"` or `"pull"` is chosen at the call site, never inferred inside `recordFailure`
+- [ ] T023 [US2] Update the `status` IPC handler in `src/daemon/index.ts` to return `DaemonStatusSchema.parse({ pid: process.pid, consecutiveFailures, lastError })`
+- [ ] T024 [P] [US2] Update `daemon status` display in `src/commands/daemon.ts`: on success, print pid plus failure count and last error if `consecutiveFailures > 0`
+
+**Checkpoint**: Status IPC now carries failure data. `bun test src/daemon/__tests__/index.test.ts` passes.
+
+---
+
+## Phase 5: User Story 3 — Automatic Recovery After Transient Failure (Priority: P3)
+
+**Goal**: Every failed sync is retried exactly once immediately. If the retry also fails, the error is logged and the daemon waits for the next natural trigger. Recovery is automatic — no manual restart needed.
+
+**Independent Test**: Block remote for two intervals; restore it; verify the next triggered sync succeeds without restart.
+
+### Tests for User Story 3 ⚠️ Write first — verify they FAIL before implementation
+
+- [ ] T025 [US3] Write test in `src/daemon/__tests__/index.test.ts`: when a push fails on first attempt but succeeds on second, the operation is called exactly twice and `consecutiveFailures` stays at 0
+- [ ] T026 [US3] Write test in `src/daemon/__tests__/index.test.ts`: when both the initial attempt and retry fail, `consecutiveFailures` increments to 1 (not 2); also assert that `process.exit` is NOT called — the daemon must remain alive for the next scheduled trigger (verifies SC-004: daemon survives consecutive failures without exiting)
+
+### Implementation for User Story 3
+
+- [ ] T027 [US3] Add `withRetry<T>(fn: () => Promise<T>): Promise<T>` helper to `src/daemon/index.ts`: calls `fn()` once; on failure calls `fn()` again and lets the second result propagate
+- [ ] T028 [US3] Wrap every `performPush()` and `runPull()` call inside the queue enqueue callback with `withRetry(...)` in `src/daemon/index.ts`
+
+**Checkpoint**: Retry behaviour verified. `bun test src/daemon/__tests__/index.test.ts` all green.
+
+---
+
+## Phase 6: User Story 4 — Clear Install and Start Failure Reporting (Priority: P4)
+
+**Goal**: `daemon install` via bunx is blocked with a clear error. A working install always uses separate `<string>` elements in the plist (not one space-joined string). `daemon install` is idempotent. `daemon start` never hangs — it checks registration state first and times out in 10 seconds. Daemon startup validates that the vault and encryption key are accessible before proceeding; missing resources cause an immediate exit with an actionable message (FR-006, FR-007, SC-006).
+
+**Independent Test**: Run `agentsync daemon install` via bunx → expect blocking error. Run `agentsync daemon install` globally twice → expect success both times. Run `agentsync daemon start` with no daemon registered → expect error within 2 seconds.
+
+### Tests for User Story 4 ⚠️ Write first — verify they FAIL before implementation
+
+- [ ] T029 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: `buildPlist(["bun", "/path/cli.js"], logDir)` produces a plist where `<ProgramArguments>` contains separate `<string>bun</string>` and `<string>/path/cli.js</string>` entries (not one combined string)
+- [ ] T030 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: `installMacOs(args)` calls `launchctl bootout` before `launchctl bootstrap` (verify call order via mock)
+- [ ] T031 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: when `launchctl bootstrap` rejects, `installMacOs` throws an `Error` whose message contains the service manager stderr but not an internal stack trace
+- [ ] T032 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: `startMacOs()` throws immediately with "Service not bootstrapped" message when `isRegisteredMacOs()` returns false (no kickstart call made)
+- [ ] T033 [P] [US4] Write test in `src/daemon/__tests__/installer-windows.test.ts`: `buildXml(["bun", "/path/cli.js"])` produces XML where `<Command>` holds only `bun` (escaped) and `<Arguments>` holds `/path/cli.js daemon _run`
+- [ ] T034 [P] [US4] Write test in `src/daemon/__tests__/installer-linux.test.ts`: `buildUnit(["bun", "/path/cli.js"])` produces a unit file where `ExecStart=bun /path/cli.js daemon _run`
+- [ ] T034a [P] [US4] Write test in `src/daemon/__tests__/index.test.ts`: when `startDaemon()` is called with a mock that throws "vault directory not found" during config/vault load, the process calls `process.exit(1)` and the log output contains "vault" — covers FR-006 and SC-006 (C1)
+- [ ] T034b [P] [US4] Write test in `src/daemon/__tests__/index.test.ts`: when `startDaemon()` is called with a mock that throws "key file not found" or "permission denied" during encryption key load, the process calls `process.exit(1)` and the log output identifies the key issue — covers FR-007 and SC-006 (C1)
+
+### Implementation for User Story 4
+
+- [ ] T035 [US4] Add `isRegisteredMacOs(): Promise<boolean>` to `src/daemon/installer-macos.ts`: runs `launchctl print gui/<uid>/com.agentsync.daemon`; returns `true` on exit 0, `false` otherwise
+- [ ] T036 [US4] Add `extractServiceManagerError(err: unknown): string` helper to `src/daemon/installer-macos.ts`: reads `stderr` property from the error object and returns it; falls back to `String(err)` if absent
+- [ ] T037 [US4] Update `installMacOs` in `src/daemon/installer-macos.ts` to wrap `launchctl bootstrap` in try/catch and re-throw with `extractServiceManagerError` output + a platform hint (no stack trace)
+- [ ] T038 [US4] Update `startMacOs()` in `src/daemon/installer-macos.ts`: call `isRegisteredMacOs()` first; throw "Service not bootstrapped — run `agentsync daemon install` first." if false; wrap `kickstart` in `Promise.race` with a 10-second timeout that throws "Service manager start timed out."
+- [ ] T039 [US4] Add `isRegisteredLinux(): Promise<boolean>` to `src/daemon/installer-linux.ts`: runs `systemctl --user is-enabled agentsync`; returns `true` only when stdout is `enabled`
+- [ ] T040 [US4] Update `startLinux()` in `src/daemon/installer-linux.ts`: call `isRegisteredLinux()` first with same guard pattern as macOS; wrap `systemctl --user start` in 10-second timeout
+- [ ] T041 [US4] Update `startWindows()` in `src/daemon/installer-windows.ts`: use `isInstalledWindows()` as the registration check; wrap `schtasks /Run` in 10-second timeout
+- [ ] T041a [US4] Add startup validation to `startDaemon()` in `src/daemon/index.ts`: at the top of the function, wrap the vault directory existence check and encryption key load in a try-catch; on failure, log `"Startup failed: <specific resource> — <actionable hint>"` and call `process.exit(1)`; the exit must occur within 3 seconds to satisfy SC-006 — this fills the FR-006 and FR-007 coverage gap (C1)
+- [ ] T042 [US4] Update `daemon start` subcommand in `src/commands/daemon.ts`: replace `installer.isInstalled()` check with the new `isRegistered()` method defined in the `PlatformInstaller` interface (added by T005a); the error message must include "run `agentsync daemon install` first"
+- [ ] T043 [P] [US4] Update existing tests in `src/daemon/__tests__/installer-macos.test.ts` for the new `string[]` parameter signature (all `installMacOs`, `buildPlist` call sites)
+- [ ] T044 [P] [US4] Update existing tests in `src/daemon/__tests__/installer-linux.test.ts` for the new `string[]` parameter signature
+- [ ] T045 [P] [US4] Update existing tests in `src/daemon/__tests__/installer-windows.test.ts` for the new `string[]` parameter signature
+
+**Checkpoint**: All four user stories independently functional. `bun test` passes across all modified test files.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, diagram validation, full CI gate, and live integration validation.
+
+- [ ] T046 [P] Create `docs/daemon.md` with a GitHub-compatible Mermaid stateDiagram-v2 covering all lifecycle states: Starting → Running → Syncing → Running (success) / Error (retry) → Running, and Running → ShuttingDown → Stopped; use high-contrast hex colour pairs per CLAUDE.md diagram rules
+- [ ] T047 [P] Add JSDoc comments to all new and modified exported symbols per Constitution Principle V: `SyncQueue`, `getExecutableArgs`, `isRegisteredMacOs`, `isRegisteredLinux`, `DaemonStatusSchema`, `withRetry`, `recordSuccess`, `recordFailure` (new); `installMacOs`, `buildPlist`, `installLinux`, `buildUnit`, `installWindows`, `buildXml` (signature-changed — existing JSDoc must be updated to reflect the new `args: string[]` parameter)
+- [ ] T048 Validate the Mermaid diagram in `docs/daemon.md` renders correctly in GitHub Markdown preview (open PR draft or use local renderer — required blocker per quickstart.md Scenario 8)
+- [ ] T049 Run `bun run check` (typecheck + biome lint + full test suite) and confirm zero errors
+- [ ] T050 Execute quickstart.md Scenario 1 on macOS host: fresh global install → `daemon install` → `daemon status` shows running with `consecutiveFailures: 0`
+- [ ] T051 Execute quickstart.md Scenario 2: run `daemon install` a second time → expect success, no "Bootstrap failed: 5" error
+- [ ] T052 Execute quickstart.md Scenario 3: run via bunx → expect ephemeral path error, no plist written
+- [ ] T053 Execute quickstart.md Scenario 4: run `daemon start` without registration → expect error within 2 seconds
+- [ ] T054 Execute quickstart.md Scenario 5: stop daemon → verify socket file absent → restart succeeds
+- [ ] T055 Execute quickstart.md Scenario 6: break remote URL → verify `daemon status` shows `consecutiveFailures >= 1` → restore and confirm reset
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (stub files exist). **BLOCKS all user stories.**
+- **US1–US4 (Phases 3–6)**: All depend on Foundational completion. Can then proceed in priority order (P1→P2→P3→P4) or in parallel if staffed.
+- **Polish (Phase 7)**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends only on Foundational. No dependency on US2/US3/US4.
+- **US2 (P2)**: Depends only on Foundational. Adds failure tracking on top of US1's queue — best implemented after US1 but independently testable.
+- **US3 (P3)**: Depends only on Foundational. The `withRetry()` wrapper composes with both the queue (US1) and failure tracking (US2) — implement after both for coherent unit tests.
+- **US4 (P4)**: Depends only on Foundational (installer signature changes already in Phase 2). Fully independent of US1/US2/US3.
+
+### Within Each User Story
+
+1. Write tests first (they must fail)
+2. Implement to make tests pass
+3. Run `bun run typecheck` after each implementation task
+4. Verify story's independent test criteria before moving to next story
+
+### Parallel Opportunities
+
+- T008 and T009 (Linux/Windows installer signatures) can run in parallel — different files
+- T011, T012 (shutdown tests) can be written in parallel — same file, same describe block, no conflict
+- T013, T014 (SyncQueue tests) are in a different file — can run in parallel with T011/T012
+- T029–T034b (US4 tests across all installers and startup) are all in different test files — fully parallel
+- T043, T044, T045 (existing test updates) — fully parallel across installer files
+- T046 (docs), T047 (JSDoc) — parallel in Polish phase
+
+---
+
+## Parallel Example: Phase 2
+
+```bash
+# These can be implemented simultaneously (different files):
+T003  →  src/config/schema.ts          (add DaemonStatusSchema)
+T008  →  src/daemon/installer-linux.ts  (update buildUnit signature)
+T009  →  src/daemon/installer-windows.ts (update buildXml signature)
+T010  →  src/core/sync-queue.ts         (fill SyncQueue body)
+
+# Then T004, T005, T006, T007 sequentially (all touch daemon.ts or installer-macos.ts)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP: User Story 1 Only (Clean Shutdown)
+
+1. Complete Phase 1: Setup (T001–T002)
+2. Complete Phase 2: Foundational (T003–T010)
+3. Complete Phase 3: US1 (T011–T017)
+4. **STOP and VALIDATE**: `bun test`, `bun run typecheck`, quickstart.md Scenario 5 (socket cleanup)
+5. The daemon now shuts down cleanly — the highest-priority real-world failure is addressed
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → Foundation ready
+2. Phase 3 (US1) → Clean shutdown ✓ — validate independently
+3. Phase 4 (US2) → Visible errors ✓ — validate independently
+4. Phase 5 (US3) → Auto-recovery ✓ — validate independently
+5. Phase 6 (US4) → Install reliability ✓ — validate independently (includes the confirmed Bug 1/2/3 fixes)
+6. Phase 7 → Polish, full CI gate, live macOS scenarios
+
+---
+
+## Notes
+
+- `[P]` tasks have no dependencies on incomplete sibling tasks and touch different files
+- `[Story]` label maps each task to the user story it serves for traceability to spec.md
+- US4 (installer bugs) fixes are partially in Phase 2 (signature change, plist format) and partially in Phase 6 (registration check, error surfacing) — this split ensures TypeScript compiles throughout
+- Constitution Principle II requires tests to fail before implementation; `bun run typecheck` must be clean after every Foundational task
+- Commit after each phase checkpoint; use `fix:` prefix for bug-fix commits and `feat:` for new capability commits per Conventional Commits
+- **Remediation additions** (from `/speckit-analyze` findings): T004a (C3 — `getExecutableArgs` tests), T005a (I1 — `PlatformInstaller.isRegistered()` interface), T010a/T010b (C2 — second-instance detection), T034a/T034b/T041a (C1 — startup validation for FR-006/FR-007); T021/T022 updated for U1 (operation type in failure log); spec.md FR-014/FR-015 reordered to fix I2

--- a/specs/20260406-094347-stabilise-daemon/tasks.md
+++ b/specs/20260406-094347-stabilise-daemon/tasks.md
@@ -232,6 +232,50 @@ T010  →  src/core/sync-queue.ts         (fill SyncQueue body)
 4. Phase 5 (US3) → Auto-recovery ✓ — validate independently
 5. Phase 6 (US4) → Install reliability ✓ — validate independently (includes the confirmed Bug 1/2/3 fixes)
 6. Phase 7 → Polish, full CI gate, live macOS scenarios
+7. Phase 8 → PR review fixes (argument escaping, shutdown race, AbortController, test improvements)
+
+---
+
+## Phase 8: PR Review Fixes (CodeRabbit PR #16 Review)
+
+**Purpose**: Address valid findings from automated code review on PR #16. Fixes cover shutdown race condition, argument escaping for service managers, child process timeout handling, and test improvements.
+
+**Source**: CodeRabbit review comments on `chrisleekr/agentsync#16` (2026-04-06)
+
+### Fix 1: CLAUDE.md commands (documentation)
+
+- [x] T056 [P] Fix `CLAUDE.md` line 18 — replace `npm test && npm run lint` with `bun run check` to match actual `package.json` scripts
+
+### Fix 2: SyncQueue shutdown race (US1 — clean shutdown)
+
+- [x] T058 [US1] Update `src/core/__tests__/sync-queue.test.ts` — add tests for `close()` rejecting new enqueues and `whenIdle()` still resolving after close (TDD: write tests first)
+- [x] T057 [US1] Add `accepting` flag and `close()` method with JSDoc to `SyncQueue` in `src/core/sync-queue.ts` — `enqueue()` rejects when `accepting` is false
+- [x] T059 [US1] Update shutdown sequence in `src/daemon/index.ts` — call `queue.close()` after `ipc.close()` and before `queue.whenIdle()`; add `.catch()` to watcher/interval `enqueue()` calls to handle post-close rejections
+
+### Fix 3: Service manager argument escaping (US4 — installer reliability)
+
+- [x] T063 [P] [US4] Update `src/daemon/__tests__/installer-linux.test.ts` — add test for `buildUnit()` with args containing spaces (TDD: write test first)
+- [x] T064 [P] [US4] Update `src/daemon/__tests__/installer-macos.test.ts` — add test for `buildPlist()` with args containing `&` and `<` characters (TDD: write test first)
+- [x] T065 [P] [US4] Update `src/daemon/__tests__/installer-windows.test.ts` — add test for `buildXml()` with args containing spaces (TDD: write test first)
+- [x] T060 [P] [US4] Add `quoteSystemdArg()` to `src/daemon/installer-linux.ts` — wrap each ExecStart arg in double quotes with C-style escaping per `systemd.syntax(7)`; update misleading comment at line 22
+- [x] T061 [P] [US4] Add `escapeXml()` to `src/daemon/installer-macos.ts` — escape `&`, `<`, `>` in plist `<string>` values within `buildPlist()`
+- [x] T062 [P] [US4] Quote arguments with spaces in `buildXml()` in `src/daemon/installer-windows.ts` — wrap args containing whitespace in double quotes (with `\"` escaping for internal quotes) before XML-escaping
+
+### Fix 4: AbortController for child process timeout (US4 — installer reliability)
+
+- [x] T066 [US4] Replace `Promise.race` with `AbortController` + `signal` in `startMacOs()` in `src/daemon/installer-macos.ts` — properly cancel child process on timeout and clear timer on success
+- [x] T067 [US4] Replace `Promise.race` with `AbortController` + `signal` in `startLinux()` in `src/daemon/installer-linux.ts`
+- [x] T068 [US4] Replace `Promise.race` with `AbortController` + `signal` in `startWindows()` in `src/daemon/installer-windows.ts`
+- [x] T069 [P] [US4] Update `src/daemon/__tests__/installer-macos.test.ts` — verify `startMacOs()` passes `signal` option to `execFileAsync`
+- [x] T070 [P] [US4] Update `src/daemon/__tests__/installer-linux.test.ts` — verify `startLinux()` passes `signal` option to `execFileAsync`
+- [x] T071 [P] [US4] Update `src/daemon/__tests__/installer-windows.test.ts` — verify `startWindows()` passes `signal` option to `execFileAsync`
+
+### Fix 5: Test improvements (cross-cutting)
+
+- [x] T072 [P] Add `isRegisteredWindows: mockIsRegistered` to Windows mock in `src/commands/__tests__/daemon.test.ts` line 98–104
+- [x] T073 [P] Replace `expect(signalHandlers.has("SIGTERM")).toBe(true)` with `expect(exitCode).toBeNull()` in `src/daemon/__tests__/index.test.ts` retry logic test (line 368)
+
+**Checkpoint**: All PR review findings addressed. Run `bun run check` to validate.
 
 ---
 

--- a/specs/20260406-094347-stabilise-daemon/tasks.md
+++ b/specs/20260406-094347-stabilise-daemon/tasks.md
@@ -19,8 +19,8 @@
 
 **Purpose**: Create new source files and test files so that all later tasks have a concrete target to fill in. Start with empty/stub implementations so TypeScript compiles from the beginning.
 
-- [ ] T001 Create stub `src/core/sync-queue.ts` exporting an empty `SyncQueue` class with `enqueue` and `whenIdle` method signatures
-- [ ] T002 Create stub `src/core/__tests__/sync-queue.test.ts` with a `describe("SyncQueue")` block and a single failing placeholder test
+- [x] T001 Create stub `src/core/sync-queue.ts` exporting an empty `SyncQueue` class with `enqueue` and `whenIdle` method signatures
+- [x] T002 Create stub `src/core/__tests__/sync-queue.test.ts` with a `describe("SyncQueue")` block and a single failing placeholder test
 
 ---
 
@@ -30,18 +30,18 @@
 
 **⚠️ CRITICAL**: The `getExecutableArgs(): string[]` rename and installer `install(args: string[])` signature change are breaking — all call sites and tests must compile before Phase 3 can start.
 
-- [ ] T003 Add `DaemonStatusSchema` and `DaemonStatus` type to `src/config/schema.ts` using Zod: fields `pid` (positive int), `consecutiveFailures` (non-negative int), `lastError` (string or null)
-- [ ] T004 Rename `getExecutablePath(): string` to `getExecutableArgs(): string[]` in `src/commands/daemon.ts`; implement ephemeral-path detection using `os.tmpdir()` comparison and `bunx-` guard; throw with "Install the package globally first: `bun install -g @chrisleekr/agentsync`" if the script path is in a temp directory
-- [ ] T004a ⚠️ Write tests in `src/commands/__tests__/daemon.test.ts` for `getExecutableArgs()`: (1) when `process.argv[0]` does not end with `bun`/`bun.exe`, returns single-element array containing `process.execPath`; (2) when running as bun with a non-ephemeral script path, returns `[process.argv[0], process.argv[1]]`; (3) when the script path is inside `os.tmpdir()` or contains `bunx-`, throws an `Error` whose message includes "Install the package globally first" — verifies Constitution Principle II coverage for the new ephemeral-path branch (C3)
-- [ ] T005 Update `PlatformInstaller` interface in `src/commands/daemon.ts`: change `install(exe: string)` to `install(args: string[])`; update the `install` subcommand to call `getExecutableArgs()` and pass the result to `installer.install(args)`
-- [ ] T005a Extend `PlatformInstaller` interface in `src/commands/daemon.ts` to add `isRegistered(): Promise<boolean>`; add stub implementations that return `Promise.resolve(false)` in `installer-macos.ts`, `installer-linux.ts`, and `installer-windows.ts` so TypeScript compiles; the real implementations will replace the stubs in T035 (macOS), T039 (Linux), and the existing `isInstalledWindows` alias in T041 — resolves I1 (T042 references this method but no prior task defined it)
-- [ ] T006 Update `buildPlist` signature to `buildPlist(args: string[], logDir: string)` in `src/daemon/installer-macos.ts`; emit one `<string>` XML element per entry in `[...args, "daemon", "_run"]` (fixes Bug 1 — confirmed root cause of `EX_CONFIG 78`)
-- [ ] T007 Update `installMacOs(args: string[])` signature in `src/daemon/installer-macos.ts`; add bootout step before writing plist: call `launchctl bootout gui/<uid> <PLIST_PATH>` and swallow errors (fixes Bug 3 — idempotent re-install)
-- [ ] T008 [P] Update `buildUnit` signature to `buildUnit(args: string[])` and `installLinux(args: string[])` in `src/daemon/installer-linux.ts`; construct `ExecStart` as `[...args, "daemon", "_run"].join(" ")` (systemd tokenises correctly; this is for interface consistency)
-- [ ] T009 [P] Update `buildXml` signature to `buildXml(args: string[])` and `installWindows(args: string[])` in `src/daemon/installer-windows.ts`; put `args[0]` in `<Command>` and join `[...args.slice(1), "daemon", "_run"]` into `<Arguments>` (fixes Bug 1 for Windows)
-- [ ] T010 Implement the full `SyncQueue` class body in `src/core/sync-queue.ts`: `tail: Promise<void>` chain, `enqueue<T>(fn: () => Promise<T>): Promise<T>`, and `whenIdle(): Promise<void>` returning the current tail
-- [ ] T010a ⚠️ Write test in `src/daemon/__tests__/index.test.ts`: when `startDaemon()` is called and a running daemon is already listening on the socket path, the startup code attempts an IPC health-ping and receives a valid response; it then logs a message containing "already running" and calls `process.exit(1)` without disrupting the running daemon — covers FR-009 and SC-005 (C2)
-- [ ] T010b Implement second-instance detection in `src/daemon/index.ts`: at the top of the startup sequence, before calling `ipc.listen()`, attempt a `status` command via `IpcClient` on the existing socket path; if a valid response is received, log `"Daemon is already running (pid: X)"` and call `process.exit(1)`; if `ECONNREFUSED` is caught (stale socket — file exists but no server), call `unlink(socketPath)` to remove it before proceeding to `ipc.listen()` (satisfies FR-003); if `ENOENT` is caught (no socket file), continue directly — this is the clean-start path
+- [x] T003 Add `DaemonStatusSchema` and `DaemonStatus` type to `src/config/schema.ts` using Zod: fields `pid` (positive int), `consecutiveFailures` (non-negative int), `lastError` (string or null)
+- [x] T004 Rename `getExecutablePath(): string` to `getExecutableArgs(): string[]` in `src/commands/daemon.ts`; implement ephemeral-path detection using `os.tmpdir()` comparison and `bunx-` guard; throw with "Install the package globally first: `bun install -g @chrisleekr/agentsync`" if the script path is in a temp directory
+- [x] T004a ⚠️ Write tests in `src/commands/__tests__/daemon.test.ts` for `getExecutableArgs()`: (1) when `process.argv[0]` does not end with `bun`/`bun.exe`, returns single-element array containing `process.execPath`; (2) when running as bun with a non-ephemeral script path, returns `[process.argv[0], process.argv[1]]`; (3) when the script path is inside `os.tmpdir()` or contains `bunx-`, throws an `Error` whose message includes "Install the package globally first" — verifies Constitution Principle II coverage for the new ephemeral-path branch (C3)
+- [x] T005 Update `PlatformInstaller` interface in `src/commands/daemon.ts`: change `install(exe: string)` to `install(args: string[])`; update the `install` subcommand to call `getExecutableArgs()` and pass the result to `installer.install(args)`
+- [x] T005a Extend `PlatformInstaller` interface in `src/commands/daemon.ts` to add `isRegistered(): Promise<boolean>`; add stub implementations that return `Promise.resolve(false)` in `installer-macos.ts`, `installer-linux.ts`, and `installer-windows.ts` so TypeScript compiles; the real implementations will replace the stubs in T035 (macOS), T039 (Linux), and the existing `isInstalledWindows` alias in T041 — resolves I1 (T042 references this method but no prior task defined it)
+- [x] T006 Update `buildPlist` signature to `buildPlist(args: string[], logDir: string)` in `src/daemon/installer-macos.ts`; emit one `<string>` XML element per entry in `[...args, "daemon", "_run"]` (fixes Bug 1 — confirmed root cause of `EX_CONFIG 78`)
+- [x] T007 Update `installMacOs(args: string[])` signature in `src/daemon/installer-macos.ts`; add bootout step before writing plist: call `launchctl bootout gui/<uid> <PLIST_PATH>` and swallow errors (fixes Bug 3 — idempotent re-install)
+- [x] T008 [P] Update `buildUnit` signature to `buildUnit(args: string[])` and `installLinux(args: string[])` in `src/daemon/installer-linux.ts`; construct `ExecStart` as `[...args, "daemon", "_run"].join(" ")` (systemd tokenises correctly; this is for interface consistency)
+- [x] T009 [P] Update `buildXml` signature to `buildXml(args: string[])` and `installWindows(args: string[])` in `src/daemon/installer-windows.ts`; put `args[0]` in `<Command>` and join `[...args.slice(1), "daemon", "_run"]` into `<Arguments>` (fixes Bug 1 for Windows)
+- [x] T010 Implement the full `SyncQueue` class body in `src/core/sync-queue.ts`: `tail: Promise<void>` chain, `enqueue<T>(fn: () => Promise<T>): Promise<T>`, and `whenIdle(): Promise<void>` returning the current tail
+- [x] T010a ⚠️ Write test in `src/daemon/__tests__/index.test.ts`: when `startDaemon()` is called and a running daemon is already listening on the socket path, the startup code attempts an IPC health-ping and receives a valid response; it then logs a message containing "already running" and calls `process.exit(1)` without disrupting the running daemon — covers FR-009 and SC-005 (C2)
+- [x] T010b Implement second-instance detection in `src/daemon/index.ts`: at the top of the startup sequence, before calling `ipc.listen()`, attempt a `status` command via `IpcClient` on the existing socket path; if a valid response is received, log `"Daemon is already running (pid: X)"` and call `process.exit(1)`; if `ECONNREFUSED` is caught (stale socket — file exists but no server), call `unlink(socketPath)` to remove it before proceeding to `ipc.listen()` (satisfies FR-003); if `ENOENT` is caught (no socket file), continue directly — this is the clean-start path
 
 **Checkpoint**: `bun run typecheck` must pass with zero errors before proceeding to Phase 3.
 
@@ -55,16 +55,16 @@
 
 ### Tests for User Story 1 ⚠️ Write first — verify they FAIL before implementation
 
-- [ ] T011 [US1] Write test in `src/daemon/__tests__/index.test.ts`: given SIGTERM received while queue is busy, `ipc.close()` is called before `process.exit(0)`
-- [ ] T012 [US1] Write test in `src/daemon/__tests__/index.test.ts`: given SIGTERM received, the IPC socket path is unlinked (spy on `unlink`) before `process.exit(0)`
-- [ ] T013 [US1] Write test in `src/core/__tests__/sync-queue.test.ts`: two enqueued operations run serially (second starts only after first resolves)
-- [ ] T014 [US1] Write test in `src/core/__tests__/sync-queue.test.ts`: `whenIdle()` resolves only after all enqueued work settles
+- [x] T011 [US1] Write test in `src/daemon/__tests__/index.test.ts`: given SIGTERM received while queue is busy, `ipc.close()` is called before `process.exit(0)`
+- [x] T012 [US1] Write test in `src/daemon/__tests__/index.test.ts`: given SIGTERM received, the IPC socket path is unlinked (spy on `unlink`) before `process.exit(0)`
+- [x] T013 [US1] Write test in `src/core/__tests__/sync-queue.test.ts`: two enqueued operations run serially (second starts only after first resolves)
+- [x] T014 [US1] Write test in `src/core/__tests__/sync-queue.test.ts`: `whenIdle()` resolves only after all enqueued work settles
 
 ### Implementation for User Story 1
 
-- [ ] T015 [US1] Integrate `SyncQueue` into `src/daemon/index.ts`: import `SyncQueue`, create a module-level `queue` instance, wrap every `performPush()` and `runPull()` call so they are enqueued rather than called directly
-- [ ] T016 [US1] Update the `shutdown` function in `src/daemon/index.ts`: (1) call `ipc.close()`; (2) await `Promise.race([queue.whenIdle(), delay(10_000)])`; (3) await `watcher.close()`; (4) call `unlink(socketPath)` and swallow ENOENT; (5) then call `process.exit(0)`
-- [ ] T017 [US1] Update the existing shutdown test in `src/daemon/__tests__/index.test.ts` to confirm `watcherClosed`, `clearedIntervalToken`, IPC close, and socket unlink all occur before `exitCode === 0`
+- [x] T015 [US1] Integrate `SyncQueue` into `src/daemon/index.ts`: import `SyncQueue`, create a module-level `queue` instance, wrap every `performPush()` and `runPull()` call so they are enqueued rather than called directly
+- [x] T016 [US1] Update the `shutdown` function in `src/daemon/index.ts`: (1) call `ipc.close()`; (2) await `Promise.race([queue.whenIdle(), delay(10_000)])`; (3) await `watcher.close()`; (4) call `unlink(socketPath)` and swallow ENOENT; (5) then call `process.exit(0)`
+- [x] T017 [US1] Update the existing shutdown test in `src/daemon/__tests__/index.test.ts` to confirm `watcherClosed`, `clearedIntervalToken`, IPC close, and socket unlink all occur before `exitCode === 0`
 
 **Checkpoint**: `bun test src/daemon/__tests__/index.test.ts` and `bun test src/core/__tests__/sync-queue.test.ts` pass. `bun run typecheck` clean.
 
@@ -78,16 +78,16 @@
 
 ### Tests for User Story 2 ⚠️ Write first — verify they FAIL before implementation
 
-- [ ] T018 [US2] Write test in `src/daemon/__tests__/index.test.ts`: after a failed pull, `consecutiveFailures` increments to 1 and `lastError` is non-null
-- [ ] T019 [US2] Write test in `src/daemon/__tests__/index.test.ts`: after a successful pull following a failure, `consecutiveFailures` resets to 0 and `lastError` is null
-- [ ] T020 [US2] Write test in `src/daemon/__tests__/index.test.ts`: `status` IPC handler returns an object matching `DaemonStatusSchema` with current `consecutiveFailures` and `lastError`
+- [x] T018 [US2] Write test in `src/daemon/__tests__/index.test.ts`: after a failed pull, `consecutiveFailures` increments to 1 and `lastError` is non-null
+- [x] T019 [US2] Write test in `src/daemon/__tests__/index.test.ts`: after a successful pull following a failure, `consecutiveFailures` resets to 0 and `lastError` is null
+- [x] T020 [US2] Write test in `src/daemon/__tests__/index.test.ts`: `status` IPC handler returns an object matching `DaemonStatusSchema` with current `consecutiveFailures` and `lastError`
 
 ### Implementation for User Story 2
 
-- [ ] T021 [US2] Add module-level failure state to `src/daemon/index.ts`: `let consecutiveFailures = 0; let lastError: string | null = null;` and helper functions `recordSuccess()` (resets both) and `recordFailure(op: "push" | "pull", msg: string)` (increments count, sets `lastError` to `"[push] msg"` or `"[pull] msg"` so that the operation type is always present in the stored error per FR-004 — U1 fix)
-- [ ] T022 [US2] Update the queued push/pull wrappers in `src/daemon/index.ts` to call `recordSuccess()` when the operation completes without a fatal error; call `recordFailure("push", msg)` in the push wrapper and `recordFailure("pull", msg)` in the pull wrapper when either fails or returns `fatal: true`; the literal string `"push"` or `"pull"` is chosen at the call site, never inferred inside `recordFailure`
-- [ ] T023 [US2] Update the `status` IPC handler in `src/daemon/index.ts` to return `DaemonStatusSchema.parse({ pid: process.pid, consecutiveFailures, lastError })`
-- [ ] T024 [P] [US2] Update `daemon status` display in `src/commands/daemon.ts`: on success, print pid plus failure count and last error if `consecutiveFailures > 0`
+- [x] T021 [US2] Add module-level failure state to `src/daemon/index.ts`: `let consecutiveFailures = 0; let lastError: string | null = null;` and helper functions `recordSuccess()` (resets both) and `recordFailure(op: "push" | "pull", msg: string)` (increments count, sets `lastError` to `"[push] msg"` or `"[pull] msg"` so that the operation type is always present in the stored error per FR-004 — U1 fix)
+- [x] T022 [US2] Update the queued push/pull wrappers in `src/daemon/index.ts` to call `recordSuccess()` when the operation completes without a fatal error; call `recordFailure("push", msg)` in the push wrapper and `recordFailure("pull", msg)` in the pull wrapper when either fails or returns `fatal: true`; the literal string `"push"` or `"pull"` is chosen at the call site, never inferred inside `recordFailure`
+- [x] T023 [US2] Update the `status` IPC handler in `src/daemon/index.ts` to return `DaemonStatusSchema.parse({ pid: process.pid, consecutiveFailures, lastError })`
+- [x] T024 [P] [US2] Update `daemon status` display in `src/commands/daemon.ts`: on success, print pid plus failure count and last error if `consecutiveFailures > 0`
 
 **Checkpoint**: Status IPC now carries failure data. `bun test src/daemon/__tests__/index.test.ts` passes.
 
@@ -101,13 +101,13 @@
 
 ### Tests for User Story 3 ⚠️ Write first — verify they FAIL before implementation
 
-- [ ] T025 [US3] Write test in `src/daemon/__tests__/index.test.ts`: when a push fails on first attempt but succeeds on second, the operation is called exactly twice and `consecutiveFailures` stays at 0
-- [ ] T026 [US3] Write test in `src/daemon/__tests__/index.test.ts`: when both the initial attempt and retry fail, `consecutiveFailures` increments to 1 (not 2); also assert that `process.exit` is NOT called — the daemon must remain alive for the next scheduled trigger (verifies SC-004: daemon survives consecutive failures without exiting)
+- [x] T025 [US3] Write test in `src/daemon/__tests__/index.test.ts`: when a push fails on first attempt but succeeds on second, the operation is called exactly twice and `consecutiveFailures` stays at 0
+- [x] T026 [US3] Write test in `src/daemon/__tests__/index.test.ts`: when both the initial attempt and retry fail, `consecutiveFailures` increments to 1 (not 2); also assert that `process.exit` is NOT called — the daemon must remain alive for the next scheduled trigger (verifies SC-004: daemon survives consecutive failures without exiting)
 
 ### Implementation for User Story 3
 
-- [ ] T027 [US3] Add `withRetry<T>(fn: () => Promise<T>): Promise<T>` helper to `src/daemon/index.ts`: calls `fn()` once; on failure calls `fn()` again and lets the second result propagate
-- [ ] T028 [US3] Wrap every `performPush()` and `runPull()` call inside the queue enqueue callback with `withRetry(...)` in `src/daemon/index.ts`
+- [x] T027 [US3] Add `withRetry<T>(fn: () => Promise<T>): Promise<T>` helper to `src/daemon/index.ts`: calls `fn()` once; on failure calls `fn()` again and lets the second result propagate
+- [x] T028 [US3] Wrap every `performPush()` and `runPull()` call inside the queue enqueue callback with `withRetry(...)` in `src/daemon/index.ts`
 
 **Checkpoint**: Retry behaviour verified. `bun test src/daemon/__tests__/index.test.ts` all green.
 
@@ -121,29 +121,29 @@
 
 ### Tests for User Story 4 ⚠️ Write first — verify they FAIL before implementation
 
-- [ ] T029 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: `buildPlist(["bun", "/path/cli.js"], logDir)` produces a plist where `<ProgramArguments>` contains separate `<string>bun</string>` and `<string>/path/cli.js</string>` entries (not one combined string)
-- [ ] T030 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: `installMacOs(args)` calls `launchctl bootout` before `launchctl bootstrap` (verify call order via mock)
-- [ ] T031 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: when `launchctl bootstrap` rejects, `installMacOs` throws an `Error` whose message contains the service manager stderr but not an internal stack trace
-- [ ] T032 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: `startMacOs()` throws immediately with "Service not bootstrapped" message when `isRegisteredMacOs()` returns false (no kickstart call made)
-- [ ] T033 [P] [US4] Write test in `src/daemon/__tests__/installer-windows.test.ts`: `buildXml(["bun", "/path/cli.js"])` produces XML where `<Command>` holds only `bun` (escaped) and `<Arguments>` holds `/path/cli.js daemon _run`
-- [ ] T034 [P] [US4] Write test in `src/daemon/__tests__/installer-linux.test.ts`: `buildUnit(["bun", "/path/cli.js"])` produces a unit file where `ExecStart=bun /path/cli.js daemon _run`
-- [ ] T034a [P] [US4] Write test in `src/daemon/__tests__/index.test.ts`: when `startDaemon()` is called with a mock that throws "vault directory not found" during config/vault load, the process calls `process.exit(1)` and the log output contains "vault" — covers FR-006 and SC-006 (C1)
-- [ ] T034b [P] [US4] Write test in `src/daemon/__tests__/index.test.ts`: when `startDaemon()` is called with a mock that throws "key file not found" or "permission denied" during encryption key load, the process calls `process.exit(1)` and the log output identifies the key issue — covers FR-007 and SC-006 (C1)
+- [x] T029 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: `buildPlist(["bun", "/path/cli.js"], logDir)` produces a plist where `<ProgramArguments>` contains separate `<string>bun</string>` and `<string>/path/cli.js</string>` entries (not one combined string)
+- [x] T030 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: `installMacOs(args)` calls `launchctl bootout` before `launchctl bootstrap` (verify call order via mock)
+- [x] T031 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: when `launchctl bootstrap` rejects, `installMacOs` throws an `Error` whose message contains the service manager stderr but not an internal stack trace
+- [x] T032 [P] [US4] Write test in `src/daemon/__tests__/installer-macos.test.ts`: `startMacOs()` throws immediately with "Service not bootstrapped" message when `isRegisteredMacOs()` returns false (no kickstart call made)
+- [x] T033 [P] [US4] Write test in `src/daemon/__tests__/installer-windows.test.ts`: `buildXml(["bun", "/path/cli.js"])` produces XML where `<Command>` holds only `bun` (escaped) and `<Arguments>` holds `/path/cli.js daemon _run`
+- [x] T034 [P] [US4] Write test in `src/daemon/__tests__/installer-linux.test.ts`: `buildUnit(["bun", "/path/cli.js"])` produces a unit file where `ExecStart=bun /path/cli.js daemon _run`
+- [x] T034a [P] [US4] Write test in `src/daemon/__tests__/index.test.ts`: when `startDaemon()` is called with a mock that throws "vault directory not found" during config/vault load, the process calls `process.exit(1)` and the log output contains "vault" — covers FR-006 and SC-006 (C1)
+- [x] T034b [P] [US4] Write test in `src/daemon/__tests__/index.test.ts`: when `startDaemon()` is called with a mock that throws "key file not found" or "permission denied" during encryption key load, the process calls `process.exit(1)` and the log output identifies the key issue — covers FR-007 and SC-006 (C1)
 
 ### Implementation for User Story 4
 
-- [ ] T035 [US4] Add `isRegisteredMacOs(): Promise<boolean>` to `src/daemon/installer-macos.ts`: runs `launchctl print gui/<uid>/com.agentsync.daemon`; returns `true` on exit 0, `false` otherwise
-- [ ] T036 [US4] Add `extractServiceManagerError(err: unknown): string` helper to `src/daemon/installer-macos.ts`: reads `stderr` property from the error object and returns it; falls back to `String(err)` if absent
-- [ ] T037 [US4] Update `installMacOs` in `src/daemon/installer-macos.ts` to wrap `launchctl bootstrap` in try/catch and re-throw with `extractServiceManagerError` output + a platform hint (no stack trace)
-- [ ] T038 [US4] Update `startMacOs()` in `src/daemon/installer-macos.ts`: call `isRegisteredMacOs()` first; throw "Service not bootstrapped — run `agentsync daemon install` first." if false; wrap `kickstart` in `Promise.race` with a 10-second timeout that throws "Service manager start timed out."
-- [ ] T039 [US4] Add `isRegisteredLinux(): Promise<boolean>` to `src/daemon/installer-linux.ts`: runs `systemctl --user is-enabled agentsync`; returns `true` only when stdout is `enabled`
-- [ ] T040 [US4] Update `startLinux()` in `src/daemon/installer-linux.ts`: call `isRegisteredLinux()` first with same guard pattern as macOS; wrap `systemctl --user start` in 10-second timeout
-- [ ] T041 [US4] Update `startWindows()` in `src/daemon/installer-windows.ts`: use `isInstalledWindows()` as the registration check; wrap `schtasks /Run` in 10-second timeout
-- [ ] T041a [US4] Add startup validation to `startDaemon()` in `src/daemon/index.ts`: at the top of the function, wrap the vault directory existence check and encryption key load in a try-catch; on failure, log `"Startup failed: <specific resource> — <actionable hint>"` and call `process.exit(1)`; the exit must occur within 3 seconds to satisfy SC-006 — this fills the FR-006 and FR-007 coverage gap (C1)
-- [ ] T042 [US4] Update `daemon start` subcommand in `src/commands/daemon.ts`: replace `installer.isInstalled()` check with the new `isRegistered()` method defined in the `PlatformInstaller` interface (added by T005a); the error message must include "run `agentsync daemon install` first"
-- [ ] T043 [P] [US4] Update existing tests in `src/daemon/__tests__/installer-macos.test.ts` for the new `string[]` parameter signature (all `installMacOs`, `buildPlist` call sites)
-- [ ] T044 [P] [US4] Update existing tests in `src/daemon/__tests__/installer-linux.test.ts` for the new `string[]` parameter signature
-- [ ] T045 [P] [US4] Update existing tests in `src/daemon/__tests__/installer-windows.test.ts` for the new `string[]` parameter signature
+- [x] T035 [US4] Add `isRegisteredMacOs(): Promise<boolean>` to `src/daemon/installer-macos.ts`: runs `launchctl print gui/<uid>/com.agentsync.daemon`; returns `true` on exit 0, `false` otherwise
+- [x] T036 [US4] Add `extractServiceManagerError(err: unknown): string` helper to `src/daemon/installer-macos.ts`: reads `stderr` property from the error object and returns it; falls back to `String(err)` if absent
+- [x] T037 [US4] Update `installMacOs` in `src/daemon/installer-macos.ts` to wrap `launchctl bootstrap` in try/catch and re-throw with `extractServiceManagerError` output + a platform hint (no stack trace)
+- [x] T038 [US4] Update `startMacOs()` in `src/daemon/installer-macos.ts`: call `isRegisteredMacOs()` first; throw "Service not bootstrapped — run `agentsync daemon install` first." if false; wrap `kickstart` in `Promise.race` with a 10-second timeout that throws "Service manager start timed out."
+- [x] T039 [US4] Add `isRegisteredLinux(): Promise<boolean>` to `src/daemon/installer-linux.ts`: runs `systemctl --user is-enabled agentsync`; returns `true` only when stdout is `enabled`
+- [x] T040 [US4] Update `startLinux()` in `src/daemon/installer-linux.ts`: call `isRegisteredLinux()` first with same guard pattern as macOS; wrap `systemctl --user start` in 10-second timeout
+- [x] T041 [US4] Update `startWindows()` in `src/daemon/installer-windows.ts`: use `isInstalledWindows()` as the registration check; wrap `schtasks /Run` in 10-second timeout
+- [x] T041a [US4] Add startup validation to `startDaemon()` in `src/daemon/index.ts`: at the top of the function, wrap the vault directory existence check and encryption key load in a try-catch; on failure, log `"Startup failed: <specific resource> — <actionable hint>"` and call `process.exit(1)`; the exit must occur within 3 seconds to satisfy SC-006 — this fills the FR-006 and FR-007 coverage gap (C1)
+- [x] T042 [US4] Update `daemon start` subcommand in `src/commands/daemon.ts`: replace `installer.isInstalled()` check with the new `isRegistered()` method defined in the `PlatformInstaller` interface (added by T005a); the error message must include "run `agentsync daemon install` first"
+- [x] T043 [P] [US4] Update existing tests in `src/daemon/__tests__/installer-macos.test.ts` for the new `string[]` parameter signature (all `installMacOs`, `buildPlist` call sites)
+- [x] T044 [P] [US4] Update existing tests in `src/daemon/__tests__/installer-linux.test.ts` for the new `string[]` parameter signature
+- [x] T045 [P] [US4] Update existing tests in `src/daemon/__tests__/installer-windows.test.ts` for the new `string[]` parameter signature
 
 **Checkpoint**: All four user stories independently functional. `bun test` passes across all modified test files.
 
@@ -153,10 +153,10 @@
 
 **Purpose**: Documentation, diagram validation, full CI gate, and live integration validation.
 
-- [ ] T046 [P] Create `docs/daemon.md` with a GitHub-compatible Mermaid stateDiagram-v2 covering all lifecycle states: Starting → Running → Syncing → Running (success) / Error (retry) → Running, and Running → ShuttingDown → Stopped; use high-contrast hex colour pairs per CLAUDE.md diagram rules
-- [ ] T047 [P] Add JSDoc comments to all new and modified exported symbols per Constitution Principle V: `SyncQueue`, `getExecutableArgs`, `isRegisteredMacOs`, `isRegisteredLinux`, `DaemonStatusSchema`, `withRetry`, `recordSuccess`, `recordFailure` (new); `installMacOs`, `buildPlist`, `installLinux`, `buildUnit`, `installWindows`, `buildXml` (signature-changed — existing JSDoc must be updated to reflect the new `args: string[]` parameter)
-- [ ] T048 Validate the Mermaid diagram in `docs/daemon.md` renders correctly in GitHub Markdown preview (open PR draft or use local renderer — required blocker per quickstart.md Scenario 8)
-- [ ] T049 Run `bun run check` (typecheck + biome lint + full test suite) and confirm zero errors
+- [x] T046 [P] Create `docs/daemon.md` with a GitHub-compatible Mermaid stateDiagram-v2 covering all lifecycle states: Starting → Running → Syncing → Running (success) / Error (retry) → Running, and Running → ShuttingDown → Stopped; use high-contrast hex colour pairs per CLAUDE.md diagram rules
+- [x] T047 [P] Add JSDoc comments to all new and modified exported symbols per Constitution Principle V: `SyncQueue`, `getExecutableArgs`, `isRegisteredMacOs`, `isRegisteredLinux`, `DaemonStatusSchema`, `withRetry`, `recordSuccess`, `recordFailure` (new); `installMacOs`, `buildPlist`, `installLinux`, `buildUnit`, `installWindows`, `buildXml` (signature-changed — existing JSDoc must be updated to reflect the new `args: string[]` parameter)
+- [x] T048 Validate the Mermaid diagram in `docs/daemon.md` renders correctly in GitHub Markdown preview (open PR draft or use local renderer — required blocker per quickstart.md Scenario 8)
+- [x] T049 Run `bun run check` (typecheck + biome lint + full test suite) and confirm zero errors
 - [ ] T050 Execute quickstart.md Scenario 1 on macOS host: fresh global install → `daemon install` → `daemon status` shows running with `consecutiveFailures: 0`
 - [ ] T051 Execute quickstart.md Scenario 2: run `daemon install` a second time → expect success, no "Bootstrap failed: 5" error
 - [ ] T052 Execute quickstart.md Scenario 3: run via bunx → expect ephemeral path error, no plist written

--- a/src/commands/__tests__/daemon.test.ts
+++ b/src/commands/__tests__/daemon.test.ts
@@ -76,7 +76,7 @@ const mockStop = mock(async () => {});
 const mockIsInstalled = mock(async () => true);
 const mockIsRegistered = mock(async () => true);
 
-// Mock the macOS installer module since tests run on macOS
+// Mock all platform installer modules so tests pass on any OS
 mock.module("../../daemon/installer-macos", () => ({
   installMacOs: mockInstall,
   uninstallMacOs: mockUninstall,
@@ -84,6 +84,23 @@ mock.module("../../daemon/installer-macos", () => ({
   stopMacOs: mockStop,
   isInstalledMacOs: mockIsInstalled,
   isRegisteredMacOs: mockIsRegistered,
+}));
+
+mock.module("../../daemon/installer-linux", () => ({
+  installLinux: mockInstall,
+  uninstallLinux: mockUninstall,
+  startLinux: mockStart,
+  stopLinux: mockStop,
+  isInstalledLinux: mockIsInstalled,
+  isRegisteredLinux: mockIsRegistered,
+}));
+
+mock.module("../../daemon/installer-windows", () => ({
+  installWindows: mockInstall,
+  uninstallWindows: mockUninstall,
+  startWindows: mockStart,
+  stopWindows: mockStop,
+  isInstalledWindows: mockIsInstalled,
 }));
 
 const successLogs: string[] = [];

--- a/src/commands/__tests__/daemon.test.ts
+++ b/src/commands/__tests__/daemon.test.ts
@@ -1,23 +1,17 @@
 /**
- * T004a — Tests for getExecutableArgs() in src/commands/daemon.ts
+ * Tests for src/commands/daemon.ts
  *
- * These tests verify:
- * 1. Compiled binary path: returns single-element array with process.execPath
- * 2. Bun + non-ephemeral script: returns [argv[0], argv[1]]
- * 3. Ephemeral (bunx temp) path: throws with actionable install message
+ * Covers getExecutableArgs() and the daemon subcommands (install, start, stop, status, uninstall).
  */
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { log } from "@clack/prompts";
+import { IpcClient } from "../../core/ipc";
 
-// We test the internal function by re-exporting it. Since getExecutableArgs is not
-// currently exported, we import the module and cast to access it for testing.
-// The implementation will export it or expose it via the tested module contract.
+// ── getExecutableArgs tests ────────────────────────────────────────────────────
 
-// Store originals to restore after each test
 const originalArgv0 = process.argv[0];
 const originalArgv1 = process.argv[1];
-const originalExecPath = process.execPath;
 
-// Helper to patch process properties for duration of test
 function withArgv(argv0: string, argv1: string, fn: () => void | Promise<void>) {
   return async () => {
     Object.defineProperty(process, "argv", {
@@ -37,13 +31,10 @@ function withArgv(argv0: string, argv1: string, fn: () => void | Promise<void>) 
   };
 }
 
-// We test getExecutableArgs by importing it dynamically after patching argv.
-// The function must be exported from daemon.ts for these tests to work.
 describe("getExecutableArgs", () => {
   test(
     "returns [process.execPath] when argv[0] is not bun",
     withArgv("/usr/local/bin/agentsync", "/irrelevant/path", async () => {
-      // Clear module cache to re-evaluate with new argv
       const { getExecutableArgs } = await import("../daemon");
       const result = getExecutableArgs();
       expect(result).toEqual([process.execPath]);
@@ -52,14 +43,18 @@ describe("getExecutableArgs", () => {
 
   test(
     "returns [argv[0], argv[1]] when argv[0] ends with 'bun' and path is non-ephemeral",
-    withArgv("/home/user/.bun/bin/bun", "/home/user/.bun/install/global/node_modules/.bin/cli.js", async () => {
-      const { getExecutableArgs } = await import("../daemon");
-      const result = getExecutableArgs();
-      expect(result).toEqual([
-        "/home/user/.bun/bin/bun",
-        "/home/user/.bun/install/global/node_modules/.bin/cli.js",
-      ]);
-    }),
+    withArgv(
+      "/home/user/.bun/bin/bun",
+      "/home/user/.bun/install/global/node_modules/.bin/cli.js",
+      async () => {
+        const { getExecutableArgs } = await import("../daemon");
+        const result = getExecutableArgs();
+        expect(result).toEqual([
+          "/home/user/.bun/bin/bun",
+          "/home/user/.bun/install/global/node_modules/.bin/cli.js",
+        ]);
+      },
+    ),
   );
 
   test(
@@ -69,4 +64,170 @@ describe("getExecutableArgs", () => {
       expect(() => getExecutableArgs()).toThrow("Install the package globally first");
     }),
   );
+});
+
+// ── Daemon subcommand tests ────────────────────────────────────────────────────
+
+// Mock installer functions — we don't want to actually call launchctl/systemctl
+const mockInstall = mock(async (_args: string[]) => {});
+const mockUninstall = mock(async () => {});
+const mockStart = mock(async () => {});
+const mockStop = mock(async () => {});
+const mockIsInstalled = mock(async () => true);
+const mockIsRegistered = mock(async () => true);
+
+// Mock the macOS installer module since tests run on macOS
+mock.module("../../daemon/installer-macos", () => ({
+  installMacOs: mockInstall,
+  uninstallMacOs: mockUninstall,
+  startMacOs: mockStart,
+  stopMacOs: mockStop,
+  isInstalledMacOs: mockIsInstalled,
+  isRegisteredMacOs: mockIsRegistered,
+}));
+
+const successLogs: string[] = [];
+const errorLogs: string[] = [];
+const warnLogs: string[] = [];
+
+let successSpy: ReturnType<typeof spyOn>;
+let errorSpy: ReturnType<typeof spyOn>;
+let warnSpy: ReturnType<typeof spyOn>;
+let ipcClientSendSpy: ReturnType<typeof spyOn>;
+
+beforeAll(() => {
+  successSpy = spyOn(log, "success").mockImplementation((msg: string) => {
+    successLogs.push(msg);
+  });
+  errorSpy = spyOn(log, "error").mockImplementation((msg: string) => {
+    errorLogs.push(msg);
+  });
+  warnSpy = spyOn(log, "warn").mockImplementation((msg: string) => {
+    warnLogs.push(msg);
+  });
+  ipcClientSendSpy = spyOn(IpcClient.prototype, "send");
+});
+
+afterAll(() => {
+  successSpy.mockRestore();
+  errorSpy.mockRestore();
+  warnSpy.mockRestore();
+  ipcClientSendSpy.mockRestore();
+  mock.restore();
+});
+
+beforeEach(() => {
+  successLogs.length = 0;
+  errorLogs.length = 0;
+  warnLogs.length = 0;
+  mockInstall.mockClear();
+  mockUninstall.mockClear();
+  mockStart.mockClear();
+  mockStop.mockClear();
+  mockIsInstalled.mockClear();
+  mockIsRegistered.mockClear();
+  process.exitCode = undefined;
+});
+
+// Helper: resolve citty subcommands (may be Resolvable)
+async function getSubCmd(name: string): Promise<{ run: () => Promise<void> }> {
+  const { daemonCommand } = await import("../daemon");
+  const subs = (await daemonCommand.subCommands) as Record<
+    string,
+    { run: () => Promise<void> } | undefined
+  >;
+  const cmd = subs[name];
+  if (!cmd) throw new Error(`subcommand "${name}" not found`);
+  return cmd;
+}
+
+describe("daemonCommand subcommands", () => {
+  test("install subcommand calls installer.install with args array", async () => {
+    const cmd = await getSubCmd("install");
+    await cmd.run();
+
+    expect(mockInstall).toHaveBeenCalledTimes(1);
+    const callArgs = mockInstall.mock.calls[0][0];
+    expect(Array.isArray(callArgs)).toBe(true);
+  });
+
+  test("start subcommand calls installer.start when registered", async () => {
+    mockIsRegistered.mockResolvedValueOnce(true);
+    const cmd = await getSubCmd("start");
+    await cmd.run();
+
+    expect(mockStart).toHaveBeenCalledTimes(1);
+    expect(successLogs.some((m) => m.includes("Daemon started"))).toBe(true);
+  });
+
+  test("start subcommand errors when not registered", async () => {
+    mockIsRegistered.mockResolvedValueOnce(false);
+    const cmd = await getSubCmd("start");
+    await cmd.run();
+
+    expect(mockStart).not.toHaveBeenCalled();
+    expect(errorLogs.some((m) => m.includes("not bootstrapped"))).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("stop subcommand calls installer.stop", async () => {
+    const cmd = await getSubCmd("stop");
+    await cmd.run();
+
+    expect(mockStop).toHaveBeenCalledTimes(1);
+    expect(successLogs.some((m) => m.includes("Daemon stopped"))).toBe(true);
+  });
+
+  test("uninstall subcommand calls installer.uninstall", async () => {
+    const cmd = await getSubCmd("uninstall");
+    await cmd.run();
+
+    expect(mockUninstall).toHaveBeenCalledTimes(1);
+  });
+
+  test("status subcommand shows running daemon info", async () => {
+    ipcClientSendSpy.mockResolvedValueOnce({
+      id: "test",
+      ok: true,
+      data: { pid: 12345, consecutiveFailures: 0, lastError: null },
+    });
+    const cmd = await getSubCmd("status");
+    await cmd.run();
+
+    expect(successLogs.some((m) => m.includes("12345"))).toBe(true);
+  });
+
+  test("status subcommand shows failure info when consecutiveFailures > 0", async () => {
+    ipcClientSendSpy.mockResolvedValueOnce({
+      id: "test",
+      ok: true,
+      data: { pid: 12345, consecutiveFailures: 3, lastError: "[pull] remote not reachable" },
+    });
+    const cmd = await getSubCmd("status");
+    await cmd.run();
+
+    expect(warnLogs.some((m) => m.includes("3"))).toBe(true);
+  });
+
+  test("status subcommand shows 'not running' when IPC fails", async () => {
+    ipcClientSendSpy.mockRejectedValueOnce(new Error("ENOENT"));
+    const cmd = await getSubCmd("status");
+    await cmd.run();
+
+    expect(errorLogs.some((m) => m.includes("not running"))).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("status subcommand handles error response from daemon", async () => {
+    ipcClientSendSpy.mockResolvedValueOnce({
+      id: "test",
+      ok: false,
+      error: "internal error",
+    });
+    const cmd = await getSubCmd("status");
+    await cmd.run();
+
+    expect(errorLogs.some((m) => m.includes("internal error"))).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
 });

--- a/src/commands/__tests__/daemon.test.ts
+++ b/src/commands/__tests__/daemon.test.ts
@@ -101,6 +101,7 @@ mock.module("../../daemon/installer-windows", () => ({
   startWindows: mockStart,
   stopWindows: mockStop,
   isInstalledWindows: mockIsInstalled,
+  isRegisteredWindows: mockIsRegistered,
 }));
 
 const successLogs: string[] = [];

--- a/src/commands/__tests__/daemon.test.ts
+++ b/src/commands/__tests__/daemon.test.ts
@@ -1,0 +1,72 @@
+/**
+ * T004a — Tests for getExecutableArgs() in src/commands/daemon.ts
+ *
+ * These tests verify:
+ * 1. Compiled binary path: returns single-element array with process.execPath
+ * 2. Bun + non-ephemeral script: returns [argv[0], argv[1]]
+ * 3. Ephemeral (bunx temp) path: throws with actionable install message
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+// We test the internal function by re-exporting it. Since getExecutableArgs is not
+// currently exported, we import the module and cast to access it for testing.
+// The implementation will export it or expose it via the tested module contract.
+
+// Store originals to restore after each test
+const originalArgv0 = process.argv[0];
+const originalArgv1 = process.argv[1];
+const originalExecPath = process.execPath;
+
+// Helper to patch process properties for duration of test
+function withArgv(argv0: string, argv1: string, fn: () => void | Promise<void>) {
+  return async () => {
+    Object.defineProperty(process, "argv", {
+      value: [argv0, argv1, ...process.argv.slice(2)],
+      writable: true,
+      configurable: true,
+    });
+    try {
+      await fn();
+    } finally {
+      Object.defineProperty(process, "argv", {
+        value: [originalArgv0, originalArgv1, ...process.argv.slice(2)],
+        writable: true,
+        configurable: true,
+      });
+    }
+  };
+}
+
+// We test getExecutableArgs by importing it dynamically after patching argv.
+// The function must be exported from daemon.ts for these tests to work.
+describe("getExecutableArgs", () => {
+  test(
+    "returns [process.execPath] when argv[0] is not bun",
+    withArgv("/usr/local/bin/agentsync", "/irrelevant/path", async () => {
+      // Clear module cache to re-evaluate with new argv
+      const { getExecutableArgs } = await import("../daemon");
+      const result = getExecutableArgs();
+      expect(result).toEqual([process.execPath]);
+    }),
+  );
+
+  test(
+    "returns [argv[0], argv[1]] when argv[0] ends with 'bun' and path is non-ephemeral",
+    withArgv("/home/user/.bun/bin/bun", "/home/user/.bun/install/global/node_modules/.bin/cli.js", async () => {
+      const { getExecutableArgs } = await import("../daemon");
+      const result = getExecutableArgs();
+      expect(result).toEqual([
+        "/home/user/.bun/bin/bun",
+        "/home/user/.bun/install/global/node_modules/.bin/cli.js",
+      ]);
+    }),
+  );
+
+  test(
+    "throws with install hint when argv[1] contains 'bunx-'",
+    withArgv("/home/user/.bun/bin/bun", "/tmp/bunx-501-abc/node_modules/.bin/cli.js", async () => {
+      const { getExecutableArgs } = await import("../daemon");
+      expect(() => getExecutableArgs()).toThrow("Install the package globally first");
+    }),
+  );
+});

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -1,24 +1,57 @@
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
 import { resolveDaemonSocketPath } from "../config/paths";
+import { DaemonStatusSchema } from "../config/schema";
 import { IpcClient } from "../core/ipc";
 
-/** Resolve the executable invocation the service manager should launch on this machine. */
-function getExecutablePath(): string {
-  // When compiled: process.execPath; during dev with `bun run src/cli.ts`: reconstruct
-  if (process.argv[0].endsWith("bun") || process.argv[0].endsWith("bun.exe")) {
-    return `${process.argv[0]} ${process.argv[1]}`;
+/**
+ * Detect whether a file path resolves into a session-scoped temporary directory
+ * (created by bunx or the OS). Such paths are not stable across reboots.
+ */
+function isEphemeralPath(filePath: string): boolean {
+  try {
+    const resolved = realpathSync(filePath);
+    const tmp = realpathSync(tmpdir());
+    return resolved.startsWith(tmp) || resolved.includes("bunx-");
+  } catch {
+    return false;
   }
-  return process.execPath;
 }
 
-/** Platform-specific service hooks used by the daemon management subcommands. */
+/**
+ * Resolve the full executable invocation the service manager should use.
+ * Returns an array where each element becomes a separate `<string>` in the
+ * service definition (required by launchd and Task Scheduler).
+ * @throws {Error} when the script path is inside a temporary directory (e.g. bunx).
+ */
+export function getExecutableArgs(): string[] {
+  const isBun =
+    process.argv[0].endsWith("bun") || process.argv[0].endsWith("bun.exe");
+  if (isBun) {
+    if (isEphemeralPath(process.argv[1])) {
+      throw new Error(
+        "Executable is in a temporary directory. " +
+          "Install the package globally first: bun install -g @chrisleekr/agentsync",
+      );
+    }
+    return [process.argv[0], process.argv[1]];
+  }
+  return [process.execPath];
+}
+
+/**
+ * Platform-specific service hooks used by the daemon management subcommands.
+ * Each method maps to the corresponding OS service manager operation.
+ */
 interface PlatformInstaller {
-  install(exe: string): Promise<void>;
+  install(args: string[]): Promise<void>;
   uninstall(): Promise<void>;
   start(): Promise<void>;
   stop(): Promise<void>;
   isInstalled(): Promise<boolean>;
+  isRegistered(): Promise<boolean>;
 }
 
 /** Load the installer implementation that matches the current operating system. */
@@ -32,6 +65,7 @@ async function getInstaller(): Promise<PlatformInstaller> {
       start: m.startMacOs,
       stop: m.stopMacOs,
       isInstalled: m.isInstalledMacOs,
+      isRegistered: m.isRegisteredMacOs,
     };
   }
   if (platform === "linux") {
@@ -42,6 +76,7 @@ async function getInstaller(): Promise<PlatformInstaller> {
       start: m.startLinux,
       stop: m.stopLinux,
       isInstalled: m.isInstalledLinux,
+      isRegistered: m.isRegisteredLinux,
     };
   }
   if (platform === "win32") {
@@ -52,6 +87,7 @@ async function getInstaller(): Promise<PlatformInstaller> {
       start: m.startWindows,
       stop: m.stopWindows,
       isInstalled: m.isInstalledWindows,
+      isRegistered: m.isInstalledWindows,
     };
   }
   throw new Error(`Unsupported platform: ${platform}`);
@@ -77,8 +113,8 @@ export const daemonCommand = defineCommand({
       meta: { description: "Install and start the daemon as a system service" },
       async run() {
         const installer = await getInstaller();
-        const exe = getExecutablePath();
-        await installer.install(exe);
+        const args = getExecutableArgs();
+        await installer.install(args);
       },
     }),
 
@@ -86,8 +122,10 @@ export const daemonCommand = defineCommand({
       meta: { description: "Start the daemon service" },
       async run() {
         const installer = await getInstaller();
-        if (!(await installer.isInstalled())) {
-          log.error("Daemon not installed. Run: agentsync daemon install");
+        if (!(await installer.isRegistered())) {
+          log.error(
+            "Service not bootstrapped — run `agentsync daemon install` first.",
+          );
           process.exitCode = 1;
           return;
         }
@@ -112,7 +150,16 @@ export const daemonCommand = defineCommand({
         try {
           const response = await client.send("status", {}, resolveDaemonSocketPath());
           if (response.ok) {
-            log.success(`Daemon is running (pid: ${(response.data as { pid: number }).pid})`);
+            const parsed = DaemonStatusSchema.safeParse(response.data);
+            const pid = parsed.success
+              ? parsed.data.pid
+              : (response.data as { pid: number }).pid;
+            const failures = parsed.success ? parsed.data.consecutiveFailures : 0;
+            const lastErr = parsed.success ? parsed.data.lastError : null;
+            log.success(`Daemon is running (pid: ${pid})`);
+            if (failures > 0) {
+              log.warn(`Consecutive failures: ${failures}. Last error: ${lastErr ?? "unknown"}`);
+            }
           } else {
             log.error(`Daemon error: ${response.error}`);
             process.exitCode = 1;

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -11,10 +11,13 @@ import { IpcClient } from "../core/ipc";
  * (created by bunx or the OS). Such paths are not stable across reboots.
  */
 function isEphemeralPath(filePath: string): boolean {
+  // Check the raw path first — bunx creates paths like /tmp/bunx-<uid>-<hash>/...
+  // which may not exist on disk during tests or after the bunx process exits.
+  if (filePath.includes("bunx-")) return true;
   try {
     const resolved = realpathSync(filePath);
     const tmp = realpathSync(tmpdir());
-    return resolved.startsWith(tmp) || resolved.includes("bunx-");
+    return resolved.startsWith(tmp);
   } catch {
     return false;
   }
@@ -27,8 +30,7 @@ function isEphemeralPath(filePath: string): boolean {
  * @throws {Error} when the script path is inside a temporary directory (e.g. bunx).
  */
 export function getExecutableArgs(): string[] {
-  const isBun =
-    process.argv[0].endsWith("bun") || process.argv[0].endsWith("bun.exe");
+  const isBun = process.argv[0].endsWith("bun") || process.argv[0].endsWith("bun.exe");
   if (isBun) {
     if (isEphemeralPath(process.argv[1])) {
       throw new Error(
@@ -123,9 +125,7 @@ export const daemonCommand = defineCommand({
       async run() {
         const installer = await getInstaller();
         if (!(await installer.isRegistered())) {
-          log.error(
-            "Service not bootstrapped — run `agentsync daemon install` first.",
-          );
+          log.error("Service not bootstrapped — run `agentsync daemon install` first.");
           process.exitCode = 1;
           return;
         }
@@ -151,9 +151,7 @@ export const daemonCommand = defineCommand({
           const response = await client.send("status", {}, resolveDaemonSocketPath());
           if (response.ok) {
             const parsed = DaemonStatusSchema.safeParse(response.data);
-            const pid = parsed.success
-              ? parsed.data.pid
-              : (response.data as { pid: number }).pid;
+            const pid = parsed.success ? parsed.data.pid : (response.data as { pid: number }).pid;
             const failures = parsed.success ? parsed.data.consecutiveFailures : 0;
             const lastErr = parsed.success ? parsed.data.lastError : null;
             log.success(`Daemon is running (pid: ${pid})`);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -25,3 +25,16 @@ export const AgentSyncConfigSchema = z.object({
 
 /** Normalized runtime shape derived from the validated config schema. */
 export type AgentSyncConfig = z.infer<typeof AgentSyncConfigSchema>;
+
+/**
+ * Schema for the status payload returned by the daemon's IPC `status` command.
+ * All fields crossing the IPC trust boundary are validated with Zod per Constitution IV.
+ */
+export const DaemonStatusSchema = z.object({
+  pid: z.number().int().positive(),
+  consecutiveFailures: z.number().int().min(0),
+  lastError: z.string().nullable(),
+});
+
+/** Normalized status shape for the daemon IPC status response. */
+export type DaemonStatus = z.infer<typeof DaemonStatusSchema>;

--- a/src/core/__tests__/sync-queue.test.ts
+++ b/src/core/__tests__/sync-queue.test.ts
@@ -115,6 +115,53 @@ describe("SyncQueue", () => {
     expect(result).toBe(42);
   });
 
+  // T058 — close() rejects new enqueues
+  test("close() causes subsequent enqueue() to reject", async () => {
+    const q = new SyncQueue();
+    q.close();
+    await expect(q.enqueue(async () => 1)).rejects.toThrow("SyncQueue is closed");
+  });
+
+  // T058 — whenIdle() still resolves after close()
+  test("whenIdle() resolves after close() when queue is idle", async () => {
+    const q = new SyncQueue();
+    q.close();
+    await expect(q.whenIdle()).resolves.toBeUndefined();
+  });
+
+  // T058 — close() does not abort in-flight work
+  test("close() does not abort already-enqueued work", async () => {
+    const q = new SyncQueue();
+    let ran = false;
+
+    let resolveFirst!: () => void;
+    const first = q.enqueue(
+      () =>
+        new Promise<void>((res) => {
+          resolveFirst = res;
+        }),
+    );
+
+    const second = q.enqueue(async () => {
+      ran = true;
+    });
+
+    // Flush microtask so fn is called and resolveFirst is assigned
+    await Promise.resolve();
+
+    // Close while work is in flight — should NOT abort existing work
+    q.close();
+
+    // New enqueues should be rejected
+    await expect(q.enqueue(async () => 99)).rejects.toThrow("SyncQueue is closed");
+
+    resolveFirst();
+    await first;
+    await second;
+
+    expect(ran).toBe(true);
+  });
+
   // failed operation does not block subsequent enqueued work
   test("a failed operation does not block subsequent enqueued work", async () => {
     const q = new SyncQueue();

--- a/src/core/__tests__/sync-queue.test.ts
+++ b/src/core/__tests__/sync-queue.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { SyncQueue } from "../sync-queue";
+
+describe("SyncQueue", () => {
+  // T013 — two enqueued operations run serially
+  test("two enqueued operations run serially — second starts only after first resolves", async () => {
+    const q = new SyncQueue();
+    const order: number[] = [];
+
+    let resolveFirst!: () => void;
+    const first = q.enqueue(
+      () =>
+        new Promise<void>((res) => {
+          resolveFirst = () => {
+            order.push(1);
+            res();
+          };
+        }),
+    );
+
+    const second = q.enqueue(async () => {
+      order.push(2);
+    });
+
+    // At this point neither has completed — first is still pending
+    expect(order).toEqual([]);
+
+    resolveFirst();
+    await first;
+    await second;
+
+    expect(order).toEqual([1, 2]);
+  });
+
+  // T013 — serialisation: second does not start while first is running
+  test("second operation does not start while first is in progress", async () => {
+    const q = new SyncQueue();
+    let secondStarted = false;
+
+    let resolveFirst!: () => void;
+    const first = q.enqueue(
+      () =>
+        new Promise<void>((res) => {
+          resolveFirst = res;
+        }),
+    );
+
+    q.enqueue(async () => {
+      secondStarted = true;
+    });
+
+    // First is still pending — second must not have started
+    expect(secondStarted).toBe(false);
+
+    resolveFirst();
+    await first;
+
+    // Now second should have run
+    await new Promise((r) => setTimeout(r, 0)); // flush microtasks
+    expect(secondStarted).toBe(true);
+  });
+
+  // T014 — whenIdle resolves only after all enqueued work settles
+  test("whenIdle() resolves only after all enqueued work settles", async () => {
+    const q = new SyncQueue();
+    const results: number[] = [];
+
+    let resolveFirst!: () => void;
+    q.enqueue(
+      () =>
+        new Promise<void>((res) => {
+          resolveFirst = res;
+        }),
+    );
+
+    q.enqueue(async () => {
+      results.push(1);
+    });
+
+    const idle = q.whenIdle();
+
+    // idle must not be resolved yet
+    let idleResolved = false;
+    idle.then(() => {
+      idleResolved = true;
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(idleResolved).toBe(false);
+
+    resolveFirst();
+    await idle;
+
+    expect(idleResolved).toBe(true);
+    expect(results).toEqual([1]);
+  });
+
+  // T014 — whenIdle resolves immediately when queue is empty
+  test("whenIdle() resolves immediately when the queue is idle", async () => {
+    const q = new SyncQueue();
+    await expect(q.whenIdle()).resolves.toBeUndefined();
+  });
+
+  // enqueue returns the value from fn
+  test("enqueue returns the resolved value of fn", async () => {
+    const q = new SyncQueue();
+    const result = await q.enqueue(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  // failed operation does not block subsequent enqueued work
+  test("a failed operation does not block subsequent enqueued work", async () => {
+    const q = new SyncQueue();
+    let secondRan = false;
+
+    const first = q.enqueue(async () => {
+      throw new Error("boom");
+    });
+
+    const second = q.enqueue(async () => {
+      secondRan = true;
+    });
+
+    await expect(first).rejects.toThrow("boom");
+    await second;
+    expect(secondRan).toBe(true);
+  });
+});

--- a/src/core/__tests__/sync-queue.test.ts
+++ b/src/core/__tests__/sync-queue.test.ts
@@ -22,7 +22,9 @@ describe("SyncQueue", () => {
       order.push(2);
     });
 
-    // At this point neither has completed — first is still pending
+    // Flush microtask so fn is called and resolveFirst is assigned
+    await Promise.resolve();
+    // First is still pending (its inner promise hasn't resolved)
     expect(order).toEqual([]);
 
     resolveFirst();
@@ -49,6 +51,9 @@ describe("SyncQueue", () => {
       secondStarted = true;
     });
 
+    // Flush microtask so fn is called and resolveFirst is assigned
+    await Promise.resolve();
+
     // First is still pending — second must not have started
     expect(secondStarted).toBe(false);
 
@@ -56,7 +61,7 @@ describe("SyncQueue", () => {
     await first;
 
     // Now second should have run
-    await new Promise((r) => setTimeout(r, 0)); // flush microtasks
+    await new Promise((r) => setTimeout(r, 0));
     expect(secondStarted).toBe(true);
   });
 
@@ -85,6 +90,8 @@ describe("SyncQueue", () => {
       idleResolved = true;
     });
 
+    // Flush microtask so fn is called and resolveFirst is assigned
+    await Promise.resolve();
     await new Promise((r) => setTimeout(r, 0));
     expect(idleResolved).toBe(false);
 

--- a/src/core/sync-queue.ts
+++ b/src/core/sync-queue.ts
@@ -6,12 +6,28 @@
  */
 export class SyncQueue {
   private tail: Promise<void> = Promise.resolve();
+  private accepting = true;
+
+  /**
+   * Permanently stop accepting new work. Already-enqueued operations continue
+   * to completion. Subsequent `enqueue()` calls reject immediately.
+   *
+   * Intended for use during daemon shutdown — call after `ipc.close()` and
+   * before `whenIdle()` to prevent watcher callbacks from adding new work.
+   */
+  close(): void {
+    this.accepting = false;
+  }
 
   /**
    * Enqueue `fn`; it will run only after any currently-running operation settles.
    * @returns A promise that resolves or rejects with the result of `fn`.
+   * @throws {Error} If the queue has been closed via `close()`.
    */
   enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    if (!this.accepting) {
+      return Promise.reject(new Error("SyncQueue is closed"));
+    }
     const result = this.tail.then(fn);
     // Advance the tail, swallowing errors so a failed operation
     // does not block subsequent enqueued work.

--- a/src/core/sync-queue.ts
+++ b/src/core/sync-queue.ts
@@ -1,0 +1,32 @@
+/**
+ * A promise-chain queue that serialises async operations so only one executes at a time.
+ *
+ * Callers enqueue functions that return promises; each function waits for the previous
+ * one to settle (resolve or reject) before it starts. No external dependencies are required.
+ */
+export class SyncQueue {
+  private tail: Promise<void> = Promise.resolve();
+
+  /**
+   * Enqueue `fn`; it will run only after any currently-running operation settles.
+   * @returns A promise that resolves or rejects with the result of `fn`.
+   */
+  enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(fn);
+    // Advance the tail, swallowing errors so a failed operation
+    // does not block subsequent enqueued work.
+    this.tail = result.then(
+      () => {},
+      () => {},
+    );
+    return result;
+  }
+
+  /**
+   * Returns a promise that resolves once all currently-queued operations have settled.
+   * Safe to call at any time — resolves immediately if the queue is already idle.
+   */
+  whenIdle(): Promise<void> {
+    return this.tail;
+  }
+}

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -13,7 +13,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { log } from "@clack/prompts";
 import { AgentPaths, resolveDaemonSocketPath } from "../../config/paths";
-import { IpcServer } from "../../core/ipc";
+import { IpcClient, IpcServer } from "../../core/ipc";
 import { Watcher } from "../../core/watcher";
 import { createAgeIdentity, createTmpDir, runGit } from "../../test-helpers/fixtures";
 
@@ -40,6 +40,7 @@ const watcherAdds: Array<{
 
 let listenedSocketPath = "";
 let watcherClosed = false;
+let ipcClosed = false;
 let scheduledIntervalMs = 0;
 let scheduledIntervalCallback: null | (() => Promise<void>) = null;
 let clearedIntervalToken: unknown = null;
@@ -62,6 +63,8 @@ let infoSpy: ReturnType<typeof spyOn>;
 let errorSpy: ReturnType<typeof spyOn>;
 let ipcOnSpy: ReturnType<typeof spyOn>;
 let ipcListenSpy: ReturnType<typeof spyOn>;
+let ipcCloseSpy: ReturnType<typeof spyOn>;
+let ipcClientSendSpy: ReturnType<typeof spyOn>;
 let watcherAddSpy: ReturnType<typeof spyOn>;
 let watcherCloseSpy: ReturnType<typeof spyOn>;
 
@@ -83,6 +86,13 @@ beforeAll(async () => {
     async (socketPath?: string) => {
       listenedSocketPath = socketPath ?? "";
     },
+  );
+  ipcCloseSpy = spyOn(IpcServer.prototype, "close").mockImplementation(function (this: IpcServer) {
+    ipcClosed = true;
+  });
+  // Default: ENOENT (no socket file = clean start)
+  ipcClientSendSpy = spyOn(IpcClient.prototype, "send").mockRejectedValue(
+    Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" }),
   );
   watcherAddSpy = spyOn(Watcher.prototype, "add").mockImplementation(function (
     this: Watcher,
@@ -124,6 +134,8 @@ afterAll(() => {
   errorSpy.mockRestore();
   ipcOnSpy.mockRestore();
   ipcListenSpy.mockRestore();
+  ipcCloseSpy.mockRestore();
+  ipcClientSendSpy.mockRestore();
   watcherAddSpy.mockRestore();
   watcherCloseSpy.mockRestore();
 
@@ -202,10 +214,16 @@ beforeEach(async () => {
   watcherAdds.length = 0;
   listenedSocketPath = "";
   watcherClosed = false;
+  ipcClosed = false;
   scheduledIntervalMs = 0;
   scheduledIntervalCallback = null;
   clearedIntervalToken = null;
   exitCode = null;
+
+  // Reset to default: clean start (no existing socket)
+  ipcClientSendSpy.mockRejectedValue(
+    Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" }),
+  );
 });
 
 afterEach(async () => {
@@ -247,5 +265,129 @@ describe("startDaemon", () => {
     expect(watcherClosed).toBe(true);
     expect(clearedIntervalToken).toBe("daemon-interval");
     expect(exitCode).toBe(0);
+  });
+});
+
+// ── T010a: Second-instance detection (FR-009, SC-005) ─────────────────────────
+describe("second-instance detection", () => {
+  test("exits with code 1 and logs 'already running' when daemon responds to health ping (T010a)", async () => {
+    ipcClientSendSpy.mockResolvedValueOnce({
+      id: "test",
+      ok: true,
+      data: { pid: 99999 },
+    });
+
+    await daemonModule.startDaemon();
+
+    expect(exitCode).toBe(1);
+    expect(infoLogs.some((m) => m.includes("already running"))).toBe(true);
+    // Must NOT have proceeded to ipc.listen
+    expect(listenedSocketPath).toBe("");
+  });
+});
+
+// ── T011/T012/T017: Clean shutdown (US1) ──────────────────────────────────────
+describe("clean shutdown (US1)", () => {
+  test("SIGTERM calls ipc.close() before process.exit(0) (T011)", async () => {
+    await daemonModule.startDaemon();
+    await signalHandlers.get("SIGTERM")?.();
+
+    expect(ipcClosed).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test("SIGTERM unlinks the socket path before process.exit(0) (T012)", async () => {
+    await daemonModule.startDaemon();
+
+    // The shutdown function calls unlink(socketPath). Since the socket file doesn't
+    // actually exist on disk in this test, the call swallows ENOENT. The important
+    // thing is that shutdown completes and exit(0) is called.
+    await signalHandlers.get("SIGTERM")?.();
+
+    expect(exitCode).toBe(0);
+    expect(watcherClosed).toBe(true);
+    expect(clearedIntervalToken).toBe("daemon-interval");
+  });
+
+  test("shutdown sequence: clearInterval → ipc.close → watcher.close → exit(0) (T017)", async () => {
+    await daemonModule.startDaemon();
+    await signalHandlers.get("SIGTERM")?.();
+
+    expect(clearedIntervalToken).toBe("daemon-interval");
+    expect(ipcClosed).toBe(true);
+    expect(watcherClosed).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+});
+
+// ── T018-T020: Failure tracking (US2) ─────────────────────────────────────────
+describe("failure tracking (US2)", () => {
+  test("after a failed pull, consecutiveFailures >= 1 and lastError is non-null (T018)", async () => {
+    await daemonModule.startDaemon();
+
+    // Pull will fail because remote doesn't exist — withRetry calls it twice
+    await ipcHandlers.get("pull")?.();
+
+    const status = (await ipcHandlers.get("status")?.()) as {
+      consecutiveFailures: number;
+      lastError: string | null;
+    };
+    expect(status.consecutiveFailures).toBeGreaterThanOrEqual(1);
+    expect(status.lastError).not.toBeNull();
+    expect(status.lastError).toContain("[pull]");
+  });
+
+  test("status IPC handler returns an object matching DaemonStatusSchema shape (T020)", async () => {
+    await daemonModule.startDaemon();
+
+    const status = (await ipcHandlers.get("status")?.()) as Record<string, unknown>;
+    expect(status).toHaveProperty("pid");
+    expect(status).toHaveProperty("consecutiveFailures");
+    expect(status).toHaveProperty("lastError");
+    expect(typeof status.pid).toBe("number");
+    expect(typeof status.consecutiveFailures).toBe("number");
+  });
+});
+
+// ── T025-T026: Retry logic (US3) ─────────────────────────────────────────────
+describe("retry logic (US3)", () => {
+  test("when both attempts fail, consecutiveFailures increments to >= 1 and process.exit is NOT called (T026)", async () => {
+    await daemonModule.startDaemon();
+
+    // Push will fail (no remote) — retry also fails
+    await ipcHandlers.get("push")?.();
+
+    const status = (await ipcHandlers.get("status")?.()) as {
+      consecutiveFailures: number;
+    };
+    expect(status.consecutiveFailures).toBeGreaterThanOrEqual(1);
+    // Daemon must NOT exit — it stays alive for the next trigger (SC-004)
+    // exitCode should still be null (not set by the push handler)
+    // Note: exitCode may have been set by second-instance detection in a prior test,
+    // but within this test's context, push handler does not call process.exit
+    expect(signalHandlers.has("SIGTERM")).toBe(true); // daemon still alive
+  });
+});
+
+// ── T034a/T034b: Startup validation (FR-006, FR-007, SC-006) ─────────────────
+describe("startup validation (US4)", () => {
+  test("exits with code 1 and log contains 'vault' when vault dir is missing (T034a)", async () => {
+    // Remove the vault directory so loadConfig fails
+    process.env.AGENTSYNC_VAULT_DIR = join(tmpDir, "nonexistent-vault");
+
+    await daemonModule.startDaemon();
+
+    expect(exitCode).toBe(1);
+    expect(errorLogs.some((m) => m.toLowerCase().includes("startup failed"))).toBe(true);
+  });
+
+  test("exits with code 1 when key file is missing (T034b)", async () => {
+    // Point to a non-existent key file
+    process.env.AGENTSYNC_KEY_PATH = join(tmpDir, "nonexistent-key.txt");
+
+    await daemonModule.startDaemon();
+
+    expect(exitCode).toBe(1);
+    expect(errorLogs.some((m) => m.toLowerCase().includes("startup failed"))).toBe(true);
   });
 });

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -362,10 +362,7 @@ describe("retry logic (US3)", () => {
     };
     expect(status.consecutiveFailures).toBeGreaterThanOrEqual(1);
     // Daemon must NOT exit — it stays alive for the next trigger (SC-004)
-    // exitCode should still be null (not set by the push handler)
-    // Note: exitCode may have been set by second-instance detection in a prior test,
-    // but within this test's context, push handler does not call process.exit
-    expect(signalHandlers.has("SIGTERM")).toBe(true); // daemon still alive
+    expect(exitCode).toBeNull();
   });
 });
 

--- a/src/daemon/__tests__/installer-linux.test.ts
+++ b/src/daemon/__tests__/installer-linux.test.ts
@@ -1,5 +1,6 @@
 /**
- * T046 — installer-linux: installLinux, uninstallLinux, startLinux, stopLinux, isInstalledLinux
+ * Tests for installer-linux: installLinux, uninstallLinux, startLinux, stopLinux,
+ * isInstalledLinux, buildUnit, isRegisteredLinux
  *
  * Strategy
  * --------
@@ -11,15 +12,46 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "b
 const fsWrites = new Map<string, string>();
 const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
 
+// Control is-enabled output for isRegisteredLinux tests
+let isEnabledStdout = "";
+let isEnabledShouldFail = false;
+
+// Build the execFile mock with custom promisify support so that
+// `promisify(execFile)` returns { stdout, stderr } rather than just stdout.
+const execFileMock = (
+  cmd: string,
+  args: string[],
+  callback: (err: Error | null, stdout: string, stderr: string) => void,
+) => {
+  execFileCalls.push({ cmd, args });
+  if (cmd === "systemctl" && args.includes("is-enabled")) {
+    if (isEnabledShouldFail) {
+      callback(new Error("not enabled"), "", "");
+      return;
+    }
+    callback(null, isEnabledStdout, "");
+    return;
+  }
+  callback(null, "", "");
+};
+
+const { promisify } = require("node:util") as typeof import("node:util");
+(execFileMock as unknown as Record<symbol, unknown>)[promisify.custom] = (
+  cmd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> =>
+  new Promise((resolve, reject) => {
+    execFileMock(cmd, args, (err, stdout, stderr) => {
+      if (err) {
+        reject(Object.assign(err, { stdout, stderr }));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+
 mock.module("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    callback: (err: Error | null, stdout: string, stderr: string) => void,
-  ) => {
-    execFileCalls.push({ cmd, args });
-    callback(null, "", "");
-  },
+  execFile: execFileMock,
 }));
 
 mock.module("node:fs/promises", () => ({
@@ -50,8 +82,6 @@ beforeAll(async () => {
   m = await import("../installer-linux");
 });
 
-// Restore mocked modules after this file completes so they do not bleed into
-// subsequent test files (e.g. integration.test.ts) that need the real node:fs/promises.
 afterAll(() => {
   mock.restore();
 });
@@ -59,11 +89,26 @@ afterAll(() => {
 beforeEach(() => {
   fsWrites.clear();
   execFileCalls.length = 0;
+  isEnabledStdout = "";
+  isEnabledShouldFail = false;
+});
+
+// T034: buildUnit emits correct ExecStart
+describe("buildUnit", () => {
+  test("produces ExecStart with each arg joined by space plus daemon _run (T034)", () => {
+    const unit = m.buildUnit(["bun", "/path/cli.js"]);
+    expect(unit).toContain("ExecStart=bun /path/cli.js daemon _run");
+  });
+
+  test("single-element args produce correct ExecStart", () => {
+    const unit = m.buildUnit(["/usr/local/bin/agentsync"]);
+    expect(unit).toContain("ExecStart=/usr/local/bin/agentsync daemon _run");
+  });
 });
 
 describe("installLinux", () => {
   test("writes a systemd unit file with the correct service name", async () => {
-    await m.installLinux("/usr/local/bin/agentsync");
+    await m.installLinux(["/usr/local/bin/agentsync"]);
 
     const written = [...fsWrites.entries()].find(([p]) => p.endsWith(".service"));
     expect(written).toBeDefined();
@@ -74,7 +119,7 @@ describe("installLinux", () => {
   });
 
   test("calls systemctl daemon-reload and enable --now", async () => {
-    await m.installLinux("/usr/local/bin/agentsync");
+    await m.installLinux(["/usr/local/bin/agentsync"]);
 
     const daemonReload = execFileCalls.find(
       (c) => c.cmd === "systemctl" && c.args.includes("daemon-reload"),
@@ -87,14 +132,14 @@ describe("installLinux", () => {
   });
 
   test("isInstalledLinux returns true after install", async () => {
-    await m.installLinux("/usr/local/bin/agentsync");
+    await m.installLinux(["/usr/local/bin/agentsync"]);
     expect(await m.isInstalledLinux()).toBe(true);
   });
 });
 
 describe("uninstallLinux", () => {
   test("calls systemctl disable --now and daemon-reload", async () => {
-    await m.installLinux("/usr/local/bin/agentsync");
+    await m.installLinux(["/usr/local/bin/agentsync"]);
     execFileCalls.length = 0;
 
     await m.uninstallLinux();
@@ -106,18 +151,16 @@ describe("uninstallLinux", () => {
   });
 
   test("isInstalledLinux returns false after uninstall", async () => {
-    await m.installLinux("/usr/local/bin/agentsync");
+    await m.installLinux(["/usr/local/bin/agentsync"]);
     await m.uninstallLinux();
     expect(await m.isInstalledLinux()).toBe(false);
   });
 });
 
 describe("startLinux / stopLinux", () => {
-  test("startLinux calls systemctl start <service>", async () => {
-    await m.startLinux();
-    const startCall = execFileCalls.find((c) => c.cmd === "systemctl" && c.args.includes("start"));
-    expect(startCall).toBeDefined();
-    expect(startCall?.args).toContain("agentsync");
+  test("startLinux throws when not registered", async () => {
+    isEnabledShouldFail = true;
+    await expect(m.startLinux()).rejects.toThrow("Service not bootstrapped");
   });
 
   test("stopLinux calls systemctl stop <service>", async () => {
@@ -131,5 +174,22 @@ describe("startLinux / stopLinux", () => {
 describe("isInstalledLinux", () => {
   test("returns false when the service file does not exist", async () => {
     expect(await m.isInstalledLinux()).toBe(false);
+  });
+});
+
+describe("isRegisteredLinux", () => {
+  test("returns true when systemctl is-enabled outputs 'enabled'", async () => {
+    isEnabledStdout = "enabled\n";
+    expect(await m.isRegisteredLinux()).toBe(true);
+  });
+
+  test("returns false when systemctl is-enabled outputs anything else", async () => {
+    isEnabledStdout = "disabled\n";
+    expect(await m.isRegisteredLinux()).toBe(false);
+  });
+
+  test("returns false when systemctl is-enabled fails", async () => {
+    isEnabledShouldFail = true;
+    expect(await m.isRegisteredLinux()).toBe(false);
   });
 });

--- a/src/daemon/__tests__/installer-linux.test.ts
+++ b/src/daemon/__tests__/installer-linux.test.ts
@@ -11,6 +11,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "b
 
 const fsWrites = new Map<string, string>();
 const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+let lastExecFileOpts: Record<string, unknown> | undefined;
 
 // Control is-enabled output for isRegisteredLinux tests
 let isEnabledStdout = "";
@@ -37,10 +38,14 @@ const execFileMock = (
 
 const { promisify } = require("node:util") as typeof import("node:util");
 (execFileMock as unknown as Record<symbol, unknown>)[promisify.custom] = (
-  cmd: string,
-  args: string[],
+  ...fnArgs: unknown[]
 ): Promise<{ stdout: string; stderr: string }> =>
   new Promise((resolve, reject) => {
+    const cmd = fnArgs[0] as string;
+    const args = fnArgs[1] as string[];
+    if (fnArgs.length > 2 && typeof fnArgs[2] === "object" && fnArgs[2] !== null) {
+      lastExecFileOpts = fnArgs[2] as Record<string, unknown>;
+    }
     execFileMock(cmd, args, (err, stdout, stderr) => {
       if (err) {
         reject(Object.assign(err, { stdout, stderr }));
@@ -91,18 +96,34 @@ beforeEach(() => {
   execFileCalls.length = 0;
   isEnabledStdout = "";
   isEnabledShouldFail = false;
+  lastExecFileOpts = undefined;
 });
 
 // T034: buildUnit emits correct ExecStart
 describe("buildUnit", () => {
-  test("produces ExecStart with each arg joined by space plus daemon _run (T034)", () => {
+  test("produces ExecStart with each arg quoted plus daemon _run (T034)", () => {
     const unit = m.buildUnit(["bun", "/path/cli.js"]);
-    expect(unit).toContain("ExecStart=bun /path/cli.js daemon _run");
+    expect(unit).toContain('ExecStart="bun" "/path/cli.js" "daemon" "_run"');
   });
 
   test("single-element args produce correct ExecStart", () => {
     const unit = m.buildUnit(["/usr/local/bin/agentsync"]);
-    expect(unit).toContain("ExecStart=/usr/local/bin/agentsync daemon _run");
+    expect(unit).toContain('ExecStart="/usr/local/bin/agentsync" "daemon" "_run"');
+  });
+
+  // T063: args containing spaces are quoted per systemd.syntax(7)
+  test("args containing spaces are quoted for systemd (T063)", () => {
+    const unit = m.buildUnit(["bun", "/home/user/My Program/cli.js"]);
+    expect(unit).toContain('"bun"');
+    expect(unit).toContain('"/home/user/My Program/cli.js"');
+    expect(unit).toContain('"daemon"');
+    expect(unit).toContain('"_run"');
+  });
+
+  test("args containing backslashes and quotes are C-style escaped (T063)", () => {
+    const unit = m.buildUnit(['/path/with"quote', "/path/with\\backslash"]);
+    expect(unit).toContain('"/path/with\\"quote"');
+    expect(unit).toContain('"/path/with\\\\backslash"');
   });
 });
 
@@ -161,6 +182,17 @@ describe("startLinux / stopLinux", () => {
   test("startLinux throws when not registered", async () => {
     isEnabledShouldFail = true;
     await expect(m.startLinux()).rejects.toThrow("Service not bootstrapped");
+  });
+
+  // T070: startLinux passes AbortSignal to execFileAsync
+  test("startLinux passes signal option to execFileAsync for start (T070)", async () => {
+    isEnabledStdout = "enabled\n";
+    await m.startLinux();
+
+    const startCall = execFileCalls.find((c) => c.cmd === "systemctl" && c.args.includes("start"));
+    expect(startCall).toBeDefined();
+    expect(lastExecFileOpts).toBeDefined();
+    expect(lastExecFileOpts?.signal).toBeInstanceOf(AbortSignal);
   });
 
   test("stopLinux calls systemctl stop <service>", async () => {

--- a/src/daemon/__tests__/installer-macos.test.ts
+++ b/src/daemon/__tests__/installer-macos.test.ts
@@ -22,23 +22,45 @@ const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
 // Control whether launchctl commands succeed or fail
 let launchctlShouldFail = false;
 let launchctlFailStderr = "Bootstrap failed: 5: Input/output error";
+let launchctlPrintShouldFail = true; // default: not registered
+
+const execFileMock = (
+  cmd: string,
+  args: string[],
+  callback: (err: Error | null, stdout: string, stderr: string) => void,
+) => {
+  execFileCalls.push({ cmd, args });
+  if (cmd === "launchctl" && args[0] === "print" && launchctlPrintShouldFail) {
+    callback(new Error("Could not find service"), "", "Could not find service");
+    return;
+  }
+  if (launchctlShouldFail && cmd === "launchctl" && args[0] === "bootstrap") {
+    const err = Object.assign(new Error("launchctl failed"), {
+      stderr: launchctlFailStderr,
+    });
+    callback(err, "", launchctlFailStderr);
+    return;
+  }
+  callback(null, "", "");
+};
+
+const { promisify } = require("node:util") as typeof import("node:util");
+(execFileMock as unknown as Record<symbol, unknown>)[promisify.custom] = (
+  cmd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> =>
+  new Promise((resolve, reject) => {
+    execFileMock(cmd, args, (err, stdout, stderr) => {
+      if (err) {
+        reject(Object.assign(err, { stdout, stderr }));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
 
 mock.module("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    callback: (err: Error | null, stdout: string, stderr: string) => void,
-  ) => {
-    execFileCalls.push({ cmd, args });
-    if (launchctlShouldFail && cmd === "launchctl" && args[0] === "bootstrap") {
-      const err = Object.assign(new Error("launchctl failed"), {
-        stderr: launchctlFailStderr,
-      });
-      callback(err, "", launchctlFailStderr);
-      return;
-    }
-    callback(null, "", "");
-  },
+  execFile: execFileMock,
 }));
 
 mock.module("node:fs/promises", () => ({
@@ -80,6 +102,7 @@ beforeEach(() => {
   execFileCalls.length = 0;
   launchctlShouldFail = false;
   launchctlFailStderr = "Bootstrap failed: 5: Input/output error";
+  launchctlPrintShouldFail = true; // default: not registered
 });
 
 // ── T029: buildPlist emits separate <string> elements ─────────────────────────

--- a/src/daemon/__tests__/installer-macos.test.ts
+++ b/src/daemon/__tests__/installer-macos.test.ts
@@ -1,5 +1,6 @@
 /**
- * T045 — installer-macos: installMacOs, uninstallMacOs, startMacOs, stopMacOs, isInstalledMacOs
+ * Tests for installer-macos: installMacOs, uninstallMacOs, startMacOs, stopMacOs,
+ * isInstalledMacOs, buildPlist, isRegisteredMacOs, extractServiceManagerError
  *
  * Strategy
  * --------
@@ -18,6 +19,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "b
 const fsWrites = new Map<string, string>();
 const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
 
+// Control whether launchctl commands succeed or fail
+let launchctlShouldFail = false;
+let launchctlFailStderr = "Bootstrap failed: 5: Input/output error";
+
 mock.module("node:child_process", () => ({
   execFile: (
     cmd: string,
@@ -25,6 +30,13 @@ mock.module("node:child_process", () => ({
     callback: (err: Error | null, stdout: string, stderr: string) => void,
   ) => {
     execFileCalls.push({ cmd, args });
+    if (launchctlShouldFail && cmd === "launchctl" && args[0] === "bootstrap") {
+      const err = Object.assign(new Error("launchctl failed"), {
+        stderr: launchctlFailStderr,
+      });
+      callback(err, "", launchctlFailStderr);
+      return;
+    }
     callback(null, "", "");
   },
 }));
@@ -66,11 +78,49 @@ afterAll(() => {
 beforeEach(() => {
   fsWrites.clear();
   execFileCalls.length = 0;
+  launchctlShouldFail = false;
+  launchctlFailStderr = "Bootstrap failed: 5: Input/output error";
 });
 
+// ── T029: buildPlist emits separate <string> elements ─────────────────────────
+describe("buildPlist", () => {
+  test("emits separate <string> elements for each arg (T029)", () => {
+    const plist = m.buildPlist(["bun", "/path/cli.js"], "/var/log");
+    // Must have individual entries, not a space-joined single string
+    expect(plist).toContain("<string>bun</string>");
+    expect(plist).toContain("<string>/path/cli.js</string>");
+    expect(plist).toContain("<string>daemon</string>");
+    expect(plist).toContain("<string>_run</string>");
+    // Must NOT have the space-joined form as a single element
+    expect(plist).not.toContain("<string>bun /path/cli.js</string>");
+  });
+
+  test("ProgramArguments array contains exactly the args + daemon + _run as separate entries", () => {
+    const plist = m.buildPlist(["/usr/local/bin/agentsync"], "/var/log");
+    expect(plist).toContain("<string>/usr/local/bin/agentsync</string>");
+    expect(plist).toContain("<string>daemon</string>");
+    expect(plist).toContain("<string>_run</string>");
+  });
+});
+
+// ── T030: installMacOs calls bootout before bootstrap ─────────────────────────
 describe("installMacOs", () => {
+  test("calls launchctl bootout before launchctl bootstrap (T030)", async () => {
+    await m.installMacOs(["bun", "/path/cli.js"]);
+
+    const bootoutIdx = execFileCalls.findIndex(
+      (c) => c.cmd === "launchctl" && c.args[0] === "bootout",
+    );
+    const bootstrapIdx = execFileCalls.findIndex(
+      (c) => c.cmd === "launchctl" && c.args[0] === "bootstrap",
+    );
+    expect(bootoutIdx).toBeGreaterThanOrEqual(0);
+    expect(bootstrapIdx).toBeGreaterThanOrEqual(0);
+    expect(bootoutIdx).toBeLessThan(bootstrapIdx);
+  });
+
   test("writes a plist file with the correct label", async () => {
-    await m.installMacOs("/usr/local/bin/agentsync");
+    await m.installMacOs(["/usr/local/bin/agentsync"]);
 
     const written = [...fsWrites.entries()].find(([p]) => p.endsWith(".plist"));
     expect(written).toBeDefined();
@@ -81,7 +131,7 @@ describe("installMacOs", () => {
   });
 
   test("calls launchctl bootstrap with the plist path", async () => {
-    await m.installMacOs("/usr/local/bin/agentsync");
+    await m.installMacOs(["/usr/local/bin/agentsync"]);
 
     const bootstrapCall = execFileCalls.find(
       (c) => c.cmd === "launchctl" && c.args[0] === "bootstrap",
@@ -91,15 +141,33 @@ describe("installMacOs", () => {
   });
 
   test("isInstalledMacOs returns true after install", async () => {
-    await m.installMacOs("/usr/local/bin/agentsync");
+    await m.installMacOs(["/usr/local/bin/agentsync"]);
     expect(await m.isInstalledMacOs()).toBe(true);
+  });
+
+  // T031: bootstrap failure surfaces stderr, not stack trace
+  test("throws with service manager stderr (not stack trace) when bootstrap fails (T031)", async () => {
+    launchctlShouldFail = true;
+    launchctlFailStderr = "Bootstrap failed: 5: Input/output error";
+
+    let thrown: Error | null = null;
+    try {
+      await m.installMacOs(["/usr/local/bin/agentsync"]);
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.message).toContain("Bootstrap failed: 5");
+    // Must not contain a Node.js stack-trace marker
+    expect(thrown?.message).not.toContain("    at ");
   });
 });
 
 describe("uninstallMacOs", () => {
   test("calls launchctl bootout and removes the plist file", async () => {
     // Install first so there is a plist to remove.
-    await m.installMacOs("/usr/local/bin/agentsync");
+    await m.installMacOs(["/usr/local/bin/agentsync"]);
     execFileCalls.length = 0;
 
     await m.uninstallMacOs();
@@ -109,19 +177,22 @@ describe("uninstallMacOs", () => {
   });
 
   test("isInstalledMacOs returns false after uninstall", async () => {
-    await m.installMacOs("/usr/local/bin/agentsync");
+    await m.installMacOs(["/usr/local/bin/agentsync"]);
     await m.uninstallMacOs();
     expect(await m.isInstalledMacOs()).toBe(false);
   });
 });
 
+// ── T032: startMacOs throws immediately when not registered ───────────────────
 describe("startMacOs / stopMacOs", () => {
-  test("startMacOs calls launchctl kickstart", async () => {
-    await m.startMacOs();
+  test("startMacOs throws 'Service not bootstrapped' when isRegisteredMacOs returns false (T032)", async () => {
+    // launchctl print will fail (not registered), no kickstart call expected
+    await expect(m.startMacOs()).rejects.toThrow("Service not bootstrapped");
+
     const kickstartCall = execFileCalls.find(
       (c) => c.cmd === "launchctl" && c.args[0] === "kickstart",
     );
-    expect(kickstartCall).toBeDefined();
+    expect(kickstartCall).toBeUndefined();
   });
 
   test("stopMacOs calls launchctl kill with SIGTERM", async () => {

--- a/src/daemon/__tests__/installer-macos.test.ts
+++ b/src/daemon/__tests__/installer-macos.test.ts
@@ -18,6 +18,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "b
 // ── In-memory FS state (captured before the module is imported) ───────────────
 const fsWrites = new Map<string, string>();
 const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+let lastExecFileOpts: Record<string, unknown> | undefined;
 
 // Control whether launchctl commands succeed or fail
 let launchctlShouldFail = false;
@@ -46,10 +47,14 @@ const execFileMock = (
 
 const { promisify } = require("node:util") as typeof import("node:util");
 (execFileMock as unknown as Record<symbol, unknown>)[promisify.custom] = (
-  cmd: string,
-  args: string[],
+  ...fnArgs: unknown[]
 ): Promise<{ stdout: string; stderr: string }> =>
   new Promise((resolve, reject) => {
+    const cmd = fnArgs[0] as string;
+    const args = fnArgs[1] as string[];
+    if (fnArgs.length > 2 && typeof fnArgs[2] === "object" && fnArgs[2] !== null) {
+      lastExecFileOpts = fnArgs[2] as Record<string, unknown>;
+    }
     execFileMock(cmd, args, (err, stdout, stderr) => {
       if (err) {
         reject(Object.assign(err, { stdout, stderr }));
@@ -103,6 +108,7 @@ beforeEach(() => {
   launchctlShouldFail = false;
   launchctlFailStderr = "Bootstrap failed: 5: Input/output error";
   launchctlPrintShouldFail = true; // default: not registered
+  lastExecFileOpts = undefined;
 });
 
 // ── T029: buildPlist emits separate <string> elements ─────────────────────────
@@ -123,6 +129,15 @@ describe("buildPlist", () => {
     expect(plist).toContain("<string>/usr/local/bin/agentsync</string>");
     expect(plist).toContain("<string>daemon</string>");
     expect(plist).toContain("<string>_run</string>");
+  });
+
+  // T064: XML special characters in args are escaped
+  test("escapes & and < in arg values (T064)", () => {
+    const plist = m.buildPlist(["/path/with&amp", "/path/<special>"], "/var/log");
+    expect(plist).toContain("<string>/path/with&amp;amp</string>");
+    expect(plist).toContain("<string>/path/&lt;special&gt;</string>");
+    // Must NOT contain unescaped & or < inside <string> elements
+    expect(plist).not.toContain("<string>/path/with&amp</string>");
   });
 });
 
@@ -216,6 +231,19 @@ describe("startMacOs / stopMacOs", () => {
       (c) => c.cmd === "launchctl" && c.args[0] === "kickstart",
     );
     expect(kickstartCall).toBeUndefined();
+  });
+
+  // T069: startMacOs passes AbortSignal to execFileAsync
+  test("startMacOs passes signal option to execFileAsync for kickstart (T069)", async () => {
+    launchctlPrintShouldFail = false; // registered
+    await m.startMacOs();
+
+    const kickstartCall = execFileCalls.find(
+      (c) => c.cmd === "launchctl" && c.args[0] === "kickstart",
+    );
+    expect(kickstartCall).toBeDefined();
+    expect(lastExecFileOpts).toBeDefined();
+    expect(lastExecFileOpts?.signal).toBeInstanceOf(AbortSignal);
   });
 
   test("stopMacOs calls launchctl kill with SIGTERM", async () => {

--- a/src/daemon/__tests__/installer-windows.test.ts
+++ b/src/daemon/__tests__/installer-windows.test.ts
@@ -126,6 +126,22 @@ describe("buildXml", () => {
     const args = xml.match(/<Arguments>(.*?)<\/Arguments>/)?.[1] ?? "";
     expect(args).toContain('\\"');
   });
+
+  // T074a: trailing backslashes are doubled per CommandLineToArgvW
+  test("args with trailing backslash have it doubled inside quotes (T074a)", () => {
+    const xml = m.buildXml(["bun", "C:\\path\\"]);
+    const args = xml.match(/<Arguments>(.*?)<\/Arguments>/)?.[1] ?? "";
+    // Trailing \ before closing " must be doubled: "C:\path\\" → Windows sees C:\path\
+    expect(args).toContain('"C:\\path\\\\"');
+  });
+
+  // T074a: backslashes before quotes are doubled
+  test("backslashes immediately before a quote are doubled (T074a)", () => {
+    const xml = m.buildXml(["bun", 'C:\\path\\"name']);
+    const args = xml.match(/<Arguments>(.*?)<\/Arguments>/)?.[1] ?? "";
+    // The \" sequence: backslash must be doubled so Windows sees literal \ + literal "
+    expect(args).toContain('\\\\\\"');
+  });
 });
 
 describe("installWindows", () => {

--- a/src/daemon/__tests__/installer-windows.test.ts
+++ b/src/daemon/__tests__/installer-windows.test.ts
@@ -1,6 +1,6 @@
 /**
- * T047 — installer-windows: installWindows, uninstallWindows, startWindows, stopWindows,
- * isInstalledWindows
+ * Tests for installer-windows: installWindows, uninstallWindows, startWindows, stopWindows,
+ * isInstalledWindows, buildXml
  *
  * Strategy
  * --------
@@ -15,24 +15,40 @@ const fsRms = new Set<string>();
 const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
 
 // isInstalledWindows checks schtasks /Query exit code; simulate it via the mock.
-// We use a flag to control the success/failure of /Query calls.
 let queryExitCode = 0; // 0 = installed, non-zero = not installed
 
-mock.module("node:child_process", () => ({
-  execFile: (
-    cmd: string,
-    args: string[],
-    callback: (err: Error | null, stdout: string, stderr: string) => void,
-  ) => {
-    execFileCalls.push({ cmd, args });
-    if (cmd === "schtasks" && args[0] === "/Query") {
-      if (queryExitCode !== 0) {
-        callback(new Error("schtasks query failed"), "", "ERROR: task not found");
+const execFileMock = (
+  cmd: string,
+  args: string[],
+  callback: (err: Error | null, stdout: string, stderr: string) => void,
+) => {
+  execFileCalls.push({ cmd, args });
+  if (cmd === "schtasks" && args[0] === "/Query") {
+    if (queryExitCode !== 0) {
+      callback(new Error("schtasks query failed"), "", "ERROR: task not found");
+      return;
+    }
+  }
+  callback(null, "", "");
+};
+
+const { promisify } = require("node:util") as typeof import("node:util");
+(execFileMock as unknown as Record<symbol, unknown>)[promisify.custom] = (
+  cmd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> =>
+  new Promise((resolve, reject) => {
+    execFileMock(cmd, args, (err, stdout, stderr) => {
+      if (err) {
+        reject(Object.assign(err, { stdout, stderr }));
         return;
       }
-    }
-    callback(null, "", "");
-  },
+      resolve({ stdout, stderr });
+    });
+  });
+
+mock.module("node:child_process", () => ({
+  execFile: execFileMock,
 }));
 
 mock.module("node:fs/promises", () => ({
@@ -63,8 +79,6 @@ beforeAll(async () => {
   m = await import("../installer-windows");
 });
 
-// Restore mocked modules after this file completes so they do not bleed into
-// subsequent test files (e.g. integration.test.ts) that need the real node:fs/promises.
 afterAll(() => {
   process.env.TEMP = originalTemp;
   mock.restore();
@@ -77,11 +91,26 @@ beforeEach(() => {
   queryExitCode = 0;
 });
 
+// T033: buildXml puts args[0] in <Command>, rest + daemon _run in <Arguments>
+describe("buildXml", () => {
+  test("<Command> holds only the binary, <Arguments> holds script + daemon _run (T033)", () => {
+    const xml = m.buildXml(["bun", "/path/cli.js"]);
+    expect(xml).toContain("<Command>bun</Command>");
+    expect(xml).toContain("<Arguments>/path/cli.js daemon _run</Arguments>");
+  });
+
+  test("single-element args put binary in <Command> and 'daemon _run' in <Arguments>", () => {
+    const xml = m.buildXml(["C:\\agentsync.exe"]);
+    // & is XML-escaped
+    expect(xml).toContain("<Command>C:\\agentsync.exe</Command>");
+    expect(xml).toContain("<Arguments>daemon _run</Arguments>");
+  });
+});
+
 describe("installWindows", () => {
   test("writes a task XML file containing the executable path", async () => {
-    await m.installWindows("C:\\Program Files\\agentsync.exe");
+    await m.installWindows(["C:\\Program Files\\agentsync.exe"]);
 
-    // A temporary XML file must have been written.
     const xmlEntry = [...fsWrites.entries()].find(([p]) => p.endsWith(".xml"));
     expect(xmlEntry).toBeDefined();
     if (!xmlEntry) return;
@@ -91,7 +120,7 @@ describe("installWindows", () => {
   });
 
   test("calls schtasks /Create with the task name", async () => {
-    await m.installWindows("C:\\Program Files\\agentsync.exe");
+    await m.installWindows(["C:\\Program Files\\agentsync.exe"]);
 
     const createCall = execFileCalls.find((c) => c.cmd === "schtasks" && c.args[0] === "/Create");
     expect(createCall).toBeDefined();
@@ -99,7 +128,7 @@ describe("installWindows", () => {
   });
 
   test("calls schtasks /Run after creating the task", async () => {
-    await m.installWindows("C:\\Program Files\\agentsync.exe");
+    await m.installWindows(["C:\\Program Files\\agentsync.exe"]);
 
     const runCall = execFileCalls.find((c) => c.cmd === "schtasks" && c.args[0] === "/Run");
     expect(runCall).toBeDefined();
@@ -107,7 +136,7 @@ describe("installWindows", () => {
   });
 
   test("removes the temporary XML file after creating the task", async () => {
-    await m.installWindows("C:\\Program Files\\agentsync.exe");
+    await m.installWindows(["C:\\Program Files\\agentsync.exe"]);
 
     const xmlEntry = [...fsRms].find((p) => p.endsWith(".xml"));
     expect(xmlEntry).toBeDefined();
@@ -126,11 +155,9 @@ describe("uninstallWindows", () => {
 });
 
 describe("startWindows / stopWindows", () => {
-  test("startWindows calls schtasks /Run with the task name", async () => {
-    await m.startWindows();
-    const runCall = execFileCalls.find((c) => c.cmd === "schtasks" && c.args[0] === "/Run");
-    expect(runCall).toBeDefined();
-    expect(runCall?.args).toContain("AgentSync");
+  test("startWindows throws when not registered", async () => {
+    queryExitCode = 1;
+    await expect(m.startWindows()).rejects.toThrow("Service not bootstrapped");
   });
 
   test("stopWindows calls schtasks /End with the task name", async () => {

--- a/src/daemon/__tests__/installer-windows.test.ts
+++ b/src/daemon/__tests__/installer-windows.test.ts
@@ -13,6 +13,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "b
 const fsWrites = new Map<string, string>();
 const fsRms = new Set<string>();
 const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+let lastExecFileOpts: Record<string, unknown> | undefined;
 
 // isInstalledWindows checks schtasks /Query exit code; simulate it via the mock.
 let queryExitCode = 0; // 0 = installed, non-zero = not installed
@@ -34,10 +35,14 @@ const execFileMock = (
 
 const { promisify } = require("node:util") as typeof import("node:util");
 (execFileMock as unknown as Record<symbol, unknown>)[promisify.custom] = (
-  cmd: string,
-  args: string[],
+  ...fnArgs: unknown[]
 ): Promise<{ stdout: string; stderr: string }> =>
   new Promise((resolve, reject) => {
+    const cmd = fnArgs[0] as string;
+    const args = fnArgs[1] as string[];
+    if (fnArgs.length > 2 && typeof fnArgs[2] === "object" && fnArgs[2] !== null) {
+      lastExecFileOpts = fnArgs[2] as Record<string, unknown>;
+    }
     execFileMock(cmd, args, (err, stdout, stderr) => {
       if (err) {
         reject(Object.assign(err, { stdout, stderr }));
@@ -89,6 +94,7 @@ beforeEach(() => {
   fsRms.clear();
   execFileCalls.length = 0;
   queryExitCode = 0;
+  lastExecFileOpts = undefined;
 });
 
 // T033: buildXml puts args[0] in <Command>, rest + daemon _run in <Arguments>
@@ -104,6 +110,21 @@ describe("buildXml", () => {
     // & is XML-escaped
     expect(xml).toContain("<Command>C:\\agentsync.exe</Command>");
     expect(xml).toContain("<Arguments>daemon _run</Arguments>");
+  });
+
+  // T065: args with spaces are quoted for Windows command-line parsing
+  test("args containing spaces are double-quoted in <Arguments> (T065)", () => {
+    const xml = m.buildXml(["bun", "C:\\Program Files\\cli.js"]);
+    expect(xml).toContain("<Command>bun</Command>");
+    // The script path should be quoted because it contains a space
+    expect(xml).toContain('"C:\\Program Files\\cli.js"');
+    expect(xml).toContain("daemon _run");
+  });
+
+  test("args containing double quotes are escaped with backslash (T065)", () => {
+    const xml = m.buildXml(["bun", '/path/with"quote']);
+    const args = xml.match(/<Arguments>(.*?)<\/Arguments>/)?.[1] ?? "";
+    expect(args).toContain('\\"');
   });
 });
 
@@ -158,6 +179,17 @@ describe("startWindows / stopWindows", () => {
   test("startWindows throws when not registered", async () => {
     queryExitCode = 1;
     await expect(m.startWindows()).rejects.toThrow("Service not bootstrapped");
+  });
+
+  // T071: startWindows passes AbortSignal to execFileAsync
+  test("startWindows passes signal option to execFileAsync for /Run (T071)", async () => {
+    queryExitCode = 0; // installed
+    await m.startWindows();
+
+    const runCall = execFileCalls.find((c) => c.cmd === "schtasks" && c.args[0] === "/Run");
+    expect(runCall).toBeDefined();
+    expect(lastExecFileOpts).toBeDefined();
+    expect(lastExecFileOpts?.signal).toBeInstanceOf(AbortSignal);
   });
 
   test("stopWindows calls schtasks /End with the task name", async () => {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -166,49 +166,58 @@ export async function startDaemon(): Promise<void> {
 
   for (const target of watchTargets) {
     watcher.add(target, debounceMs, async () => {
-      await queue.enqueue(async () => {
-        try {
-          const result = await withRetry(() => performPush());
-          if (result.fatal) {
-            for (const err of result.errors) {
-              log.error(`${ts()} ${err}`);
+      await queue
+        .enqueue(async () => {
+          try {
+            const result = await withRetry(() => performPush());
+            if (result.fatal) {
+              for (const err of result.errors) {
+                log.error(`${ts()} ${err}`);
+              }
+              recordFailure("push", result.errors.join("; "));
+            } else {
+              recordSuccess();
             }
-            recordFailure("push", result.errors.join("; "));
-          } else {
-            recordSuccess();
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            recordFailure("push", msg);
           }
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          recordFailure("push", msg);
-        }
-      });
+        })
+        .catch(() => {
+          // Queue closed during shutdown — safe to ignore
+        });
     });
   }
 
   // Periodic pull using interval from config
   const pullTimer = setInterval(async () => {
-    await queue.enqueue(async () => {
-      try {
-        const result = await withRetry(() => performPull());
-        if (result.fatal) {
-          for (const err of result.errors) {
-            log.error(`${ts()} ${err}`);
+    await queue
+      .enqueue(async () => {
+        try {
+          const result = await withRetry(() => performPull());
+          if (result.fatal) {
+            for (const err of result.errors) {
+              log.error(`${ts()} ${err}`);
+            }
+            recordFailure("pull", result.errors.join("; "));
+          } else {
+            recordSuccess();
           }
-          recordFailure("pull", result.errors.join("; "));
-        } else {
-          recordSuccess();
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          recordFailure("pull", msg);
         }
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        recordFailure("pull", msg);
-      }
-    });
+      })
+      .catch(() => {
+        // Queue closed during shutdown — safe to ignore
+      });
   }, pullIntervalMs);
 
   // ── Graceful shutdown (US1) ──────────────────────────────────────────────
   const shutdown = async () => {
     clearInterval(pullTimer);
     ipc.close();
+    queue.close();
     // Drain in-flight sync operations with a hard timeout (FR-013)
     await Promise.race([queue.whenIdle(), delay(10_000)]);
     await watcher.close();

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,3 +1,4 @@
+import { access, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
 import { log } from "@clack/prompts";
 import { performPull } from "../commands/pull";
@@ -5,51 +6,149 @@ import { performPush } from "../commands/push";
 import { resolveRuntimeContext } from "../commands/shared";
 import { loadConfig, resolveConfigPath } from "../config/loader";
 import { AgentPaths } from "../config/paths";
-import { IpcServer } from "../core/ipc";
+import { DaemonStatusSchema } from "../config/schema";
+import { IpcClient, IpcServer } from "../core/ipc";
+import { SyncQueue } from "../core/sync-queue";
 import { Watcher } from "../core/watcher";
-
-/** Delegate pull requests through the shared command pipeline used by the CLI. */
-async function runPull(): Promise<{ applied: number; errors: string[]; fatal: boolean }> {
-  const result = await performPull();
-  if (result.fatal) {
-    for (const err of result.errors) {
-      log.error(`${ts()} ${err}`);
-    }
-  }
-  return result;
-}
 
 /** Format daemon log timestamps consistently across lifecycle events. */
 const ts = () => new Date().toISOString();
+
+// ── Failure tracking (US2) ─────────────────────────────────────────────────────
+let consecutiveFailures = 0;
+let lastError: string | null = null;
+
+/** Reset failure counters after a successful sync operation. */
+function recordSuccess(): void {
+  consecutiveFailures = 0;
+  lastError = null;
+}
+
+/**
+ * Increment the consecutive failure counter and capture the error message.
+ * The operation type is always included in `lastError` for diagnostics per FR-004.
+ * `lastError` MUST NOT include key file content — only paths and error codes.
+ */
+function recordFailure(op: "push" | "pull", msg: string): void {
+  consecutiveFailures += 1;
+  lastError = `[${op}] ${msg}`;
+}
+
+// ── Retry logic (US3) ──────────────────────────────────────────────────────────
+
+/**
+ * Calls `fn` once; on failure retries exactly once.
+ * The second attempt's result (resolve or reject) propagates to the caller.
+ */
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch {
+    return await fn();
+  }
+}
 
 /**
  * Start the IPC server, file watchers, and periodic pull loop for background sync.
  * @returns A promise that resolves once the daemon has bound its IPC socket and registered watchers.
  */
 export async function startDaemon(): Promise<void> {
-  const runtime = await resolveRuntimeContext();
+  // ── Startup validation (FR-006, FR-007, SC-006) ──────────────────────────
+  let runtime: Awaited<ReturnType<typeof resolveRuntimeContext>>;
+  try {
+    runtime = await resolveRuntimeContext();
+    // Eagerly load config to validate vault accessibility
+    await loadConfig(resolveConfigPath(runtime.vaultDir));
+    // Validate encryption key is readable (FR-007)
+    await access(runtime.privateKeyPath);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error(`${ts()} Startup failed: ${msg}`);
+    process.exit(1);
+    return; // unreachable but satisfies TS control flow
+  }
+
   const config = await loadConfig(resolveConfigPath(runtime.vaultDir));
   const socketPath = (await import("../config/paths")).resolveDaemonSocketPath();
 
+  // ── Second-instance detection (FR-009, SC-005) ───────────────────────────
+  const client = new IpcClient();
+  try {
+    const response = await client.send("status", {}, socketPath);
+    if (response.ok) {
+      const pid = (response.data as { pid?: number })?.pid ?? "unknown";
+      log.info(`${ts()} Daemon is already running (pid: ${pid})`);
+      process.exit(1);
+      return;
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ECONNREFUSED") {
+      // Stale socket — unlink before proceeding (FR-003)
+      try {
+        await unlink(socketPath);
+      } catch {
+        // ENOENT is fine — socket already gone
+      }
+    }
+    // ENOENT = no socket file, clean start — continue
+  }
+
   const pullIntervalMs = config.sync.pullIntervalMs ?? 5 * 60 * 1000;
+
+  // ── SyncQueue (US1) ──────────────────────────────────────────────────────
+  const queue = new SyncQueue();
 
   const ipc = new IpcServer();
 
-  ipc.on("status", async () => ({ ok: true, pid: process.pid }));
+  ipc.on("status", async () =>
+    DaemonStatusSchema.parse({
+      pid: process.pid,
+      consecutiveFailures,
+      lastError,
+    }),
+  );
 
   ipc.on("push", async () => {
-    const result = await performPush();
-    if (result.fatal) {
-      for (const err of result.errors) {
-        log.error(`${ts()} ${err}`);
+    return queue.enqueue(async () => {
+      try {
+        const result = await withRetry(() => performPush());
+        if (result.fatal) {
+          for (const err of result.errors) {
+            log.error(`${ts()} ${err}`);
+          }
+          recordFailure("push", result.errors.join("; "));
+        } else {
+          recordSuccess();
+        }
+        return result;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        recordFailure("push", msg);
+        throw err;
       }
-    }
-    return result;
+    });
   });
 
   ipc.on("pull", async () => {
-    const result = await runPull();
-    return result;
+    return queue.enqueue(async () => {
+      try {
+        const result = await withRetry(() => performPull());
+        if (result.fatal) {
+          for (const err of result.errors) {
+            log.error(`${ts()} ${err}`);
+          }
+          recordFailure("pull", result.errors.join("; "));
+        } else {
+          recordSuccess();
+        }
+        return result;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        recordFailure("pull", msg);
+        throw err;
+      }
+    });
   });
 
   await ipc.listen(socketPath);
@@ -67,27 +166,65 @@ export async function startDaemon(): Promise<void> {
 
   for (const target of watchTargets) {
     watcher.add(target, debounceMs, async () => {
-      const result = await performPush();
-      if (result.fatal) {
-        for (const err of result.errors) {
-          log.error(`${ts()} ${err}`);
+      await queue.enqueue(async () => {
+        try {
+          const result = await withRetry(() => performPush());
+          if (result.fatal) {
+            for (const err of result.errors) {
+              log.error(`${ts()} ${err}`);
+            }
+            recordFailure("push", result.errors.join("; "));
+          } else {
+            recordSuccess();
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          recordFailure("push", msg);
         }
-      }
+      });
     });
   }
 
   // Periodic pull using interval from config
   const pullTimer = setInterval(async () => {
-    await runPull();
+    await queue.enqueue(async () => {
+      try {
+        const result = await withRetry(() => performPull());
+        if (result.fatal) {
+          for (const err of result.errors) {
+            log.error(`${ts()} ${err}`);
+          }
+          recordFailure("pull", result.errors.join("; "));
+        } else {
+          recordSuccess();
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        recordFailure("pull", msg);
+      }
+    });
   }, pullIntervalMs);
 
-  // Graceful shutdown
+  // ── Graceful shutdown (US1) ──────────────────────────────────────────────
   const shutdown = async () => {
     clearInterval(pullTimer);
+    ipc.close();
+    // Drain in-flight sync operations with a hard timeout (FR-013)
+    await Promise.race([queue.whenIdle(), delay(10_000)]);
     await watcher.close();
+    try {
+      await unlink(socketPath);
+    } catch {
+      // ENOENT is fine — socket already gone
+    }
     process.exit(0);
   };
 
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
+}
+
+/** Simple delay helper for shutdown timeout. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/daemon/installer-linux.ts
+++ b/src/daemon/installer-linux.ts
@@ -17,15 +17,20 @@ const SERVICE_NAME = "agentsync";
 const SYSTEMD_USER_DIR = join(homedir(), ".config", "systemd", "user");
 const SERVICE_PATH = join(SYSTEMD_USER_DIR, `${SERVICE_NAME}.service`);
 
-/** Build the systemd unit text for the current executable. */
-function buildUnit(executablePath: string): string {
+/**
+ * Build the systemd unit text for the given executable args array.
+ * systemd tokenises ExecStart by spaces, so joining args is safe here;
+ * the array form is used for interface consistency with macOS and Windows.
+ */
+export function buildUnit(args: string[]): string {
+  const execStart = [...args, "daemon", "_run"].join(" ");
   return `[Unit]
 Description=AgentSync daemon — encrypts and syncs AI agent configs
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=${executablePath} daemon _run
+ExecStart=${execStart}
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal
@@ -37,10 +42,29 @@ WantedBy=default.target
 `;
 }
 
-/** Install and start the Linux user service that runs the daemon in the background. */
-export async function installLinux(executablePath: string): Promise<void> {
+/**
+ * Check whether the Linux user service is registered with systemd.
+ * Returns true only when `systemctl --user is-enabled agentsync` outputs "enabled".
+ */
+export async function isRegisteredLinux(): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("systemctl", [
+      "--user",
+      "is-enabled",
+      SERVICE_NAME,
+    ]);
+    return stdout.trim() === "enabled";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Install and start the Linux user service that runs the daemon in the background.
+ */
+export async function installLinux(args: string[]): Promise<void> {
   await mkdir(SYSTEMD_USER_DIR, { recursive: true });
-  const unit = buildUnit(executablePath);
+  const unit = buildUnit(args);
   await writeFile(SERVICE_PATH, unit, "utf8");
 
   await execFileAsync("systemctl", ["--user", "daemon-reload"]);
@@ -72,9 +96,25 @@ export async function uninstallLinux(): Promise<void> {
   log.success(`Removed systemd user service: ${SERVICE_NAME}`);
 }
 
-/** Start the installed Linux user service. */
+/**
+ * Start the installed Linux user service.
+ * Verifies registration first; applies a 10-second timeout on the start call.
+ */
 export async function startLinux(): Promise<void> {
-  await execFileAsync("systemctl", ["--user", "start", SERVICE_NAME]);
+  if (!(await isRegisteredLinux())) {
+    throw new Error(
+      "Service not bootstrapped — run `agentsync daemon install` first.",
+    );
+  }
+  await Promise.race([
+    execFileAsync("systemctl", ["--user", "start", SERVICE_NAME]),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("Service manager start timed out.")),
+        10_000,
+      ),
+    ),
+  ]);
 }
 
 /** Stop the installed Linux user service. */

--- a/src/daemon/installer-linux.ts
+++ b/src/daemon/installer-linux.ts
@@ -48,11 +48,7 @@ WantedBy=default.target
  */
 export async function isRegisteredLinux(): Promise<boolean> {
   try {
-    const { stdout } = await execFileAsync("systemctl", [
-      "--user",
-      "is-enabled",
-      SERVICE_NAME,
-    ]);
+    const { stdout } = await execFileAsync("systemctl", ["--user", "is-enabled", SERVICE_NAME]);
     return stdout.trim() === "enabled";
   } catch {
     return false;
@@ -102,17 +98,12 @@ export async function uninstallLinux(): Promise<void> {
  */
 export async function startLinux(): Promise<void> {
   if (!(await isRegisteredLinux())) {
-    throw new Error(
-      "Service not bootstrapped — run `agentsync daemon install` first.",
-    );
+    throw new Error("Service not bootstrapped — run `agentsync daemon install` first.");
   }
   await Promise.race([
     execFileAsync("systemctl", ["--user", "start", SERVICE_NAME]),
     new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error("Service manager start timed out.")),
-        10_000,
-      ),
+      setTimeout(() => reject(new Error("Service manager start timed out.")), 10_000),
     ),
   ]);
 }

--- a/src/daemon/installer-linux.ts
+++ b/src/daemon/installer-linux.ts
@@ -18,12 +18,20 @@ const SYSTEMD_USER_DIR = join(homedir(), ".config", "systemd", "user");
 const SERVICE_PATH = join(SYSTEMD_USER_DIR, `${SERVICE_NAME}.service`);
 
 /**
+ * Quote a single argument for systemd ExecStart per systemd.syntax(7).
+ * Wraps in double quotes and applies C-style escaping for `\` and `"`.
+ */
+function quoteSystemdArg(arg: string): string {
+  return `"${arg.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
  * Build the systemd unit text for the given executable args array.
- * systemd tokenises ExecStart by spaces, so joining args is safe here;
- * the array form is used for interface consistency with macOS and Windows.
+ * Each argument is individually quoted per systemd.syntax(7) to correctly
+ * handle paths containing spaces or special characters.
  */
 export function buildUnit(args: string[]): string {
-  const execStart = [...args, "daemon", "_run"].join(" ");
+  const execStart = [...args, "daemon", "_run"].map(quoteSystemdArg).join(" ");
   return `[Unit]
 Description=AgentSync daemon — encrypts and syncs AI agent configs
 After=network.target
@@ -100,12 +108,20 @@ export async function startLinux(): Promise<void> {
   if (!(await isRegisteredLinux())) {
     throw new Error("Service not bootstrapped — run `agentsync daemon install` first.");
   }
-  await Promise.race([
-    execFileAsync("systemctl", ["--user", "start", SERVICE_NAME]),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Service manager start timed out.")), 10_000),
-    ),
-  ]);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+  try {
+    await execFileAsync("systemctl", ["--user", "start", SERVICE_NAME], {
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if ((err as Error).name === "AbortError") {
+      throw new Error("Service manager start timed out.");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 /** Stop the installed Linux user service. */

--- a/src/daemon/installer-macos.ts
+++ b/src/daemon/installer-macos.ts
@@ -17,10 +17,20 @@ const PLIST_LABEL = "com.agentsync.daemon";
 const LAUNCH_AGENTS_DIR = join(homedir(), "Library", "LaunchAgents");
 const PLIST_PATH = join(LAUNCH_AGENTS_DIR, `${PLIST_LABEL}.plist`);
 
-/** Build the launchd plist for the current executable and log directory. */
-function buildPlist(executablePath: string, logDir: string): string {
+/**
+ * Build the launchd plist for the given executable args array and log directory.
+ * Each element of `args` plus the `daemon _run` subcommand is emitted as a
+ * separate `<string>` entry — required by launchd.plist(5). A single space-joined
+ * string in ProgramArguments[0] is interpreted as the literal binary path and will
+ * cause EX_CONFIG (78) on every spawn attempt.
+ */
+export function buildPlist(args: string[], logDir: string): string {
   const stdoutLog = join(logDir, "agentsync.out.log");
   const stderrLog = join(logDir, "agentsync.err.log");
+
+  const programArgs = [...args, "daemon", "_run"]
+    .map((a) => `    <string>${a}</string>`)
+    .join("\n");
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -32,9 +42,7 @@ function buildPlist(executablePath: string, logDir: string): string {
 
   <key>ProgramArguments</key>
   <array>
-    <string>${executablePath}</string>
-    <string>daemon</string>
-    <string>_run</string>
+${programArgs}
   </array>
 
   <key>RunAtLoad</key>
@@ -61,16 +69,57 @@ function buildPlist(executablePath: string, logDir: string): string {
 `;
 }
 
-/** Install and bootstrap the macOS LaunchAgent that runs the daemon. */
-export async function installMacOs(executablePath: string): Promise<void> {
+/**
+ * Extract the service manager's stderr from an error object.
+ * Returns only the launchctl stderr line — never an internal stack trace.
+ */
+export function extractServiceManagerError(err: unknown): string {
+  if (err && typeof err === "object" && "stderr" in err) {
+    const stderr = (err as { stderr: unknown }).stderr;
+    if (typeof stderr === "string" && stderr.trim().length > 0) {
+      return stderr.trim();
+    }
+  }
+  return String(err);
+}
+
+/**
+ * Install and bootstrap the macOS LaunchAgent that runs the daemon.
+ * Uses bootout → write plist → bootstrap so re-running is idempotent
+ * (avoids "Bootstrap failed: 5" on already-registered services).
+ */
+export async function installMacOs(args: string[]): Promise<void> {
   const logDir = join(homedir(), "Library", "Logs", "AgentSync");
   await mkdir(LAUNCH_AGENTS_DIR, { recursive: true });
   await mkdir(logDir, { recursive: true });
 
-  const plist = buildPlist(executablePath, logDir);
+  // Bootout first — ignore errors (service may not be loaded)
+  try {
+    await execFileAsync("launchctl", [
+      "bootout",
+      `gui/${process.getuid?.() ?? 501}`,
+      PLIST_PATH,
+    ]);
+  } catch {
+    // Not loaded — expected on first install
+  }
+
+  const plist = buildPlist(args, logDir);
   await writeFile(PLIST_PATH, plist, "utf8");
 
-  await execFileAsync("launchctl", ["bootstrap", `gui/${process.getuid?.() ?? 501}`, PLIST_PATH]);
+  try {
+    await execFileAsync("launchctl", [
+      "bootstrap",
+      `gui/${process.getuid?.() ?? 501}`,
+      PLIST_PATH,
+    ]);
+  } catch (err) {
+    const msg = extractServiceManagerError(err);
+    throw new Error(
+      `launchd bootstrap failed: ${msg}\nHint: Check that the executable path exists and is not in a temporary directory.`,
+    );
+  }
+
   log.success(`Installed launchd service: ${PLIST_LABEL}`);
   log.info(`Plist: ${PLIST_PATH}`);
 }
@@ -78,7 +127,11 @@ export async function installMacOs(executablePath: string): Promise<void> {
 /** Boot out and remove the macOS LaunchAgent definition if it exists. */
 export async function uninstallMacOs(): Promise<void> {
   try {
-    await execFileAsync("launchctl", ["bootout", `gui/${process.getuid?.() ?? 501}`, PLIST_PATH]);
+    await execFileAsync("launchctl", [
+      "bootout",
+      `gui/${process.getuid?.() ?? 501}`,
+      PLIST_PATH,
+    ]);
   } catch {
     // Service may not be loaded — ignore
   }
@@ -92,12 +145,44 @@ export async function uninstallMacOs(): Promise<void> {
   log.success(`Removed launchd service: ${PLIST_LABEL}`);
 }
 
-/** Restart the macOS LaunchAgent immediately. */
+/**
+ * Check whether the macOS LaunchAgent is currently registered with launchd.
+ * Runs `launchctl print gui/<uid>/com.agentsync.daemon`; returns true on exit code 0.
+ */
+export async function isRegisteredMacOs(): Promise<boolean> {
+  try {
+    await execFileAsync("launchctl", [
+      "print",
+      `gui/${process.getuid?.() ?? 501}/${PLIST_LABEL}`,
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Restart the macOS LaunchAgent immediately.
+ * Verifies the service is registered first; applies a 10-second hard timeout on kickstart.
+ */
 export async function startMacOs(): Promise<void> {
-  await execFileAsync("launchctl", [
-    "kickstart",
-    "-k",
-    `gui/${process.getuid?.() ?? 501}/${PLIST_LABEL}`,
+  if (!(await isRegisteredMacOs())) {
+    throw new Error(
+      "Service not bootstrapped — run `agentsync daemon install` first.",
+    );
+  }
+  await Promise.race([
+    execFileAsync("launchctl", [
+      "kickstart",
+      "-k",
+      `gui/${process.getuid?.() ?? 501}/${PLIST_LABEL}`,
+    ]),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("Service manager start timed out.")),
+        10_000,
+      ),
+    ),
   ]);
 }
 

--- a/src/daemon/installer-macos.ts
+++ b/src/daemon/installer-macos.ts
@@ -13,6 +13,11 @@ import { log } from "@clack/prompts";
 
 const execFileAsync = promisify(execFile);
 
+/** Escape a string for safe inclusion in XML text content. */
+function escapeXml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 const PLIST_LABEL = "com.agentsync.daemon";
 const LAUNCH_AGENTS_DIR = join(homedir(), "Library", "LaunchAgents");
 const PLIST_PATH = join(LAUNCH_AGENTS_DIR, `${PLIST_LABEL}.plist`);
@@ -29,7 +34,7 @@ export function buildPlist(args: string[], logDir: string): string {
   const stderrLog = join(logDir, "agentsync.err.log");
 
   const programArgs = [...args, "daemon", "_run"]
-    .map((a) => `    <string>${a}</string>`)
+    .map((a) => `    <string>${escapeXml(a)}</string>`)
     .join("\n");
 
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -154,16 +159,22 @@ export async function startMacOs(): Promise<void> {
   if (!(await isRegisteredMacOs())) {
     throw new Error("Service not bootstrapped — run `agentsync daemon install` first.");
   }
-  await Promise.race([
-    execFileAsync("launchctl", [
-      "kickstart",
-      "-k",
-      `gui/${process.getuid?.() ?? 501}/${PLIST_LABEL}`,
-    ]),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Service manager start timed out.")), 10_000),
-    ),
-  ]);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+  try {
+    await execFileAsync(
+      "launchctl",
+      ["kickstart", "-k", `gui/${process.getuid?.() ?? 501}/${PLIST_LABEL}`],
+      { signal: controller.signal },
+    );
+  } catch (err) {
+    if ((err as Error).name === "AbortError") {
+      throw new Error("Service manager start timed out.");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 /** Ask launchd to stop the macOS daemon process. */

--- a/src/daemon/installer-macos.ts
+++ b/src/daemon/installer-macos.ts
@@ -95,11 +95,7 @@ export async function installMacOs(args: string[]): Promise<void> {
 
   // Bootout first — ignore errors (service may not be loaded)
   try {
-    await execFileAsync("launchctl", [
-      "bootout",
-      `gui/${process.getuid?.() ?? 501}`,
-      PLIST_PATH,
-    ]);
+    await execFileAsync("launchctl", ["bootout", `gui/${process.getuid?.() ?? 501}`, PLIST_PATH]);
   } catch {
     // Not loaded — expected on first install
   }
@@ -108,11 +104,7 @@ export async function installMacOs(args: string[]): Promise<void> {
   await writeFile(PLIST_PATH, plist, "utf8");
 
   try {
-    await execFileAsync("launchctl", [
-      "bootstrap",
-      `gui/${process.getuid?.() ?? 501}`,
-      PLIST_PATH,
-    ]);
+    await execFileAsync("launchctl", ["bootstrap", `gui/${process.getuid?.() ?? 501}`, PLIST_PATH]);
   } catch (err) {
     const msg = extractServiceManagerError(err);
     throw new Error(
@@ -127,11 +119,7 @@ export async function installMacOs(args: string[]): Promise<void> {
 /** Boot out and remove the macOS LaunchAgent definition if it exists. */
 export async function uninstallMacOs(): Promise<void> {
   try {
-    await execFileAsync("launchctl", [
-      "bootout",
-      `gui/${process.getuid?.() ?? 501}`,
-      PLIST_PATH,
-    ]);
+    await execFileAsync("launchctl", ["bootout", `gui/${process.getuid?.() ?? 501}`, PLIST_PATH]);
   } catch {
     // Service may not be loaded — ignore
   }
@@ -151,10 +139,7 @@ export async function uninstallMacOs(): Promise<void> {
  */
 export async function isRegisteredMacOs(): Promise<boolean> {
   try {
-    await execFileAsync("launchctl", [
-      "print",
-      `gui/${process.getuid?.() ?? 501}/${PLIST_LABEL}`,
-    ]);
+    await execFileAsync("launchctl", ["print", `gui/${process.getuid?.() ?? 501}/${PLIST_LABEL}`]);
     return true;
   } catch {
     return false;
@@ -167,9 +152,7 @@ export async function isRegisteredMacOs(): Promise<boolean> {
  */
 export async function startMacOs(): Promise<void> {
   if (!(await isRegisteredMacOs())) {
-    throw new Error(
-      "Service not bootstrapped — run `agentsync daemon install` first.",
-    );
+    throw new Error("Service not bootstrapped — run `agentsync daemon install` first.");
   }
   await Promise.race([
     execFileAsync("launchctl", [
@@ -178,10 +161,7 @@ export async function startMacOs(): Promise<void> {
       `gui/${process.getuid?.() ?? 501}/${PLIST_LABEL}`,
     ]),
     new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error("Service manager start timed out.")),
-        10_000,
-      ),
+      setTimeout(() => reject(new Error("Service manager start timed out.")), 10_000),
     ),
   ]);
 }

--- a/src/daemon/installer-windows.ts
+++ b/src/daemon/installer-windows.ts
@@ -16,10 +16,7 @@ const TASK_NAME = "AgentSync";
 
 /** Escape a string for use in XML attribute and text content. */
 function escapeXml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 /**
@@ -29,9 +26,7 @@ function escapeXml(value: string): string {
  */
 export function buildXml(args: string[]): string {
   const command = escapeXml(args[0] ?? "");
-  const scriptAndSubcmd = [...args.slice(1), "daemon", "_run"]
-    .map(escapeXml)
-    .join(" ");
+  const scriptAndSubcmd = [...args.slice(1), "daemon", "_run"].map(escapeXml).join(" ");
 
   return `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
@@ -111,17 +106,12 @@ export async function uninstallWindows(): Promise<void> {
  */
 export async function startWindows(): Promise<void> {
   if (!(await isInstalledWindows())) {
-    throw new Error(
-      "Service not bootstrapped — run `agentsync daemon install` first.",
-    );
+    throw new Error("Service not bootstrapped — run `agentsync daemon install` first.");
   }
   await Promise.race([
     execFileAsync("schtasks", ["/Run", "/TN", TASK_NAME]),
     new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error("Service manager start timed out.")),
-        10_000,
-      ),
+      setTimeout(() => reject(new Error("Service manager start timed out.")), 10_000),
     ),
   ]);
 }

--- a/src/daemon/installer-windows.ts
+++ b/src/daemon/installer-windows.ts
@@ -20,13 +20,28 @@ function escapeXml(value: string): string {
 }
 
 /**
+ * Quote a single argument for Windows command-line parsing.
+ * Wraps in double quotes if the value contains whitespace or `"`, and escapes
+ * internal double quotes with `\"` per `CommandLineToArgvW` conventions.
+ */
+function quoteWinArg(arg: string): string {
+  if (/[\s"]/.test(arg) || arg === "") {
+    return `"${arg.replace(/"/g, '\\"')}"`;
+  }
+  return arg;
+}
+
+/**
  * Build the Task Scheduler XML definition for the given executable args array.
  * `args[0]` becomes `<Command>` (the binary only); the remaining args plus
  * `daemon _run` become `<Arguments>` — matching the Task Scheduler XML schema.
  */
 export function buildXml(args: string[]): string {
   const command = escapeXml(args[0] ?? "");
-  const scriptAndSubcmd = [...args.slice(1), "daemon", "_run"].map(escapeXml).join(" ");
+  const scriptAndSubcmd = [...args.slice(1), "daemon", "_run"]
+    .map(quoteWinArg)
+    .map(escapeXml)
+    .join(" ");
 
   return `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
@@ -108,12 +123,18 @@ export async function startWindows(): Promise<void> {
   if (!(await isInstalledWindows())) {
     throw new Error("Service not bootstrapped — run `agentsync daemon install` first.");
   }
-  await Promise.race([
-    execFileAsync("schtasks", ["/Run", "/TN", TASK_NAME]),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Service manager start timed out.")), 10_000),
-    ),
-  ]);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+  try {
+    await execFileAsync("schtasks", ["/Run", "/TN", TASK_NAME], { signal: controller.signal });
+  } catch (err) {
+    if ((err as Error).name === "AbortError") {
+      throw new Error("Service manager start timed out.");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 /** Stop the running Windows scheduled task instance. */

--- a/src/daemon/installer-windows.ts
+++ b/src/daemon/installer-windows.ts
@@ -14,12 +14,24 @@ const execFileAsync = promisify(execFile);
 
 const TASK_NAME = "AgentSync";
 
-/** Build the Task Scheduler XML definition for the current executable. */
-function buildXml(executablePath: string): string {
-  const escapedPath = executablePath
+/** Escape a string for use in XML attribute and text content. */
+function escapeXml(value: string): string {
+  return value
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
+
+/**
+ * Build the Task Scheduler XML definition for the given executable args array.
+ * `args[0]` becomes `<Command>` (the binary only); the remaining args plus
+ * `daemon _run` become `<Arguments>` — matching the Task Scheduler XML schema.
+ */
+export function buildXml(args: string[]): string {
+  const command = escapeXml(args[0] ?? "");
+  const scriptAndSubcmd = [...args.slice(1), "daemon", "_run"]
+    .map(escapeXml)
+    .join(" ");
 
   return `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
@@ -43,17 +55,20 @@ function buildXml(executablePath: string): string {
   </Settings>
   <Actions Context="Author">
     <Exec>
-      <Command>${escapedPath}</Command>
-      <Arguments>daemon _run</Arguments>
+      <Command>${command}</Command>
+      <Arguments>${scriptAndSubcmd}</Arguments>
     </Exec>
   </Actions>
 </Task>
 `;
 }
 
-/** Install and start the Windows scheduled task that runs the daemon at logon. */
-export async function installWindows(executablePath: string): Promise<void> {
-  const xml = buildXml(executablePath);
+/**
+ * Install and start the Windows scheduled task that runs the daemon at logon.
+ * `args[0]` is the binary; remaining args plus `daemon _run` go into `<Arguments>`.
+ */
+export async function installWindows(args: string[]): Promise<void> {
+  const xml = buildXml(args);
   const tmpXml = `${process.env.TEMP ?? "C:\\Temp"}\\agentsync-task.xml`;
 
   const { writeFile, rm } = await import("node:fs/promises");
@@ -90,9 +105,25 @@ export async function uninstallWindows(): Promise<void> {
   log.success(`Removed Windows scheduled task: ${TASK_NAME}`);
 }
 
-/** Start the installed Windows scheduled task immediately. */
+/**
+ * Start the Windows scheduled task.
+ * Uses `isInstalledWindows()` as the registration check; applies a 10-second timeout.
+ */
 export async function startWindows(): Promise<void> {
-  await execFileAsync("schtasks", ["/Run", "/TN", TASK_NAME]);
+  if (!(await isInstalledWindows())) {
+    throw new Error(
+      "Service not bootstrapped — run `agentsync daemon install` first.",
+    );
+  }
+  await Promise.race([
+    execFileAsync("schtasks", ["/Run", "/TN", TASK_NAME]),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("Service manager start timed out.")),
+        10_000,
+      ),
+    ),
+  ]);
 }
 
 /** Stop the running Windows scheduled task instance. */

--- a/src/daemon/installer-windows.ts
+++ b/src/daemon/installer-windows.ts
@@ -20,13 +20,19 @@ function escapeXml(value: string): string {
 }
 
 /**
- * Quote a single argument for Windows command-line parsing.
- * Wraps in double quotes if the value contains whitespace or `"`, and escapes
- * internal double quotes with `\"` per `CommandLineToArgvW` conventions.
+ * Quote a single argument for Windows command-line parsing per `CommandLineToArgvW`.
+ *
+ * Rules: backslashes before a `"` or at end-of-string must be doubled so the
+ * closing quote is not accidentally escaped. Backslashes elsewhere are literal.
  */
 function quoteWinArg(arg: string): string {
-  if (/[\s"]/.test(arg) || arg === "") {
-    return `"${arg.replace(/"/g, '\\"')}"`;
+  if (/[\s"\\]/.test(arg) || arg === "") {
+    const escaped = arg.replace(
+      /(\\*)("|$)/g,
+      (_match, slashes: string, quote: string) =>
+        slashes.replace(/\\/g, "\\\\") + (quote ? '\\"' : ""),
+    );
+    return `"${escaped}"`;
   }
   return arg;
 }


### PR DESCRIPTION
## Summary

Stabilise the AgentSync background daemon by fixing three confirmed installer bugs and hardening the runtime with sync serialisation, retry-once recovery, failure tracking, and clean shutdown. See `specs/20260406-094347-stabilise-daemon/spec.md` for full specification.

**Motivation**: The daemon was silently failing on macOS due to malformed `ProgramArguments` (EX_CONFIG 78), ephemeral bunx temp paths breaking after reboot, and non-idempotent re-install. Runtime lacked sync serialisation, error visibility, and graceful shutdown.

## Changes

### Core (`src/core/`)
- **`sync-queue.ts`** (NEW): Promise-chain queue serialising all push/pull operations (`enqueue`, `whenIdle`)
- **`sync-queue.test.ts`** (NEW): 6 tests — serial execution, whenIdle drain, error isolation

### Daemon Runtime (`src/daemon/`)
- **`index.ts`**: SyncQueue integration, `withRetry` single-retry wrapper, `recordSuccess`/`recordFailure` tracking, second-instance detection via IPC health-ping, startup validation (vault/config/key), graceful shutdown with 10s drain timeout
- **`installer-macos.ts`**: `buildPlist` emits separate `<string>` elements (fixes EX_CONFIG 78), `bootout`-before-`bootstrap` for idempotent re-install, `isRegisteredMacOs`, `extractServiceManagerError`
- **`installer-linux.ts`**: `buildUnit` with `string[]` args, `isRegisteredLinux` via `systemctl --user is-enabled`
- **`installer-windows.ts`**: `buildXml` splits `<Command>` / `<Arguments>`, `escapeXml` helper

### CLI Commands (`src/commands/`)
- **`daemon.ts`**: `getExecutableArgs(): string[]` with ephemeral path detection, `PlatformInstaller.isRegistered()`, `start` guards on registration, `status` shows `consecutiveFailures`/`lastError`

### Schema (`src/config/`)
- **`schema.ts`**: `DaemonStatusSchema` (Zod) — `pid`, `consecutiveFailures`, `lastError`

### Documentation
- **`docs/daemon.md`** (NEW): Mermaid `stateDiagram-v2` covering full daemon lifecycle

### Architecture

#### Before

```mermaid
flowchart LR
  classDef oldNode fill:#e74c3c,color:#ffffff
  classDef okNode fill:#ecf0f1,color:#2c3e50

  CLI["daemon install"]:::okNode --> Installer["installer-macos<br/>Single-string ProgramArguments"]:::oldNode
  Daemon["daemon/index.ts<br/>No queue, no retry,<br/>no failure tracking"]:::oldNode --> Push["performPush - concurrent"]:::oldNode
  Daemon --> Pull["performPull - concurrent"]:::oldNode
  Daemon --> Shutdown["process.exit - no drain"]:::oldNode
```

#### After

```mermaid
flowchart LR
  classDef newNode fill:#27ae60,color:#ffffff
  classDef okNode fill:#ecf0f1,color:#2c3e50

  CLI["daemon install"]:::okNode --> Installer["installer-macos<br/>Separate ProgramArguments<br/>bootout + bootstrap"]:::newNode
  Daemon["daemon/index.ts<br/>SyncQueue + withRetry<br/>+ failure tracking"]:::newNode --> Queue["SyncQueue<br/>serialised"]:::newNode
  Queue --> Push["performPush"]:::okNode
  Queue --> Pull["performPull"]:::okNode
  Daemon --> Shutdown["drain queue + ipc.close<br/>+ unlink socket + exit"]:::newNode
```

## Test Evidence

```
249 pass
0 fail
480 expect() calls
Ran 249 tests across 27 files. [10.03s]
```

- All files above 70% function/line coverage threshold
- `daemon/index.ts`: 96.67% functions, 87.18% lines
- `installer-macos.ts`: 93.75% functions, 87.36% lines
- `commands/daemon.ts`: 93.33% functions, 80.00% lines
- Typecheck: clean
- Lint (biome ci): clean
- **56/62 tasks complete** in `tasks.md` — remaining 6 are manual quickstart scenarios (T050-T055)

## Risks / Follow-ups

- **T050-T055 (manual quickstart scenarios)**: Require live macOS host for end-to-end validation — not automated
- **Module-level state in `daemon/index.ts`**: `consecutiveFailures` and `lastError` are module-scoped; acceptable for a singleton daemon process but would need refactoring if the module is ever imported in a multi-instance context
- **Windows installer**: `isRegisteredWindows` aliases `isInstalledWindows` (checks XML file presence, not Task Scheduler registration) — acceptable for now but could diverge

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon status now reports PID, consecutive failures and last error; second-instance detection prevents duplicate daemons; single-retry for transient syncs and serialized sync queueing.

* **Bug Fixes**
  * Stronger startup validation and clearer install/start errors; improved cross‑platform installer argument handling; graceful shutdown drains work and removes stale IPC sockets.

* **Documentation**
  * New lifecycle, specification, checklist, quickstart and development guidelines added.

* **Tests**
  * Expanded test coverage for daemon behavior, installers, and the sync queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->