### PR TITLE
feat(migrate): add cross-agent configuration migration command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Auto-generated from all feature plans. Last updated: 2026-04-06
 
 ## Active Technologies
-- TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), @iarna/toml 2.2.x (Codex TOML), zod 4.x (validation) (20260406-125441-config-migration)
+- TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), @iarna/toml ^2.2.5 (Codex TOML), zod 4.x (validation) (20260406-125441-config-migration)
 - Local filesystem only (agent config files via `AgentPaths` from `src/config/paths.ts`) (20260406-125441-config-migration)
 
 - TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x (20260406-094347-stabilise-daemon)
@@ -24,7 +24,7 @@ bun run check
 TypeScript 6.x, strict mode (`"strict": true`): Follow standard conventions
 
 ## Recent Changes
-- 20260406-125441-config-migration: Added TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), @iarna/toml 2.2.x (Codex TOML), zod 4.x (validation)
+- 20260406-125441-config-migration: Added TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), @iarna/toml ^2.2.5 (Codex TOML), zod 4.x (validation)
 
 - 20260406-094347-stabilise-daemon: Added TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 Auto-generated from all feature plans. Last updated: 2026-04-06
 
 ## Active Technologies
+- TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), @iarna/toml 2.2.x (Codex TOML), zod 4.x (validation) (20260406-125441-config-migration)
+- Local filesystem only (agent config files via `AgentPaths` from `src/config/paths.ts`) (20260406-125441-config-migration)
 
 - TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x (20260406-094347-stabilise-daemon)
 
@@ -22,6 +24,7 @@ bun run check
 TypeScript 6.x, strict mode (`"strict": true`): Follow standard conventions
 
 ## Recent Changes
+- 20260406-125441-config-migration: Added TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), @iarna/toml 2.2.x (Codex TOML), zod 4.x (validation)
 
 - 20260406-094347-stabilise-daemon: Added TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -173,6 +173,33 @@ bunx --package @chrisleekr/agentsync agentsync key rotate
 - Rotation depends on the old private key still being available so existing vault files can be decrypted.
 - Recipient names should describe machines clearly because they become the stable config key.
 
+## migrate
+
+**Why**: Translate configuration from one agent's format to another — global rules, MCP servers, or commands.
+
+**Typical usage**:
+
+```bash
+bunx --package @chrisleekr/agentsync agentsync migrate --from claude --to cursor
+bunx --package @chrisleekr/agentsync agentsync migrate --from claude --to all --type mcp
+bunx --package @chrisleekr/agentsync agentsync migrate --from claude --to cursor --type commands --name review.md
+bunx --package @chrisleekr/agentsync agentsync migrate --from claude --to cursor --dry-run
+```
+
+**Needs**: source agent config files present on disk. No vault initialisation required.
+
+**Outcome**: target agent config files are created or updated with translated content from the source agent.
+
+**Config types**: `global-rules`, `mcp`, `commands`. Omit `--type` to migrate all.
+
+**Caveats**:
+
+- Migration is a one-shot local operation — it does not push or pull from the vault.
+- Colliding entries are overwritten. For MCP servers, per-server merge preserves target-only servers.
+- Migration aborts if literal secrets (API keys, tokens) are detected in MCP content.
+- Skills migration is not supported — deferred to a follow-up issue.
+- Use `--dry-run` to preview changes before writing.
+
 ## Source-based execution
 
 If you are working from a clone before a package is published, use the contributor workflow from [development.md](development.md) and run commands through `bun run src/cli.ts ...`.

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -1,0 +1,110 @@
+# Cross-Agent Configuration Migration
+
+## Overview
+
+The `agentsync migrate` command translates configuration from one AI agent's format to another. It reads local agent config files, transforms them through format-specific translators, and writes the result to the target agent's config location.
+
+No vault initialisation is required — `migrate` operates on local files only.
+
+## Command
+
+```bash
+agentsync migrate --from <agent> --to <agent|all> [--type <type>] [--name <file>] [--dry-run]
+```
+
+| Flag | Required | Values | Description |
+|------|----------|--------|-------------|
+| `--from` | yes | claude, cursor, codex, copilot, vscode | Source agent |
+| `--to` | yes | claude, cursor, codex, copilot, vscode, all | Target agent(s) |
+| `--type` | no | global-rules, mcp, commands | Filter to one config type |
+| `--name` | no | filename (requires --type) | Migrate a single artefact |
+| `--dry-run` | no | — | Preview without writing |
+
+## Config Type Support Matrix
+
+| From \ To | Claude | Cursor | Codex | Copilot | VS Code |
+|-----------|--------|--------|-------|---------|---------|
+| **Claude** | — | GR, MCP, CMD | GR, MCP, CMD | GR, CMD | MCP |
+| **Cursor** | GR, MCP, CMD | — | GR, MCP, CMD | GR, CMD | MCP |
+| **Codex** | GR, MCP, CMD | GR, MCP, CMD | — | GR, CMD | MCP |
+| **Copilot** | GR, CMD | GR, CMD | GR, CMD | — | — |
+| **VS Code** | MCP | MCP | MCP | — | — |
+
+**GR** = global-rules, **MCP** = MCP servers, **CMD** = commands
+
+## Migration Flow
+
+```mermaid
+flowchart TD
+    classDef input fill:#1a5276,color:#ffffff
+    classDef process fill:#1e8449,color:#ffffff
+    classDef decision fill:#7d3c98,color:#ffffff
+    classDef output fill:#b9770e,color:#ffffff
+    classDef skip fill:#922b21,color:#ffffff
+
+    CLI["CLI: parse --from, --to, --type, --name, --dry-run"]:::input
+    VALIDATE["Validate agent names and flags"]:::process
+    RESOLVE["Resolve targets and config types"]:::process
+    LOOP["For each target + config type"]:::process
+    LOOKUP["Lookup translator in registry"]:::decision
+    NO_TRANSLATOR["Skip: no translator"]:::skip
+    READ["Read source artefacts"]:::process
+    TRANSLATE["Translate content"]:::process
+    DETECT{"MCP? Check for secrets"}:::decision
+    ABORT["ABORT: secrets found"]:::skip
+    DRYRUN{"Dry run?"}:::decision
+    PREVIEW["Log preview"]:::output
+    WRITE["Write to target"]:::process
+    REPORT["Print summary"]:::output
+
+    CLI --> VALIDATE --> RESOLVE --> LOOP
+    LOOP --> LOOKUP
+    LOOKUP -->|"not found"| NO_TRANSLATOR
+    LOOKUP -->|"found"| READ --> TRANSLATE --> DETECT
+    DETECT -->|"secrets"| ABORT
+    DETECT -->|"clean"| DRYRUN
+    DRYRUN -->|"yes"| PREVIEW
+    DRYRUN -->|"no"| WRITE
+    WRITE --> REPORT
+    PREVIEW --> REPORT
+    NO_TRANSLATOR --> LOOP
+```
+
+## Key Behaviours
+
+- **Overwrite on collision**: If the target already has a matching entry, the source value wins.
+- **MCP per-server merge**: Only colliding server names are overwritten; target-only servers are preserved.
+- **Secret detection**: If API keys or tokens are found in MCP `env` fields, migration aborts with a clear error. Remove literal secrets and retry.
+- **Graceful skipping**: Missing source files and unsupported pairs produce skip messages, not errors.
+
+## Examples
+
+### Migrate everything from Claude to Cursor
+
+```bash
+agentsync migrate --from claude --to cursor --dry-run   # preview
+agentsync migrate --from claude --to cursor              # apply
+```
+
+### Migrate only MCP servers to Codex (JSON → TOML)
+
+```bash
+agentsync migrate --from claude --to codex --type mcp
+```
+
+### Broadcast to all agents
+
+```bash
+agentsync migrate --from claude --to all
+```
+
+### Migrate a single command file
+
+```bash
+agentsync migrate --from claude --to cursor --type commands --name review.md
+```
+
+## Related docs
+
+- [command-reference.md](command-reference.md)
+- [architecture.md](architecture.md)

--- a/specs/20260406-125441-config-migration/checklists/requirements.md
+++ b/specs/20260406-125441-config-migration/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Cross-Agent Configuration Migration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (Out of Scope section added)
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation after clarification session.
+- 3 clarifications resolved: conflict resolution scope, vault dependency, MCP merge strategy.
+- Spec aligned with GitHub issue #15 (config type support matrix, CLI flags, out-of-scope items, secret redaction).

--- a/specs/20260406-125441-config-migration/contracts/cli-migrate.md
+++ b/specs/20260406-125441-config-migration/contracts/cli-migrate.md
@@ -5,7 +5,7 @@
 
 ## Command Signature
 
-```
+```bash
 agentsync migrate --from <agent> --to <agent|all> [--type <config-type>] [--name <artefact>] [--dry-run]
 ```
 
@@ -30,43 +30,41 @@ agentsync migrate --from <agent> --to <agent|all> [--type <config-type>] [--name
 
 ### Success (exit code 0)
 
-```
+```text
 ◆  agentsync migrate
 
 │  → ~/.cursor/mcp.json: cursor MCP servers written
 │  → ~/.cursor/commands/review.md: cursor command written
-│  ⚠ Skipped (no translator): claude→cursor skills
 │
-└  Migrated 2 artefact(s). 1 pair(s) skipped.
+└  Migrated 2 artefact(s).
 ```
 
 ### Dry-run (exit code 0)
 
-```
+```text
 ◆  agentsync migrate --dry-run
 
 │  [dry-run] → ~/.cursor/mcp.json: cursor MCP servers
 │  [dry-run] → ~/.cursor/commands/review.md: cursor command
-│  [dry-run] skipped (no translator): claude→cursor skills
 │
 └  Dry run complete. 2 artefact(s) would be written.
 ```
 
 ### Error — invalid agent (exit code 1)
 
-```
+```text
 ✖  Unknown agent "vim". Valid agents: claude, cursor, codex, copilot, vscode
 ```
 
 ### Error — --name without --type (exit code 1)
 
-```
+```text
 ✖  --name requires --type to be specified
 ```
 
 ### Error — secret detected in MCP content (exit code 1)
 
-```
+```text
 ✖  Literal secret detected in MCP server "github", field "env.GITHUB_TOKEN"
 ✖  Migration aborted. Remove secret literals from source config and retry.
 ```

--- a/specs/20260406-125441-config-migration/contracts/cli-migrate.md
+++ b/specs/20260406-125441-config-migration/contracts/cli-migrate.md
@@ -1,0 +1,89 @@
+# CLI Contract: `agentsync migrate`
+
+**Feature**: `20260406-125441-config-migration`
+**Date**: 2026-04-06
+
+## Command Signature
+
+```
+agentsync migrate --from <agent> --to <agent|all> [--type <config-type>] [--name <artefact>] [--dry-run]
+```
+
+## Arguments
+
+| Flag | Type | Required | Values | Description |
+|------|------|----------|--------|-------------|
+| `--from` | string | yes | `claude`, `cursor`, `codex`, `copilot`, `vscode` | Source agent to read configuration from |
+| `--to` | string | yes | `claude`, `cursor`, `codex`, `copilot`, `vscode`, `all` | Target agent(s) to write configuration to |
+| `--type` | string | no | `global-rules`, `mcp`, `commands` | Filter to a single config type. Omit to migrate all types. |
+| `--name` | string | no | Filename (e.g., `review.md`) | Migrate a single named artefact. Requires `--type`. |
+| `--dry-run` | boolean | no | — | Preview changes without writing to disk |
+
+## Validation Rules
+
+1. `--from` and `--to` must be recognised agent names (or `all` for `--to`)
+2. `--from` and `--to` must not be the same agent (unless `--to` is `all`)
+3. `--name` requires `--type` to be specified
+4. `--type` must be one of the defined ConfigType values
+
+## Output Behaviour
+
+### Success (exit code 0)
+
+```
+◆  agentsync migrate
+
+│  → ~/.cursor/mcp.json: cursor MCP servers written
+│  → ~/.cursor/commands/review.md: cursor command written
+│  ⚠ Skipped (no translator): claude→cursor skills
+│
+└  Migrated 2 artefact(s). 1 pair(s) skipped.
+```
+
+### Dry-run (exit code 0)
+
+```
+◆  agentsync migrate --dry-run
+
+│  [dry-run] → ~/.cursor/mcp.json: cursor MCP servers
+│  [dry-run] → ~/.cursor/commands/review.md: cursor command
+│  [dry-run] skipped (no translator): claude→cursor skills
+│
+└  Dry run complete. 2 artefact(s) would be written.
+```
+
+### Error — invalid agent (exit code 1)
+
+```
+✖  Unknown agent "vim". Valid agents: claude, cursor, codex, copilot, vscode
+```
+
+### Error — --name without --type (exit code 1)
+
+```
+✖  --name requires --type to be specified
+```
+
+### Error — secret detected in MCP content (exit code 1)
+
+```
+✖  Literal secret detected in MCP server "github", field "env.GITHUB_TOKEN"
+✖  Migration aborted. Remove secret literals from source config and retry.
+```
+
+## Return Type (programmatic)
+
+`performMigrate()` returns `MigrateResult`:
+
+```typescript
+interface MigrateResult {
+  migrated: MigratedArtifact[];
+  skipped: Array<{ reason: string; pair: MigrationPair }>;
+  warnings: string[];
+  errors: string[];
+}
+```
+
+- Never throws on missing source files
+- `errors` is non-empty for fatal validation failures (invalid agent name, detected secrets in MCP content)
+- Individual write failures are caught per-artefact and reported in `errors` without aborting remaining artefacts

--- a/specs/20260406-125441-config-migration/data-model.md
+++ b/specs/20260406-125441-config-migration/data-model.md
@@ -56,14 +56,14 @@ Aggregate outcome of a migration operation.
 |-------|------|-------------|
 | migrated | MigratedArtifact[] | Successfully translated and written (or previewed) items |
 | skipped | Array<{ reason: string; pair: MigrationPair }> | Items not migrated, with explanation |
-| warnings | string[] | Non-fatal issues (e.g., secret redaction applied) |
+| warnings | string[] | Non-fatal issues (e.g., unsupported field ignored, deprecated mapping applied) |
 | errors | string[] | Fatal issues that prevented migration |
 
 ### Translator (Function Type)
 
 Pure function that converts source content to target format.
 
-```
+```typescript
 (sourceContent: string, sourceName?: string) → { content: string; targetName: string } | null
 ```
 

--- a/specs/20260406-125441-config-migration/data-model.md
+++ b/specs/20260406-125441-config-migration/data-model.md
@@ -1,0 +1,109 @@
+# Data Model: Cross-Agent Configuration Migration
+
+**Feature**: `20260406-125441-config-migration`
+**Date**: 2026-04-06
+
+## Entities
+
+### ConfigType
+
+Enumeration of translatable configuration categories.
+
+| Value | Description |
+|-------|-------------|
+| `global-rules` | Agent-wide instruction files (CLAUDE.md, AGENTS.md, instructions.md, Cursor rules string) |
+| `mcp` | MCP server definitions (JSON mcpServers or TOML mcp.servers) |
+| `commands` | Command/rule/prompt Markdown files (directory + extension conventions) |
+
+**Note**: `skills` is explicitly out of scope for this feature.
+
+### McpServer (Intermediate Representation)
+
+Canonical shape shared by all agents' MCP configurations, used as the translation bridge between JSON and TOML formats.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Server identifier (key in mcpServers object or TOML table name) |
+| command | string | yes | Executable command to run the server |
+| args | string[] | no | Command-line arguments (default: []) |
+| env | Record<string, string> | no | Environment variables (default: {}) |
+
+### MigrationPair
+
+Identifies a specific directional translation.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| from | AgentName | yes | Source agent |
+| to | AgentName | yes | Target agent |
+| type | ConfigType | yes | Configuration type being translated |
+
+### MigratedArtifact
+
+Represents a single file or config entry that was (or would be) written.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| targetPath | string | yes | Absolute destination path on disk |
+| content | string | yes | Transformed content ready to write |
+| description | string | yes | Human-readable summary of the transformation |
+
+### MigrateResult
+
+Aggregate outcome of a migration operation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| migrated | MigratedArtifact[] | Successfully translated and written (or previewed) items |
+| skipped | Array<{ reason: string; pair: MigrationPair }> | Items not migrated, with explanation |
+| warnings | string[] | Non-fatal issues (e.g., secret redaction applied) |
+| errors | string[] | Fatal issues that prevented migration |
+
+### Translator (Function Type)
+
+Pure function that converts source content to target format.
+
+```
+(sourceContent: string, sourceName?: string) → { content: string; targetName: string } | null
+```
+
+- Returns `null` when content is empty or untranslatable
+- `sourceName` is provided for file-based types (commands) to derive the target filename
+- `targetName` may be a sentinel value (e.g., `__cursor_rules__`) for inline config targets
+
+## Relationships
+
+```mermaid
+flowchart LR
+    classDef entity fill:#1a5276,color:#ffffff
+    classDef enum fill:#1e8449,color:#ffffff
+    classDef func fill:#7d3c98,color:#ffffff
+
+    ConfigType["ConfigType<br/>global-rules / mcp / commands"]:::enum
+    MigrationPair["MigrationPair<br/>from + to + type"]:::entity
+    Translator["Translator<br/>sourceContent → targetContent"]:::func
+    McpServer["McpServer<br/>name + command + args + env"]:::entity
+    MigratedArtifact["MigratedArtifact<br/>targetPath + content"]:::entity
+    MigrateResult["MigrateResult<br/>migrated + skipped + warnings"]:::entity
+
+    MigrationPair -->|"references"| ConfigType
+    MigrationPair -->|"resolves to"| Translator
+    Translator -->|"produces"| MigratedArtifact
+    Translator -->|"uses as intermediate"| McpServer
+    MigrateResult -->|"contains"| MigratedArtifact
+    MigrateResult -->|"references skipped"| MigrationPair
+```
+
+## Config Type Support Matrix
+
+Defines which (from → to) pairs have registered translators:
+
+| From \ To | Claude | Cursor | Codex | Copilot | VS Code |
+|-----------|--------|--------|-------|---------|---------|
+| **Claude** | — | GR, MCP, CMD | GR, MCP, CMD | GR, CMD | MCP |
+| **Cursor** | GR, MCP, CMD | — | GR, MCP, CMD | GR, CMD | MCP |
+| **Codex** | GR, MCP, CMD | GR, MCP, CMD | — | GR, CMD | MCP |
+| **Copilot** | GR, CMD | GR, CMD | GR, CMD | — | — |
+| **VS Code** | MCP | MCP | MCP | — | — |
+
+Legend: GR = global-rules, MCP = mcp, CMD = commands

--- a/specs/20260406-125441-config-migration/plan.md
+++ b/specs/20260406-125441-config-migration/plan.md
@@ -1,0 +1,174 @@
+# Implementation Plan: Cross-Agent Configuration Migration
+
+**Branch**: `20260406-125441-config-migration` | **Date**: 2026-04-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/20260406-125441-config-migration/spec.md`
+
+## Summary
+
+Add an `agentsync migrate` command that translates configuration artefacts (global rules, MCP servers, commands) from one AI agent's format to another. Uses a translator registry pattern where each `(from, to, configType)` triple maps to a pure transformation function. Operates on local agent config files directly via `AgentPaths` — no vault dependency. MCP servers use per-server merge (preserve target-only entries). Secret detection applied to all MCP content before writing — migration aborts if secrets found (constitution Principle I).
+
+## Technical Context
+
+**Language/Version**: TypeScript 6.x, strict mode (`"strict": true`)
+**Primary Dependencies**: citty 0.2.x (CLI), @clack/prompts 1.2.x (output), @iarna/toml 2.2.x (Codex TOML), zod 4.x (validation)
+**Storage**: Local filesystem only (agent config files via `AgentPaths` from `src/config/paths.ts`)
+**Testing**: `bun test` with `__tests__/` co-located directories, `*.test.ts` convention
+**Target Platform**: macOS, Linux, Windows (cross-platform via `AgentPaths` platform detection)
+**Project Type**: CLI tool
+**Performance Goals**: N/A — one-shot command, config files are small (<100KB)
+**Constraints**: No new runtime dependencies. Must not modify source agent files. Must abort on detected secret literals in MCP content (constitution Principle I). CLI arguments must be validated with Zod (constitution Principle IV).
+**Scale/Scope**: 5 agents × 3 config types = 15 directional pairs per type, ~40 registered translators total
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Phase 0 Evaluation
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | **PASS** | FR-011 requires secret detection on MCP content; migration aborts if secrets found (not silently redacted). Aligns with constitution: "Detected secrets MUST cause the operation to abort with a clear error, not silently redact." |
+| II. Test Coverage (NON-NEGOTIABLE) | **PASS** | New runtime modules (`src/migrate/`, `src/commands/migrate.ts`) require automated tests. Target ≥70% line coverage for all modules. Translators are pure functions — highly testable with fixture inputs/outputs. |
+| III. Cross-Platform Daemon | **N/A** | Migration is a one-shot CLI command, not daemon-related. Uses platform-aware `AgentPaths` already. |
+| IV. Code Quality (Biome) | **PASS** | No new dependencies. Zod schema for `MigrateOptions` defined in `src/config/schema.ts` for CLI argument validation. Biome formatting/linting applies automatically. |
+| V. Documentation Standards | **PASS** | All exported functions require JSDoc. `docs/migrate.md` with Mermaid flow diagram required. `docs/command-reference.md` updated. |
+
+- **Test coverage impact**: Automated tests required — this is new runtime code (translators, orchestrator, CLI command).
+- **Documentation impact**: Mermaid diagram required in `docs/migrate.md` to illustrate the migration flow (read source → translate → detect secrets → write).
+- **Diagram validation**: Mermaid diagram in `docs/migrate.md` must be validated before merge.
+
+### Post-Phase 1 Re-Evaluation
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Security-First | **PASS** | Research R3 confirms `redactSecretLiterals()` is applied after translation; if secrets detected, migration aborts with clear error. No data written. |
+| II. Test Coverage | **PASS** | Each translator is a pure function testable with fixture strings. Orchestrator testable with mocked `readIfExists`/`atomicWrite`. Edge cases (write failure, partial failure) covered in T012. |
+| IV. Code Quality | **PASS** | Zero new dependencies confirmed (R6). Zod schema for MigrateOptions in `src/config/schema.ts`. Types defined in `src/migrate/types.ts`. |
+| V. Documentation | **PASS** | CLI contract in `contracts/cli-migrate.md`. Flow diagram planned for `docs/migrate.md`. Command reference updated. |
+
+## Analysis Remediations Applied
+
+Findings from `/speckit.analyze` session, all resolved:
+
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| C1: Secret redact vs abort | HIGH | Changed to abort (constitution alignment). Updated FR-011, SC-005, R3, T012, T016. |
+| C2: Read-only target edge case | MEDIUM | Added test case to T012. |
+| C3: Partial failure edge case | MEDIUM | Added test case to T012. Orchestrator catches per-artefact write errors. |
+| C4: source ≠ target validation | MEDIUM | Added to FR-009. Already covered in T013. |
+| C5: Missing command-reference.md | MEDIUM | Added to T027 scope. |
+| C6: Zod schema for CLI args | MEDIUM | Added to T002 scope. |
+| C8: File path references assumption | LOW | Added to spec Assumptions. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/20260406-125441-config-migration/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0: research findings (7 decisions)
+├── data-model.md        # Phase 1: entity definitions and relationships
+├── quickstart.md        # Phase 1: usage guide
+├── contracts/
+│   └── cli-migrate.md   # Phase 1: CLI command contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2: task breakdown (31 tasks, 8 phases)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── migrate/                          # NEW: migration feature module
+│   ├── types.ts                      # ConfigType, MigrationPair, MigrateResult, Translator
+│   ├── registry.ts                   # MigrationRegistry: (from, to, type) → Translator
+│   ├── migrate.ts                    # performMigrate() orchestrator
+│   ├── translators/
+│   │   ├── global-rules.ts           # All global-rules pairwise translations
+│   │   ├── mcp.ts                    # MCP translations (JSON ↔ JSON ↔ TOML)
+│   │   └── commands.ts               # Command/rule/prompt file translations
+│   └── __tests__/
+│       ├── registry.test.ts          # Registry lookup and supported pairs tests
+│       ├── migrate.test.ts           # Orchestrator tests (mocked fs)
+│       └── translators/
+│           ├── global-rules.test.ts  # Translator fixture tests
+│           ├── mcp.test.ts           # JSON↔TOML conversion tests
+│           └── commands.test.ts      # Filename convention tests
+├── commands/
+│   ├── migrate.ts                    # NEW: CLI command wrapper
+│   └── __tests__/
+│       └── migrate.test.ts           # NEW: CLI command tests
+├── config/
+│   └── schema.ts                     # MODIFIED: add MigrateOptions Zod schema
+├── cli.ts                            # MODIFIED: register migrateCommand
+├── agents/                           # UNCHANGED: existing agent adapters (read-only usage)
+└── core/
+    └── sanitizer.ts                  # UNCHANGED: redactSecretLiterals (read-only usage)
+
+docs/
+├── migrate.md                        # NEW: user-facing migration guide with Mermaid diagram
+└── command-reference.md              # MODIFIED: add migrate command entry
+```
+
+**Structure Decision**: New `src/migrate/` module follows the existing pattern of feature-scoped directories (like `src/daemon/`). Translators are isolated in a subdirectory for maintainability as more agent pairs are added. Tests are co-located in `__tests__/` per constitution Principle II.
+
+## Migration Flow
+
+```mermaid
+flowchart TD
+    classDef input fill:#1a5276,color:#ffffff
+    classDef process fill:#1e8449,color:#ffffff
+    classDef decision fill:#7d3c98,color:#ffffff
+    classDef output fill:#b9770e,color:#ffffff
+    classDef skip fill:#922b21,color:#ffffff
+
+    CLI["CLI: parse --from, --to, --type, --name, --dry-run"]:::input
+    VALIDATE["Validate agent names, flags, Zod schema"]:::process
+    RESOLVE_TARGETS["Resolve target agents<br/>--to all expands to all other agents"]:::process
+    RESOLVE_TYPES["Resolve config types<br/>--type filters or default all"]:::process
+
+    LOOP_TARGET["For each target agent"]:::process
+    LOOP_TYPE["For each config type"]:::process
+
+    LOOKUP["Lookup translator in registry"]:::decision
+    NO_TRANSLATOR["Skip: no translator registered"]:::skip
+    READ_SOURCE["Read source artefacts via AgentPaths"]:::process
+    NO_SOURCE["Skip: no source files found"]:::skip
+
+    TRANSLATE["Run translator function"]:::process
+    NULL_RESULT["Skip: translator returned null"]:::skip
+
+    DETECT_SECRETS{"MCP type?<br/>Run redactSecretLiterals"}:::decision
+    SECRETS_FOUND["ABORT: secrets detected<br/>list offending fields"]:::skip
+    DRYRUN{"--dry-run?"}:::decision
+    PREVIEW["Log preview: target path + description"]:::output
+    WRITE["Write via atomicWrite or apply function<br/>MCP: read-then-merge per server"]:::process
+    RECORD["Record MigratedArtifact"]:::output
+
+    REPORT["Print summary: migrated + skipped + warnings"]:::output
+
+    CLI --> VALIDATE --> RESOLVE_TARGETS --> RESOLVE_TYPES
+    RESOLVE_TYPES --> LOOP_TARGET --> LOOP_TYPE
+    LOOP_TYPE --> LOOKUP
+    LOOKUP -->|"not found"| NO_TRANSLATOR
+    LOOKUP -->|"found"| READ_SOURCE
+    READ_SOURCE -->|"empty"| NO_SOURCE
+    READ_SOURCE -->|"has content"| TRANSLATE
+    TRANSLATE -->|"null"| NULL_RESULT
+    TRANSLATE -->|"content"| DETECT_SECRETS
+    DETECT_SECRETS -->|"secrets found"| SECRETS_FOUND
+    DETECT_SECRETS -->|"clean"| DRYRUN
+    DRYRUN -->|"yes"| PREVIEW
+    DRYRUN -->|"no"| WRITE
+    WRITE --> RECORD
+    PREVIEW --> RECORD
+    RECORD --> LOOP_TYPE
+    NO_TRANSLATOR --> LOOP_TYPE
+    NO_SOURCE --> LOOP_TYPE
+    NULL_RESULT --> LOOP_TYPE
+    LOOP_TYPE -->|"done"| LOOP_TARGET
+    LOOP_TARGET -->|"done"| REPORT
+```

--- a/specs/20260406-125441-config-migration/plan.md
+++ b/specs/20260406-125441-config-migration/plan.md
@@ -17,7 +17,7 @@ Add an `agentsync migrate` command that translates configuration artefacts (glob
 **Project Type**: CLI tool
 **Performance Goals**: N/A — one-shot command, config files are small (<100KB)
 **Constraints**: No new runtime dependencies. Must not modify source agent files. Must abort on detected secret literals in MCP content (constitution Principle I). CLI arguments must be validated with Zod (constitution Principle IV).
-**Scale/Scope**: 5 agents × 3 config types = 15 directional pairs per type, ~40 registered translators total
+**Scale/Scope**: 5 agents, 3 config types, 12 registered translators per type (not all pairs supported), 36 total
 
 ## Constitution Check
 

--- a/specs/20260406-125441-config-migration/quickstart.md
+++ b/specs/20260406-125441-config-migration/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: Cross-Agent Configuration Migration
+
+**Feature**: `20260406-125441-config-migration`
+**Date**: 2026-04-06
+
+## Prerequisites
+
+- Bun ≥1.x installed
+- At least one AI agent configured on the machine (Claude, Cursor, Codex, Copilot, or VS Code)
+- No vault initialisation required — `migrate` operates on local agent config files directly
+
+## Common Workflows
+
+### 1. Migrate everything from Claude to Cursor
+
+```bash
+# Preview what would change
+agentsync migrate --from claude --to cursor --dry-run
+
+# Apply the migration
+agentsync migrate --from claude --to cursor
+```
+
+### 2. Migrate only MCP servers from Claude to Codex
+
+Codex uses TOML format for MCP servers while Claude uses JSON. The translator handles the conversion automatically.
+
+```bash
+agentsync migrate --from claude --to codex --type mcp
+```
+
+### 3. Broadcast Claude config to all agents
+
+```bash
+agentsync migrate --from claude --to all
+```
+
+This migrates all translatable config types to every compatible agent. Unsupported pairs (e.g., MCP to Copilot) are skipped with a message.
+
+### 4. Migrate a single command file
+
+```bash
+agentsync migrate --from claude --to cursor --type commands --name review.md
+```
+
+### 5. Migrate Codex MCP (TOML) to VS Code (JSON)
+
+```bash
+agentsync migrate --from codex --to vscode --type mcp
+```
+
+## What Gets Migrated
+
+| Config Type | What It Contains | Agents That Support It |
+|-------------|-----------------|----------------------|
+| `global-rules` | Agent instruction files (CLAUDE.md, AGENTS.md, etc.) | Claude, Cursor, Codex, Copilot |
+| `mcp` | MCP server definitions | Claude, Cursor, Codex, VS Code |
+| `commands` | Command/rule/prompt Markdown files | Claude, Cursor, Codex, Copilot |
+
+## Key Behaviours
+
+- **Overwrite on collision**: If the target already has a matching entry (e.g., same MCP server name), the source value wins
+- **MCP per-server merge**: Only colliding server names are overwritten; target-only servers are preserved
+- **Secret detection**: If API keys or tokens are found in MCP `env` fields, migration aborts with a clear error. Remove literal secrets from source config (use environment variable references instead) and retry.
+- **Graceful skipping**: Missing source files and unsupported pairs produce skip messages, not errors
+
+## Development
+
+### Run tests
+
+```bash
+bun test src/migrate/
+```
+
+### Type-check
+
+```bash
+bun run typecheck
+```
+
+### Full CI check
+
+```bash
+bun run check
+```

--- a/specs/20260406-125441-config-migration/research.md
+++ b/specs/20260406-125441-config-migration/research.md
@@ -1,0 +1,79 @@
+# Research: Cross-Agent Configuration Migration
+
+**Feature**: `20260406-125441-config-migration`
+**Date**: 2026-04-06
+
+## R1: Agent Configuration Format Differences
+
+**Decision**: Use a translator registry pattern — each `(from, to, configType)` triple maps to a pure function that transforms source content to target format.
+
+**Rationale**: Agent configs share the same logical shape but differ in serialisation:
+- **Global Rules**: All Markdown-based. Claude uses `CLAUDE.md`, Cursor stores rules as an inline string in `settings.json`, Codex uses `AGENTS.md`, Copilot uses `instructions.md`. Translation is wrapping/unwrapping, not semantic transformation.
+- **MCP Servers**: Claude/Cursor/VS Code use JSON `{ "mcpServers": { "<name>": { "command", "args", "env" } } }`. Codex uses TOML `[mcp.servers.<name>]` with the same logical fields. The intermediate representation is a `McpServer[]` array.
+- **Commands**: All are Markdown files differing only in directory and file extension convention: `.claude/commands/*.md`, `.cursor/commands/*.md`, `.codex/rules/*.md`, `.copilot/prompts/*.prompt.md`.
+
+**Alternatives considered**:
+- Single universal format (rejected: would require all agents to agree on a schema, which is not the case)
+- AST-based Markdown transformation (rejected: rules are opaque Markdown strings with no shared structure beyond headings)
+
+## R2: MCP Per-Server Merge Strategy
+
+**Decision**: Read-then-merge at the individual server level. When writing MCP config to a target, read the existing target file, merge source servers into it by name (overwriting collisions), and write back the combined result.
+
+**Rationale**: Users may have target-specific MCP servers that shouldn't be destroyed during migration. The existing `applyClaudeMcp()` and `applyCodexConfig()` already implement this pattern (selective field merge), so migration follows the same convention.
+
+**Alternatives considered**:
+- Full file replacement (rejected: would silently destroy target-only servers)
+- Deep merge of individual server properties (rejected: over-complex for v1; source server config should be taken as authoritative)
+
+## R3: Secret Detection in Migration Path
+
+**Decision**: Apply `redactSecretLiterals()` from `src/core/sanitizer.ts` to all MCP content after translation but before writing to disk. If any secrets are detected, abort the migration with a clear error listing the offending fields. This reuses the existing 4-pattern regex detection (OpenAI keys, GitHub tokens, Slack bot tokens, base64-like tokens).
+
+**Rationale**: MCP server configs often contain API keys in `env` fields. Constitution Principle I states: "Detected secrets MUST cause the operation to abort with a clear error, not silently redact." Even though migration is local-to-local, the constitution's "abort" requirement applies to all secret detection — no data (even local writes) should proceed with detected secrets. The user should fix the source config (e.g., use environment variable references instead of literal keys) and re-run.
+
+**Alternatives considered**:
+- Skip detection for local-only operations (rejected: constitution mandates detection, and migrated config could later be pushed to vault)
+- Redact secrets and continue with warnings (rejected: constitution Principle I explicitly says "abort, not silently redact" — /speckit.analyze flagged this as a HIGH finding)
+
+## R4: Cursor Rules Special Handling
+
+**Decision**: Cursor stores global rules as a `rules` string field inside `settings.json`, not as a separate file. The translator returns a sentinel target name (`__cursor_rules__`), and the orchestrator routes this through `applyCursorRules()` which performs a JSON read-modify-write on `settings.json`.
+
+**Rationale**: This is how the existing `applyCursorVault` path works. Reusing it ensures consistency and avoids duplicating the settings.json merge logic.
+
+**Alternatives considered**:
+- Writing a `.cursorules` file (rejected: Cursor reads rules from settings.json, not a standalone file in the global config)
+
+## R5: Command File Extension Translation
+
+**Decision**: Commands are Markdown files with agent-specific naming conventions:
+- Claude/Cursor: `*.md`
+- Codex: `*.md` (in `rules/` directory)
+- Copilot: `*.prompt.md`
+
+Translation strips/adds the `.prompt.md` suffix when crossing the Copilot boundary.
+
+**Rationale**: The file content is identical Markdown — only the filename convention differs. The issue's architecture confirms this approach.
+
+**Alternatives considered**:
+- Frontmatter injection for agent identification (rejected: adds complexity with no benefit; agents don't read cross-agent frontmatter)
+
+## R6: No New Dependencies Required
+
+**Decision**: The migration feature requires zero new runtime dependencies. All needed capabilities exist:
+- `@iarna/toml` for Codex TOML parsing/serialisation
+- `@clack/prompts` for CLI output (log.info, log.success, log.warn, log.error)
+- `citty` for command definition
+- `zod` for argument validation (optional — citty handles basic arg types)
+- `readIfExists` / `atomicWrite` from `src/agents/_utils.ts`
+
+**Rationale**: Keeping the dependency footprint unchanged reduces review burden and aligns with constitution Principle IV (dependency additions must be justified).
+
+## R7: Two-Layer Command Pattern
+
+**Decision**: Follow the existing `performPush` / `pushCommand` pattern:
+- `src/migrate/migrate.ts` exports `performMigrate(options)` → pure logic, returns `MigrateResult`
+- `src/commands/migrate.ts` exports `migrateCommand` → CLI wrapper using `defineCommand`
+
+**Rationale**: This separation enables unit testing of migration logic without CLI scaffolding, consistent with every other command in the project.

--- a/specs/20260406-125441-config-migration/spec.md
+++ b/specs/20260406-125441-config-migration/spec.md
@@ -1,0 +1,170 @@
+# Feature Specification: Cross-Agent Configuration Migration
+
+**Feature Branch**: `20260406-125441-config-migration`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: User description: "Cross-Agent Configuration Migration (agentsync migrate)"
+
+## Clarifications
+
+### Session 2026-04-06
+
+- Q: Should conflict resolution (interactive prompts, `--force`, `--skip-conflicts`) be in scope? → A: No — overwrite target on collision. Conflict resolution UI deferred to follow-up (`--merge` flag).
+- Q: Does `migrate` require prior `agentsync init` (vault setup)? → A: No — `migrate` works standalone using `AgentPaths` only, no vault dependency.
+- Q: When migrating MCP servers, should source replace the entire target `mcpServers` block or merge per-server? → A: Per-server merge — overwrite matching server names, preserve target-only servers.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Migrate Configuration Between Agents (Priority: P1)
+
+A user who has a well-configured Claude setup (MCP servers, rules, custom commands) wants to replicate equivalent settings in Cursor without manually recreating each configuration item. The user runs `agentsync migrate --from claude --to cursor` and the tool reads Claude's configuration, maps compatible settings to Cursor's format, and writes them to Cursor's configuration files. If the target already has conflicting entries, they are overwritten.
+
+**Why this priority**: This is the core value proposition — users invest significant time configuring one agent and want to reuse that investment across other agents. Without this, users must manually translate settings between incompatible formats, which is error-prone and time-consuming.
+
+**Independent Test**: Can be fully tested by configuring one agent's settings, running the migrate command, and verifying the target agent's configuration files contain the mapped equivalents.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has Claude configured with MCP servers, **When** they run `agentsync migrate --from claude --to cursor`, **Then** matching MCP server entries appear in Cursor's configuration with correct format translation
+2. **Given** a user has Cursor rules configured, **When** they run `agentsync migrate --from cursor --to claude`, **Then** equivalent rules appear in Claude's configuration with appropriate format adjustments
+3. **Given** a source agent has settings with no equivalent in the target agent, **When** migration runs, **Then** unmappable settings are listed in a summary report and the user is informed which items were skipped and why
+4. **Given** the target agent already has a conflicting entry (e.g., same MCP server name), **When** migration runs, **Then** the source value overwrites the target value
+
+---
+
+### User Story 2 - Preview Migration Before Applying (Priority: P2)
+
+A user wants to see what changes would be made before committing to a migration. The user runs `agentsync migrate --from claude --to cursor --dry-run` and sees a detailed preview of what would be created, modified, or skipped in the target agent's configuration.
+
+**Why this priority**: Migration modifies configuration files that may already contain custom settings. Users need confidence that migration won't overwrite their existing work before applying changes.
+
+**Independent Test**: Can be tested by running the dry-run command and verifying it produces accurate output without modifying any files on disk.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user runs migrate with `--dry-run`, **When** the command completes, **Then** no target configuration files are modified and a human-readable list of proposed writes is displayed
+2. **Given** the target agent already has some configuration, **When** dry-run executes, **Then** the preview clearly shows which files would be created or overwritten
+
+---
+
+### User Story 3 - Selective Migration by Config Type (Priority: P3)
+
+A user wants to migrate only a specific type of configuration (e.g., only MCP servers, only global rules, only commands) rather than everything. The user runs `agentsync migrate --from claude --to cursor --type mcp` to migrate just MCP server configurations.
+
+**Why this priority**: Fine-grained control reduces risk and lets users incrementally adopt settings from another agent without an all-or-nothing approach.
+
+**Independent Test**: Can be tested by migrating a single type and verifying only that type's settings appear in the target, with all other target configuration unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user specifies `--type mcp`, **When** migration runs, **Then** only MCP server configurations are migrated and all other configuration types remain untouched
+2. **Given** a user omits `--type`, **When** migration runs, **Then** all translatable config types are migrated
+
+---
+
+### User Story 4 - Broadcast Migration to All Agents (Priority: P4)
+
+A user wants to propagate their Claude configuration to every other installed agent at once. The user runs `agentsync migrate --from claude --to all` and the tool migrates all translatable configuration to Cursor, Codex, Copilot, and VS Code in a single invocation.
+
+**Why this priority**: Power users who maintain one canonical agent configuration want a single command to fan out updates, rather than running separate commands per target.
+
+**Independent Test**: Can be tested by running `--to all` and verifying each target agent received the expected configuration files.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user runs `agentsync migrate --from claude --to all`, **When** migration completes, **Then** each of the other four agents receives all translatable configuration from Claude
+2. **Given** a user runs `--to all --type mcp`, **When** migration completes, **Then** only MCP configurations are migrated to agents that support MCP (Copilot is skipped with a message)
+
+---
+
+### User Story 5 - Migrate a Single Named Artefact (Priority: P5)
+
+A user wants to migrate one specific command file (e.g., `review.md`) from Claude to Cursor without migrating all commands. The user runs `agentsync migrate --from claude --to cursor --type commands --name review.md`.
+
+**Why this priority**: Targeted migration gives users surgical control when they only want to share one artefact.
+
+**Independent Test**: Can be tested by running with `--name` and verifying only that single file appears in the target.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user specifies `--type commands --name review.md`, **When** migration runs, **Then** only `review.md` is migrated and other command files in the source are untouched
+2. **Given** a user specifies `--name` for a file that does not exist in the source, **When** migration runs, **Then** the user receives an error message identifying the missing artefact
+
+---
+
+### Edge Cases
+
+- What happens when the source agent has no configuration files present on disk?
+- How does the system handle migration between agents where the source has a configuration type (e.g., commands) that has no equivalent concept in the target agent?
+- What happens if the target agent's configuration files are read-only or locked by another process?
+- What happens when a configuration value references a local file path that exists for one agent's directory structure but not another?
+- How does the system handle partial migration failure (e.g., 3 of 5 MCP servers migrate successfully but 2 fail)?
+- What happens when MCP server configuration contains secret literals (API keys, tokens)?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a `migrate` command that accepts a source agent (`--from`), a target agent (`--to` including `all`), and optional flags (`--dry-run`, `--type`, `--name`)
+- **FR-002**: System MUST read the source agent's configuration from its known file locations without modifying source files
+- **FR-003**: System MUST map source configuration items to the target agent's format using a defined mapping between agent configuration schemas
+- **FR-004**: System MUST write mapped configuration to the target agent's known file locations, overwriting existing entries on collision. For MCP servers, individual server entries are merged by name — source servers overwrite matching target servers, but target-only servers are preserved
+- **FR-005**: System MUST report a summary after migration listing: items successfully migrated, items skipped (with reasons), and items that encountered errors
+- **FR-006**: System MUST support a dry-run mode that previews changes without writing to disk
+- **FR-007**: System MUST support filtering migration by configuration type (`global-rules`, `mcp`, `commands`)
+- **FR-008**: System MUST support targeting a single named artefact via `--name` (requires `--type`)
+- **FR-009**: System MUST validate that both source and target agents are recognised names and that source and target are not the same agent before proceeding
+- **FR-010**: System MUST support `--to all` to migrate to every other registered agent in a single invocation
+- **FR-011**: System MUST apply secret detection (`redactSecretLiterals`) to all translated MCP content before writing to the target. If secrets are detected, the migration MUST abort with a clear error listing the offending fields, consistent with constitution Principle I
+- **FR-012**: System MUST support all five currently registered agents (Claude, Cursor, Codex, Copilot, VS Code) as both source and target, subject to the config type support matrix (unsupported pairs are skipped with a message)
+- **FR-013**: System MUST never throw on a missing source file — missing sources are reported in the skipped summary
+
+### Config Type Support Matrix
+
+Migration feasibility depends on the source-target pair and config type:
+
+- **Global Rules**: Supported between Claude, Cursor, Codex, and Copilot (all use Markdown-based rules). VS Code has no global rules concept.
+- **MCP Servers**: Supported between Claude, Cursor, Codex, and VS Code (JSON `mcpServers` or TOML `[mcp.servers]`). Copilot has no MCP concept.
+- **Commands**: Supported between Claude, Cursor, Codex, and Copilot (Markdown files with directory/extension conventions). VS Code has no commands concept.
+- **Skills**: Out of scope for this feature — deferred to follow-up issue.
+
+### Key Entities
+
+- **Migration Mapping**: Defines how a configuration concept (e.g., "MCP server") in one agent translates to the equivalent concept in another agent, including format transformations
+- **Migration Plan**: The computed set of actions (create, overwrite, skip) that a migration would perform, generated before execution and displayed during dry-run
+- **Migration Report**: The post-execution summary of what was migrated, skipped, or errored, including reasons for each outcome
+- **Configuration Type**: One of `global-rules`, `mcp`, or `commands` — a logical grouping that can be independently selected for migration via `--type`
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can migrate MCP server configuration between any two supported agents in a single command invocation
+- **SC-002**: Dry-run mode accurately predicts 100% of changes that would be applied in a real migration
+- **SC-003**: Users receive a clear summary after every migration identifying each item that was migrated, skipped, or errored
+- **SC-004**: `--to all` successfully fans out migration to all compatible target agents in a single invocation
+- **SC-005**: Secret literals in MCP configuration are detected and cause migration to abort with a clear error before writing to any target agent
+- **SC-006**: All translators are covered by automated tests with fixture inputs and expected outputs
+
+## Assumptions
+
+- Source and target agents are installed on the same machine where agentsync runs
+- Agent configuration files follow the formats defined in the existing agent registry (no custom or non-standard config locations)
+- Migration operates on local configuration files only — it does not require vault initialisation and does not push or pull from the vault
+- The existing `AgentPaths` and agent snapshot infrastructure can be leveraged to locate and read source configurations
+- All global rules formats are Markdown — translation is wrapping/unwrapping, not semantic transformation
+- MCP server schemas share the same logical shape (name, command, args, env) across agents, differing only in serialisation format (JSON vs TOML)
+- File path references in configuration content are not rewritten during migration (translators treat content as opaque strings)
+
+## Out of Scope
+
+- **Conflict resolution UI** — if a target file already exists with different content, this feature overwrites. A `--merge` flag is a follow-up.
+- **Skills migration** — Copilot's `SKILL.md` directory format has no structural equivalent in other agents. Deferred to follow-up issue.
+- **Bidirectional live sync** — migration is an explicit, one-shot command. Automatic daemon-triggered cross-agent migration is a separate feature.
+- **Semantic transformation of rule content** — translators treat content as opaque Markdown strings. No LLM rewriting is performed.
+
+## Documentation Impact
+
+- The project README and CLI help text must be updated to document the new `migrate` command and its flags
+- A `docs/migrate.md` guide should be created explaining migration concepts, supported mappings between agents, and common workflows
+- The `migrate` command must be registered in `src/cli.ts` and documented in `docs/command-reference.md`

--- a/specs/20260406-125441-config-migration/tasks.md
+++ b/specs/20260406-125441-config-migration/tasks.md
@@ -1,0 +1,240 @@
+# Tasks: Cross-Agent Configuration Migration
+
+**Input**: Design documents from `specs/20260406-125441-config-migration/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/cli-migrate.md
+
+**Tests**: Automated tests are required — this feature introduces new runtime code (translators, orchestrator, CLI command). Constitution Principle II mandates ≥70% line coverage for all new modules.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the migration module directory structure and shared type definitions
+
+- [x] T001 Create directory structure: `src/migrate/`, `src/migrate/translators/`, `src/migrate/__tests__/`, `src/migrate/__tests__/translators/`
+- [x] T002 Define shared types (ConfigType, MigrationPair, MigratedArtifact, MigrateResult, Translator) in `src/migrate/types.ts` per data-model.md. Also define Zod schema for `MigrateOptions` in `src/config/schema.ts` for CLI argument validation per constitution Principle IV
+
+**Checkpoint**: Type definitions compile with `bun run typecheck`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Translator registry and source-reading infrastructure that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T003 Implement translator registry with `register()`, `getTranslator()`, and `getSupportedPairs()` in `src/migrate/registry.ts`
+- [x] T004 [P] Write tests for registry lookup, missing translator returns null, and `getSupportedPairs()` filtering in `src/migrate/__tests__/registry.test.ts`
+- [x] T005 [P] Implement global-rules translators (12 pairwise functions: Claude↔Cursor, Claude↔Codex, Claude↔Copilot, Cursor↔Codex, Cursor↔Copilot, Codex↔Copilot) in `src/migrate/translators/global-rules.ts`
+- [x] T006 [P] Implement MCP translators (12 pairwise functions: JSON↔JSON for Claude/Cursor/VS Code, JSON↔TOML for Codex) with per-server merge in `src/migrate/translators/mcp.ts`. Secret detection is handled by the orchestrator, not the translators
+- [x] T007 [P] Implement commands translators (12 pairwise functions with `.prompt.md` extension handling for Copilot) in `src/migrate/translators/commands.ts`
+- [x] T008 [P] Write fixture-based tests for global-rules translators (empty input returns null, Claude→Cursor returns sentinel, round-trip preservation) in `src/migrate/__tests__/translators/global-rules.test.ts`
+- [x] T009 [P] Write fixture-based tests for MCP translators (JSON→JSON identity, JSON→TOML conversion, TOML→JSON conversion, per-server merge preserves target-only servers) in `src/migrate/__tests__/translators/mcp.test.ts`
+- [x] T010 [P] Write fixture-based tests for commands translators (filename passthrough, `.prompt.md` suffix added for Copilot, `.prompt.md` stripped from Copilot, empty content returns null) in `src/migrate/__tests__/translators/commands.test.ts`
+- [x] T011 Register all translators in `src/migrate/registry.ts` — call `register()` for each (from, to, type) triple per the support matrix in data-model.md
+
+**Checkpoint**: All translator tests pass with `bun test src/migrate/__tests__/translators/`. Registry correctly resolves translators for all supported pairs.
+
+---
+
+## Phase 3: User Story 1 — Migrate Configuration Between Agents (Priority: P1) MVP
+
+**Goal**: Users can run `agentsync migrate --from claude --to cursor` to translate and write all config types
+
+**Independent Test**: Configure Claude with MCP servers + rules + commands, run migrate to Cursor, verify Cursor config files contain correct translated content
+
+### Tests for User Story 1
+
+- [x] T012 [P] [US1] Write orchestrator tests in `src/migrate/__tests__/migrate.test.ts`: source reading via mocked `readIfExists`, translator dispatch, `atomicWrite` calls, summary report structure, graceful handling of missing source files (FR-013), abort on detected secret literals in MCP content (FR-011), write failure on read-only target reports error in `MigrateResult.errors` without crashing (edge case), partial migration failure continues remaining artefacts and reports per-item errors (edge case)
+- [x] T013 [P] [US1] Write CLI command tests in `src/commands/__tests__/migrate.test.ts`: argument parsing, validation of `--from`/`--to` agent names (FR-009), error on same source and target, integration with `performMigrate`
+
+### Implementation for User Story 1
+
+- [x] T014 [US1] Implement `readSourceArtefacts(agent, type, filterName?)` in `src/migrate/migrate.ts` — reads source config files using `readIfExists` and `AgentPaths` for each config type (global-rules from file/settings.json, MCP from JSON/TOML, commands from directory listing)
+- [x] T015 [US1] Implement `applyMigrated(to, type, targetName, content, dryRun)` in `src/migrate/migrate.ts` — routes writes to existing agent apply functions (`applyCursorRules`, `applyClaudeMcp`, `applyCodexConfig`, etc.)
+- [x] T016 [US1] Implement `performMigrate(options)` orchestrator in `src/migrate/migrate.ts` — loops over targets and types, calls `readSourceArtefacts` → translator → secret detection via `redactSecretLiterals` (MCP only, abort with error if secrets found) → `applyMigrated`, builds and returns `MigrateResult`. Catch write errors per-artefact without aborting the entire migration.
+- [x] T017 [US1] Implement CLI command in `src/commands/migrate.ts` — define `migrateCommand` with `defineCommand` from citty, parse args (`--from`, `--to`, `--type`, `--name`, `--dry-run`), call `performMigrate`, format output with `@clack/prompts` log functions per contracts/cli-migrate.md
+- [x] T018 [US1] Register `migrateCommand` in `src/cli.ts` — add `migrate: migrateCommand` to the `subCommands` object
+
+**Checkpoint**: `agentsync migrate --from claude --to cursor` works end-to-end. All US1 tests pass with `bun test src/migrate/ src/commands/__tests__/migrate.test.ts`.
+
+---
+
+## Phase 4: User Story 2 — Preview Migration Before Applying (Priority: P2)
+
+**Goal**: `--dry-run` previews all changes without writing to disk
+
+**Independent Test**: Run `agentsync migrate --from claude --to cursor --dry-run`, verify zero file modifications and human-readable output listing all intended writes
+
+### Tests for User Story 2
+
+- [x] T019 [US2] Add dry-run test cases in `src/migrate/__tests__/migrate.test.ts`: verify `atomicWrite` / apply functions are NOT called when `dryRun: true`, verify `MigrateResult.migrated` still contains all artefacts (for preview display), verify CLI output includes `[dry-run]` prefix per contracts/cli-migrate.md
+
+### Implementation for User Story 2
+
+- [x] T020 [US2] Verify `performMigrate` correctly passes `dryRun` flag through to `applyMigrated` (already wired in T016), add dry-run output formatting in `src/commands/migrate.ts` CLI command to print `[dry-run] →` prefix for each artefact
+
+**Checkpoint**: `agentsync migrate --from claude --to cursor --dry-run` produces accurate preview output, no files written. US2 tests pass.
+
+---
+
+## Phase 5: User Story 3 — Selective Migration by Config Type (Priority: P3)
+
+**Goal**: `--type mcp` filters migration to a single config type
+
+**Independent Test**: Run with `--type mcp`, verify only MCP config is migrated and global-rules + commands are untouched
+
+### Tests for User Story 3
+
+- [x] T021 [US3] Add type-filtering test cases in `src/migrate/__tests__/migrate.test.ts`: verify only specified type is processed when `type` option is set, verify all types processed when `type` is omitted, verify invalid type value produces error
+
+### Implementation for User Story 3
+
+- [x] T022 [US3] Add `--type` validation in `src/commands/migrate.ts` — validate value is one of `global-rules`, `mcp`, `commands` and surface error for invalid values
+
+**Checkpoint**: `--type` filtering works correctly. US3 tests pass.
+
+---
+
+## Phase 6: User Story 4 — Broadcast Migration to All Agents (Priority: P4)
+
+**Goal**: `--to all` fans out migration to every other registered agent
+
+**Independent Test**: Run `agentsync migrate --from claude --to all`, verify each of the 4 other agents receives translated config where supported, and unsupported pairs (e.g., MCP→Copilot) are skipped with a message
+
+### Tests for User Story 4
+
+- [x] T023 [US4] Add broadcast test cases in `src/migrate/__tests__/migrate.test.ts`: verify `--to all` expands to all agents except source, verify unsupported pairs produce skip entries in `MigrateResult.skipped` with descriptive reasons, verify `--to all --type mcp` only sends MCP to compatible agents
+
+### Implementation for User Story 4
+
+- [x] T024 [US4] Add `--to all` validation in `src/commands/migrate.ts` — validate that `--to all` and `--from` are not the same concept (already handled by expansion logic in `performMigrate`), ensure skip messages are formatted with target agent name
+
+**Checkpoint**: `--to all` correctly fans out to all compatible agents. US4 tests pass.
+
+---
+
+## Phase 7: User Story 5 — Migrate a Single Named Artefact (Priority: P5)
+
+**Goal**: `--name review.md` with `--type commands` migrates only that one file
+
+**Independent Test**: Run with `--type commands --name review.md`, verify only `review.md` appears in target and other command files are untouched
+
+### Tests for User Story 5
+
+- [x] T025 [US5] Add name-filtering test cases in `src/migrate/__tests__/migrate.test.ts`: verify `--name` filters to single artefact, verify `--name` without `--type` produces error, verify `--name` for nonexistent file produces descriptive skip/error message
+
+### Implementation for User Story 5
+
+- [x] T026 [US5] Add `--name` requires `--type` validation in `src/commands/migrate.ts`, pass `name` through to `performMigrate` options which passes to `readSourceArtefacts` `filterName` parameter
+
+**Checkpoint**: `--name` filtering works correctly. US5 tests pass.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, validation, and final quality checks
+
+- [x] T027 [P] Create `docs/migrate.md` with user-facing migration guide including: command reference, config type support matrix table, common workflow examples from quickstart.md, and Mermaid flow diagram from plan.md. Also update `docs/command-reference.md` with the migrate command entry
+- [x] T028 [P] Add JSDoc comments to all exported functions in `src/migrate/types.ts`, `src/migrate/registry.ts`, `src/migrate/migrate.ts`, and `src/migrate/translators/*.ts` per constitution Principle V
+- [x] T029 Validate Mermaid diagram in `docs/migrate.md` renders correctly
+- [x] T030 Run `bun run check` (typecheck + lint + test) — all must pass
+- [x] T031 Run quickstart.md validation — manually execute the 5 workflow examples and verify expected output
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (types must exist for registry and translators)
+- **User Story 1 (Phase 3)**: Depends on Phase 2 (registry + translators must be registered)
+- **User Stories 2–5 (Phases 4–7)**: Depend on Phase 3 (orchestrator + CLI must exist). Can then proceed in parallel.
+- **Polish (Phase 8)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational only — core migration end-to-end
+- **US2 (P2)**: Depends on US1 — adds dry-run test coverage and output formatting
+- **US3 (P3)**: Depends on US1 — adds `--type` validation and test coverage
+- **US4 (P4)**: Depends on US1 — adds `--to all` expansion and test coverage
+- **US5 (P5)**: Depends on US1 — adds `--name` validation and test coverage
+
+### Within Each User Story
+
+- Tests written first (TDD) → verify they fail
+- Implementation follows to make tests pass
+- Checkpoint validation at end of each phase
+
+### Parallel Opportunities
+
+**Phase 2 (Foundational)** — Maximum parallelism:
+```
+T005 global-rules translators  ─┐
+T006 MCP translators            ├── All in parallel (different files)
+T007 commands translators       │
+T008 global-rules tests         │
+T009 MCP tests                  │
+T010 commands tests             ─┘
+```
+
+**Phases 4–7 (US2–US5)** — After US1 completes, all can proceed in parallel:
+```
+US2 dry-run (T019-T020)        ─┐
+US3 --type (T021-T022)          ├── All in parallel
+US4 --to all (T023-T024)        │
+US5 --name (T025-T026)         ─┘
+```
+
+**Phase 8 (Polish)** — docs and JSDoc in parallel:
+```
+T027 docs/migrate.md           ─┐
+T028 JSDoc comments             ─┘── In parallel
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001–T002)
+2. Complete Phase 2: Foundational (T003–T011)
+3. Complete Phase 3: User Story 1 (T012–T018)
+4. **STOP and VALIDATE**: Run `bun test` and manually test `agentsync migrate --from claude --to cursor`
+5. MVP is usable — core migration works
+
+### Incremental Delivery
+
+1. Setup + Foundational → Types + Registry + Translators ready
+2. Add US1 → Core migration works → **MVP**
+3. Add US2 → Dry-run preview available
+4. Add US3 → Type filtering available
+5. Add US4 → Broadcast to all agents
+6. Add US5 → Single artefact targeting
+7. Polish → Documentation, JSDoc, final validation
+8. Each story adds value without breaking previous stories
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable after US1 MVP
+- US2–US5 are lightweight (1 test task + 1 implementation task each) because the orchestrator already handles their flags — these phases primarily ensure test coverage
+- Translators are pure functions with no side effects — ideal for parallel development and testing
+- Secret detection (FR-011) aborts migration if secrets found in MCP content — tested in orchestrator tests (T012), not in translator tests (translators are pure format converters)
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently

--- a/specs/20260406-125441-config-migration/tasks.md
+++ b/specs/20260406-125441-config-migration/tasks.md
@@ -180,7 +180,7 @@
 ### Parallel Opportunities
 
 **Phase 2 (Foundational)** — Maximum parallelism:
-```
+```text
 T005 global-rules translators  ─┐
 T006 MCP translators            ├── All in parallel (different files)
 T007 commands translators       │
@@ -190,7 +190,7 @@ T010 commands tests             ─┘
 ```
 
 **Phases 4–7 (US2–US5)** — After US1 completes, all can proceed in parallel:
-```
+```text
 US2 dry-run (T019-T020)        ─┐
 US3 --type (T021-T022)          ├── All in parallel
 US4 --to all (T023-T024)        │
@@ -198,7 +198,7 @@ US5 --name (T025-T026)         ─┘
 ```
 
 **Phase 8 (Polish)** — docs and JSDoc in parallel:
-```
+```text
 T027 docs/migrate.md           ─┐
 T028 JSDoc comments             ─┘── In parallel
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { daemonCommand } from "./commands/daemon";
 import { doctorCommand } from "./commands/doctor";
 import { initCommand } from "./commands/init";
 import { keyCommand } from "./commands/key";
+import { migrateCommand } from "./commands/migrate";
 import { pullCommand } from "./commands/pull";
 import { pushCommand } from "./commands/push";
 import { statusCommand } from "./commands/status";
@@ -23,6 +24,7 @@ const main = defineCommand({
     doctor: doctorCommand,
     daemon: daemonCommand,
     key: keyCommand,
+    migrate: migrateCommand,
   },
 });
 

--- a/src/commands/__tests__/migrate.test.ts
+++ b/src/commands/__tests__/migrate.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for src/commands/migrate.ts — CLI argument validation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { MigrateOptionsSchema } from "../../config/schema";
+
+describe("MigrateOptionsSchema", () => {
+  test("accepts valid claude → cursor migration", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "cursor",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts --to all", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "all",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts --type flag", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "cursor",
+      type: "mcp",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts --name with --type", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "cursor",
+      type: "commands",
+      name: "review.md",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects unknown agent name", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "vim",
+      to: "cursor",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects same source and target (FR-009)", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "claude",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("different");
+    }
+  });
+
+  test("allows same agent when --to is all", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "all",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects --name without --type", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "cursor",
+      name: "review.md",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("--name requires --type");
+    }
+  });
+
+  test("rejects invalid --type value", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "cursor",
+      type: "skills",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("defaults dryRun to false", () => {
+    const result = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "cursor",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dryRun).toBe(false);
+    }
+  });
+});

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -63,13 +63,11 @@ export const migrateCommand = defineCommand({
     const options = parsed.data;
     const result = await performMigrate(options);
 
-    // Fatal errors — abort
-    if (result.errors.length > 0) {
+    const hasErrors = result.errors.length > 0;
+    if (hasErrors) {
       for (const e of result.errors) {
         log.error(e);
       }
-      process.exitCode = 1;
-      return;
     }
 
     // Dry-run output
@@ -87,6 +85,7 @@ export const migrateCommand = defineCommand({
       } else {
         log.info(`Dry run complete. ${result.migrated.length} artefact(s) would be written.`);
       }
+      if (hasErrors) process.exitCode = 1;
       return;
     }
 
@@ -104,5 +103,6 @@ export const migrateCommand = defineCommand({
         log.warn(`Skipped (${s.reason}): ${s.pair.from}\u2192${s.pair.to} ${s.pair.type}`);
       }
     }
+    if (hasErrors) process.exitCode = 1;
   },
 });

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,108 @@
+/**
+ * src/commands/migrate.ts
+ *
+ * CLI wrapper for the cross-agent configuration migration feature.
+ * Follows the two-layer pattern: performMigrate() handles logic,
+ * this module handles argument parsing and output formatting.
+ */
+
+import { log } from "@clack/prompts";
+import { defineCommand } from "citty";
+import { MigrateOptionsSchema } from "../config/schema";
+import { performMigrate } from "../migrate/migrate";
+
+/** CLI command definition for `agentsync migrate`. */
+export const migrateCommand = defineCommand({
+  meta: {
+    name: "migrate",
+    description: "Translate configuration from one agent format to another",
+  },
+  args: {
+    from: {
+      type: "string",
+      description: "Source agent (claude|cursor|codex|copilot|vscode)",
+      required: true,
+    },
+    to: {
+      type: "string",
+      description: "Target agent (claude|cursor|codex|copilot|vscode|all)",
+      required: true,
+    },
+    type: {
+      type: "string",
+      description: "Config type to migrate (global-rules|mcp|commands). Omit to migrate all.",
+    },
+    name: {
+      type: "string",
+      description: "Specific artefact name (e.g. review.md). Requires --type.",
+    },
+    dryRun: {
+      type: "boolean",
+      description: "Show what would be written without touching disk",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    // Validate with Zod (constitution Principle IV)
+    const parsed = MigrateOptionsSchema.safeParse({
+      from: args.from,
+      to: args.to,
+      type: args.type || undefined,
+      name: args.name || undefined,
+      dryRun: args.dryRun,
+    });
+
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues) {
+        log.error(issue.message);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    const options = parsed.data;
+    const result = await performMigrate(options);
+
+    // Fatal errors — abort
+    if (result.errors.length > 0) {
+      for (const e of result.errors) {
+        log.error(e);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    // Dry-run output
+    if (options.dryRun) {
+      for (const m of result.migrated) {
+        log.info(`[dry-run] \u2192 ${m.targetPath}: ${m.description}`);
+      }
+      for (const s of result.skipped) {
+        log.warn(
+          `[dry-run] skipped (${s.reason}): ${s.pair.from}\u2192${s.pair.to} ${s.pair.type}`,
+        );
+      }
+      if (result.migrated.length === 0) {
+        log.info("Dry run complete. Nothing would be written.");
+      } else {
+        log.info(`Dry run complete. ${result.migrated.length} artefact(s) would be written.`);
+      }
+      return;
+    }
+
+    // Real migration output
+    if (result.migrated.length === 0) {
+      log.info("Nothing to migrate.");
+    } else {
+      for (const m of result.migrated) {
+        log.success(`\u2192 ${m.targetPath}`);
+      }
+      log.success(`Migrated ${result.migrated.length} artefact(s).`);
+    }
+    if (result.skipped.length > 0) {
+      for (const s of result.skipped) {
+        log.warn(`Skipped (${s.reason}): ${s.pair.from}\u2192${s.pair.to} ${s.pair.type}`);
+      }
+    }
+  },
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -38,3 +38,31 @@ export const DaemonStatusSchema = z.object({
 
 /** Normalized status shape for the daemon IPC status response. */
 export type DaemonStatus = z.infer<typeof DaemonStatusSchema>;
+
+/** Valid agent names accepted by CLI arguments. */
+const AgentNameEnum = z.enum(["claude", "cursor", "codex", "copilot", "vscode"]);
+
+/** Valid config types for the migrate command's --type flag. */
+const ConfigTypeEnum = z.enum(["global-rules", "mcp", "commands"]);
+
+/**
+ * Schema for the `migrate` command's CLI arguments.
+ * Validated per Constitution Principle IV (CLI arguments cross a trust boundary).
+ */
+export const MigrateOptionsSchema = z
+  .object({
+    from: AgentNameEnum,
+    to: z.union([AgentNameEnum, z.literal("all")]),
+    type: ConfigTypeEnum.optional(),
+    name: z.string().optional(),
+    dryRun: z.boolean().default(false),
+  })
+  .refine((opts) => opts.to === "all" || opts.from !== opts.to, {
+    message: "Source and target agent must be different",
+  })
+  .refine((opts) => !opts.name || opts.type !== undefined, {
+    message: "--name requires --type to be specified",
+  });
+
+/** Validated migrate options shape. */
+export type MigrateOptions = z.infer<typeof MigrateOptionsSchema>;

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests for src/migrate/migrate.ts — the migration orchestrator.
+ * Uses temp directories with mocked AgentPaths to test reading,
+ * translation, secret detection, and write behaviour.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentPaths } from "../../config/paths";
+import { performMigrate, readSourceArtefacts } from "../migrate";
+
+// ── Mutable path references for testing ──────────────────────────────────────
+
+type MutablePaths<K extends keyof typeof AgentPaths> = {
+  -readonly [P in keyof (typeof AgentPaths)[K]]: (typeof AgentPaths)[K][P];
+};
+
+const testClaude = AgentPaths.claude as MutablePaths<"claude">;
+const testCursor = AgentPaths.cursor as MutablePaths<"cursor">;
+const testCodex = AgentPaths.codex as MutablePaths<"codex">;
+const testCopilot = AgentPaths.copilot as MutablePaths<"copilot">;
+const testVscode = AgentPaths.vscode as MutablePaths<"vscode">;
+
+let tmpDir: string;
+let origClaude: typeof AgentPaths.claude;
+let origCursor: typeof AgentPaths.cursor;
+let origCodex: typeof AgentPaths.codex;
+let origCopilot: typeof AgentPaths.copilot;
+let origVscode: typeof AgentPaths.vscode;
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `migrate-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tmpDir, { recursive: true });
+
+  // Save originals
+  origClaude = { ...AgentPaths.claude };
+  origCursor = { ...AgentPaths.cursor };
+  origCodex = { ...AgentPaths.codex };
+  origCopilot = { ...AgentPaths.copilot };
+  origVscode = { ...AgentPaths.vscode };
+
+  // Redirect all agent paths to temp directory
+  testClaude.claudeMd = join(tmpDir, "claude", "CLAUDE.md");
+  testClaude.mcpJson = join(tmpDir, "claude", ".claude.json");
+  testClaude.commandsDir = join(tmpDir, "claude", "commands");
+  testClaude.settingsJson = join(tmpDir, "claude", "settings.json");
+
+  testCursor.settingsJson = join(tmpDir, "cursor", "settings.json");
+  testCursor.mcpGlobal = join(tmpDir, "cursor", "mcp.json");
+  testCursor.commandsDir = join(tmpDir, "cursor", "commands");
+
+  testCodex.agentsMd = join(tmpDir, "codex", "AGENTS.md");
+  testCodex.configToml = join(tmpDir, "codex", "config.toml");
+  testCodex.rulesDir = join(tmpDir, "codex", "rules");
+
+  testCopilot.instructionsFile = join(tmpDir, "copilot", "instructions");
+  testCopilot.promptsDir = join(tmpDir, "copilot", "prompts");
+
+  testVscode.mcpJson = join(tmpDir, "vscode", "mcp.json");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+  // Restore originals
+  Object.assign(testClaude, origClaude);
+  Object.assign(testCursor, origCursor);
+  Object.assign(testCodex, origCodex);
+  Object.assign(testCopilot, origCopilot);
+  Object.assign(testVscode, origVscode);
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function writeFixture(path: string, content: string) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+}
+
+// ── readSourceArtefacts ──────────────────────────────────────────────────────
+
+describe("readSourceArtefacts", () => {
+  test("reads claude global-rules from CLAUDE.md", async () => {
+    writeFixture(testClaude.claudeMd, "# My Rules");
+    const result = await readSourceArtefacts("claude", "global-rules");
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("# My Rules");
+  });
+
+  test("reads cursor global-rules from settings.json inline", async () => {
+    writeFixture(testCursor.settingsJson, JSON.stringify({ rules: "Be helpful.", other: true }));
+    const result = await readSourceArtefacts("cursor", "global-rules");
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("Be helpful.");
+    expect(result[0].name).toBe("__cursor_rules__");
+  });
+
+  test("reads claude MCP from .claude.json", async () => {
+    writeFixture(testClaude.mcpJson, JSON.stringify({ mcpServers: { gh: { command: "gh-mcp" } } }));
+    const result = await readSourceArtefacts("claude", "mcp");
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("gh-mcp");
+  });
+
+  test("reads commands from directory", async () => {
+    mkdirSync(testClaude.commandsDir, { recursive: true });
+    writeFileSync(join(testClaude.commandsDir, "review.md"), "# Review");
+    writeFileSync(join(testClaude.commandsDir, "lint.md"), "# Lint");
+    const result = await readSourceArtefacts("claude", "commands");
+    expect(result).toHaveLength(2);
+  });
+
+  test("filterName restricts to single command", async () => {
+    mkdirSync(testClaude.commandsDir, { recursive: true });
+    writeFileSync(join(testClaude.commandsDir, "review.md"), "# Review");
+    writeFileSync(join(testClaude.commandsDir, "lint.md"), "# Lint");
+    const result = await readSourceArtefacts("claude", "commands", "review.md");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("review.md");
+  });
+
+  test("returns empty for missing source files (FR-013)", async () => {
+    const result = await readSourceArtefacts("claude", "global-rules");
+    expect(result).toHaveLength(0);
+  });
+
+  test("returns empty for vscode global-rules (unsupported)", async () => {
+    const result = await readSourceArtefacts("vscode", "global-rules");
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ── performMigrate ───────────────────────────────────────────────────────────
+
+describe("performMigrate", () => {
+  test("migrates claude global-rules to cursor", async () => {
+    writeFixture(testClaude.claudeMd, "# My Rules\n\nBe concise.");
+    writeFixture(testCursor.settingsJson, JSON.stringify({}));
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "cursor",
+      type: "global-rules",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.migrated).toHaveLength(1);
+    expect(result.migrated[0].targetPath).toBe(testCursor.settingsJson);
+  });
+
+  test("migrates claude MCP to codex (JSON → TOML)", async () => {
+    writeFixture(
+      testClaude.mcpJson,
+      JSON.stringify({
+        mcpServers: { gh: { command: "gh-mcp", args: [], env: {} } },
+      }),
+    );
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "codex",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.migrated).toHaveLength(1);
+    expect(result.migrated[0].targetPath).toBe(testCodex.configToml);
+  });
+
+  test("dry-run does not write files", async () => {
+    writeFixture(testClaude.claudeMd, "# Rules");
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "codex",
+      type: "global-rules",
+      dryRun: true,
+    });
+
+    expect(result.migrated).toHaveLength(1);
+    // Target file should NOT exist
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = await readIfExists(testCodex.agentsMd);
+    expect(written).toBeNull();
+  });
+
+  test("type filtering only migrates specified type", async () => {
+    writeFixture(testClaude.claudeMd, "# Rules");
+    writeFixture(testClaude.mcpJson, JSON.stringify({ mcpServers: { gh: { command: "gh" } } }));
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "cursor",
+      type: "mcp",
+      dryRun: true,
+    });
+
+    // Should only have MCP artefact, not global-rules
+    for (const m of result.migrated) {
+      expect(m.description).toContain("MCP");
+    }
+  });
+
+  test("--to all expands to all agents except source", async () => {
+    writeFixture(testClaude.claudeMd, "# Rules");
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "all",
+      type: "global-rules",
+      dryRun: true,
+    });
+
+    // Claude has global-rules translators to cursor, codex, copilot (not vscode)
+    const migratedTargets = result.migrated.map((m) => m.description);
+    expect(migratedTargets.some((d) => d.includes("cursor"))).toBe(true);
+    expect(migratedTargets.some((d) => d.includes("codex"))).toBe(true);
+    expect(migratedTargets.some((d) => d.includes("copilot"))).toBe(true);
+    // vscode should be skipped
+    const vsSkip = result.skipped.find(
+      (s) => s.pair.to === "vscode" && s.pair.type === "global-rules",
+    );
+    expect(vsSkip).toBeDefined();
+  });
+
+  test("aborts on detected secret in MCP content (FR-011)", async () => {
+    writeFixture(
+      testClaude.mcpJson,
+      JSON.stringify({
+        mcpServers: {
+          gh: {
+            command: "gh-mcp",
+            args: [],
+            env: { TOKEN: "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" },
+          },
+        },
+      }),
+    );
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "cursor",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("aborted for security");
+    expect(result.migrated).toHaveLength(0);
+  });
+
+  test("MCP per-server merge preserves target-only servers", async () => {
+    writeFixture(
+      testClaude.mcpJson,
+      JSON.stringify({
+        mcpServers: { gh: { command: "gh-mcp", args: [], env: {} } },
+      }),
+    );
+    writeFixture(
+      testCursor.mcpGlobal,
+      JSON.stringify({
+        mcpServers: { slack: { command: "slack-mcp", args: [], env: {} } },
+      }),
+    );
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "cursor",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = await readIfExists(testCursor.mcpGlobal);
+    expect(written).not.toBeNull();
+    const parsed = JSON.parse(written as string);
+    expect(parsed.mcpServers.gh).toBeDefined();
+    expect(parsed.mcpServers.slack).toBeDefined();
+  });
+
+  test("Codex TOML merge preserves non-MCP sections", async () => {
+    writeFixture(
+      testClaude.mcpJson,
+      JSON.stringify({
+        mcpServers: { gh: { command: "gh-mcp", args: [], env: {} } },
+      }),
+    );
+    // Existing codex config has auth section + existing MCP server
+    writeFixture(
+      testCodex.configToml,
+      '[auth]\ntoken = "abc"\n\n[mcp.servers.slack]\ncommand = "slack-mcp"\nargs = []\n\n[mcp.servers.slack.env]\n',
+    );
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "codex",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = await readIfExists(testCodex.configToml);
+    expect(written).not.toBeNull();
+    // Auth section preserved
+    expect(written).toContain("token");
+    // Both MCP servers present (merged)
+    expect(written).toContain("gh");
+    expect(written).toContain("slack");
+  });
+
+  test("reports skip for missing source files (FR-013)", async () => {
+    const result = await performMigrate({
+      from: "claude",
+      to: "cursor",
+      type: "global-rules",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.skipped.length).toBeGreaterThan(0);
+    expect(result.skipped[0].reason).toContain("No source");
+  });
+
+  test("--name filters to single command artefact", async () => {
+    mkdirSync(testClaude.commandsDir, { recursive: true });
+    writeFileSync(join(testClaude.commandsDir, "review.md"), "# Review");
+    writeFileSync(join(testClaude.commandsDir, "lint.md"), "# Lint");
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "cursor",
+      type: "commands",
+      name: "review.md",
+      dryRun: true,
+    });
+
+    expect(result.migrated).toHaveLength(1);
+    expect(result.migrated[0].targetPath).toContain("review.md");
+  });
+
+  test("partial write failure continues remaining artefacts", async () => {
+    mkdirSync(testClaude.commandsDir, { recursive: true });
+    writeFileSync(join(testClaude.commandsDir, "review.md"), "# Review");
+    writeFileSync(join(testClaude.commandsDir, "lint.md"), "# Lint");
+
+    // Make cursor commands dir read-only after first write would succeed
+    // We test this by writing to a valid target — the orchestrator should
+    // handle any errors per-artefact
+    const result = await performMigrate({
+      from: "claude",
+      to: "cursor",
+      type: "commands",
+      dryRun: false,
+    });
+
+    // Both should succeed in normal conditions
+    expect(result.migrated.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -5,10 +5,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { AgentPaths } from "../../config/paths";
 import { performMigrate, readSourceArtefacts } from "../migrate";
 
@@ -75,7 +75,7 @@ afterEach(async () => {
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function writeFixture(path: string, content: string) {
-  mkdirSync(join(path, ".."), { recursive: true });
+  mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, content);
 }
 
@@ -349,9 +349,10 @@ describe("performMigrate", () => {
     writeFileSync(join(testClaude.commandsDir, "review.md"), "# Review");
     writeFileSync(join(testClaude.commandsDir, "lint.md"), "# Lint");
 
-    // Make cursor commands dir read-only after first write would succeed
-    // We test this by writing to a valid target — the orchestrator should
-    // handle any errors per-artefact
+    // Make cursor commands dir read-only to force write failures
+    mkdirSync(testCursor.commandsDir, { recursive: true });
+    chmodSync(testCursor.commandsDir, 0o444);
+
     const result = await performMigrate({
       from: "claude",
       to: "cursor",
@@ -359,7 +360,10 @@ describe("performMigrate", () => {
       dryRun: false,
     });
 
-    // Both should succeed in normal conditions
-    expect(result.migrated.length).toBeGreaterThanOrEqual(1);
+    // Write failures should be recorded in errors, not thrown
+    expect(result.errors.length).toBeGreaterThan(0);
+
+    // Restore permissions for cleanup
+    chmodSync(testCursor.commandsDir, 0o755);
   });
 });

--- a/src/migrate/__tests__/registry.test.ts
+++ b/src/migrate/__tests__/registry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { getSupportedPairs, getTranslator } from "../registry";
+
+describe("getTranslator", () => {
+  test("returns a function for a registered pair", () => {
+    const t = getTranslator("claude", "cursor", "mcp");
+    expect(t).toBeFunction();
+  });
+
+  test("returns null for an unregistered pair", () => {
+    const t = getTranslator("vscode", "copilot", "mcp");
+    expect(t).toBeNull();
+  });
+
+  test("returns null for skills (out of scope)", () => {
+    const t = getTranslator("claude", "cursor", "skills" as "mcp");
+    expect(t).toBeNull();
+  });
+});
+
+describe("getSupportedPairs", () => {
+  test("returns all pairs when no type filter is given", () => {
+    const pairs = getSupportedPairs();
+    expect(pairs.length).toBeGreaterThan(0);
+    // 12 global-rules + 12 mcp + 12 commands = 36 total
+    expect(pairs.length).toBe(36);
+  });
+
+  test("filters by config type", () => {
+    const mcpPairs = getSupportedPairs("mcp");
+    expect(mcpPairs.length).toBe(12);
+    for (const p of mcpPairs) {
+      expect(p.type).toBe("mcp");
+    }
+  });
+
+  test("returns correct from/to for a known pair", () => {
+    const grPairs = getSupportedPairs("global-rules");
+    const claudeToCursor = grPairs.find((p) => p.from === "claude" && p.to === "cursor");
+    expect(claudeToCursor).toBeDefined();
+  });
+});

--- a/src/migrate/__tests__/translators/commands.test.ts
+++ b/src/migrate/__tests__/translators/commands.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { translateCommand } from "../../translators/commands";
+
+describe("commands translators", () => {
+  test("empty content returns null", () => {
+    expect(translateCommand.claudeToCursor("", "review.md")).toBeNull();
+    expect(translateCommand.claudeToCursor("  ", "review.md")).toBeNull();
+  });
+
+  test("missing sourceName returns null", () => {
+    expect(translateCommand.claudeToCursor("content")).toBeNull();
+  });
+
+  test("claude → cursor passes filename through", () => {
+    const result = translateCommand.claudeToCursor("# Review\nCheck code.", "review.md");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("review.md");
+    expect(result?.content).toBe("# Review\nCheck code.\n");
+  });
+
+  test("claude → copilot adds .prompt.md suffix", () => {
+    const result = translateCommand.claudeToCopilot("# Review", "review.md");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("review.prompt.md");
+  });
+
+  test("copilot → claude strips .prompt.md suffix", () => {
+    const result = translateCommand.copilotToClaude("# Review", "review.prompt.md");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("review.md");
+  });
+
+  test("codex → copilot adds .prompt.md suffix", () => {
+    const result = translateCommand.codexToCopilot("# Lint", "lint.md");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("lint.prompt.md");
+  });
+
+  test("copilot → codex strips .prompt.md suffix", () => {
+    const result = translateCommand.copilotToCodex("# Lint", "lint.prompt.md");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("lint.md");
+  });
+
+  test("round-trip claude → copilot → claude preserves filename", () => {
+    const toCopilot = translateCommand.claudeToCopilot("content", "review.md");
+    const backToClaude = translateCommand.copilotToClaude(
+      toCopilot?.content as string,
+      toCopilot?.targetName as string,
+    );
+    expect(backToClaude?.targetName).toBe("review.md");
+  });
+});

--- a/src/migrate/__tests__/translators/global-rules.test.ts
+++ b/src/migrate/__tests__/translators/global-rules.test.ts
@@ -93,7 +93,9 @@ describe("global-rules translators", () => {
   test("round-trip claude → codex → claude preserves content", () => {
     const original = "# My Rules\n\nBe helpful and concise.";
     const toCodex = translateGlobalRules.claudeToCodex(original);
-    const backToClaude = translateGlobalRules.codexToClaude(toCodex?.content as string);
+    expect(toCodex).not.toBeNull();
+    if (!toCodex) return;
+    const backToClaude = translateGlobalRules.codexToClaude(toCodex.content);
     expect(backToClaude?.content).toBe(original);
   });
 });

--- a/src/migrate/__tests__/translators/global-rules.test.ts
+++ b/src/migrate/__tests__/translators/global-rules.test.ts
@@ -49,6 +49,47 @@ describe("global-rules translators", () => {
     expect(result?.targetName).toBe("__cursor_rules__");
   });
 
+  test("copilot → claude targets CLAUDE.md", () => {
+    const result = translateGlobalRules.copilotToClaude("instructions content");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("CLAUDE.md");
+    expect(result?.content).toBe("instructions content");
+  });
+
+  test("cursor → codex wraps with heading, targets AGENTS.md", () => {
+    const result = translateGlobalRules.cursorToCodex("cursor rules");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("AGENTS.md");
+    expect(result?.content).toContain("migrated from Cursor");
+  });
+
+  test("codex → cursor returns sentinel", () => {
+    const result = translateGlobalRules.codexToCursor("codex rules");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("__cursor_rules__");
+  });
+
+  test("cursor → copilot wraps with heading, targets instructions.md", () => {
+    const result = translateGlobalRules.cursorToCopilot("cursor rules");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("instructions.md");
+    expect(result?.content).toContain("migrated from Cursor");
+  });
+
+  test("codex → copilot targets instructions.md", () => {
+    const result = translateGlobalRules.codexToCopilot("codex rules");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("instructions.md");
+    expect(result?.content).toBe("codex rules");
+  });
+
+  test("copilot → codex targets AGENTS.md", () => {
+    const result = translateGlobalRules.copilotToCodex("copilot instructions");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("AGENTS.md");
+    expect(result?.content).toBe("copilot instructions");
+  });
+
   test("round-trip claude → codex → claude preserves content", () => {
     const original = "# My Rules\n\nBe helpful and concise.";
     const toCodex = translateGlobalRules.claudeToCodex(original);

--- a/src/migrate/__tests__/translators/global-rules.test.ts
+++ b/src/migrate/__tests__/translators/global-rules.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { translateGlobalRules } from "../../translators/global-rules";
+
+describe("global-rules translators", () => {
+  test("empty input returns null", () => {
+    expect(translateGlobalRules.claudeToCursor("")).toBeNull();
+    expect(translateGlobalRules.claudeToCursor("   ")).toBeNull();
+  });
+
+  test("claude → cursor returns sentinel target name", () => {
+    const result = translateGlobalRules.claudeToCursor("# My Rules\n\nBe helpful.");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("__cursor_rules__");
+    expect(result?.content).toBe("# My Rules\n\nBe helpful.");
+  });
+
+  test("cursor → claude wraps content with heading", () => {
+    const result = translateGlobalRules.cursorToClaude("Be concise.");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("rules.md");
+    expect(result?.content).toContain("migrated from Cursor");
+    expect(result?.content).toContain("Be concise.");
+  });
+
+  test("claude → codex preserves content, targets AGENTS.md", () => {
+    const content = "# Guidelines\n\nFollow these rules.";
+    const result = translateGlobalRules.claudeToCodex(content);
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("AGENTS.md");
+    expect(result?.content).toBe(content);
+  });
+
+  test("codex → claude preserves content, targets CLAUDE.md", () => {
+    const content = "# Agent Rules";
+    const result = translateGlobalRules.codexToClaude(content);
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("CLAUDE.md");
+  });
+
+  test("claude → copilot targets instructions.md", () => {
+    const result = translateGlobalRules.claudeToCopilot("rules");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("instructions.md");
+  });
+
+  test("copilot → cursor returns sentinel", () => {
+    const result = translateGlobalRules.copilotToCursor("instructions");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("__cursor_rules__");
+  });
+
+  test("round-trip claude → codex → claude preserves content", () => {
+    const original = "# My Rules\n\nBe helpful and concise.";
+    const toCodex = translateGlobalRules.claudeToCodex(original);
+    const backToClaude = translateGlobalRules.codexToClaude(toCodex?.content as string);
+    expect(backToClaude?.content).toBe(original);
+  });
+});

--- a/src/migrate/__tests__/translators/mcp.test.ts
+++ b/src/migrate/__tests__/translators/mcp.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { translateMcp } from "../../translators/mcp";
+
+const FIXTURE_JSON = JSON.stringify(
+  {
+    mcpServers: {
+      github: { command: "gh-mcp", args: ["serve"], env: { GITHUB_TOKEN: "test" } },
+      slack: { command: "slack-mcp", args: [], env: {} },
+    },
+  },
+  null,
+  2,
+);
+
+const FIXTURE_TOML = `[mcp.servers.github]
+command = "gh-mcp"
+args = ["serve"]
+
+[mcp.servers.github.env]
+GITHUB_TOKEN = "test"
+
+[mcp.servers.slack]
+command = "slack-mcp"
+args = []
+
+[mcp.servers.slack.env]
+`;
+
+describe("MCP translators", () => {
+  test("empty mcpServers returns null", () => {
+    expect(translateMcp.claudeToCursor('{"mcpServers":{}}')).toBeNull();
+  });
+
+  test("invalid JSON returns null", () => {
+    expect(translateMcp.claudeToCursor("not json")).toBeNull();
+  });
+
+  test("JSON → JSON identity (claude → cursor)", () => {
+    const result = translateMcp.claudeToCursor(FIXTURE_JSON);
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("mcp.json");
+    const parsed = JSON.parse(result?.content as string);
+    expect(parsed.mcpServers.github.command).toBe("gh-mcp");
+    expect(parsed.mcpServers.slack.command).toBe("slack-mcp");
+  });
+
+  test("JSON → TOML (claude → codex)", () => {
+    const result = translateMcp.claudeToCodex(FIXTURE_JSON);
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("config.toml");
+    expect(result?.content).toContain("[mcp.servers.github]");
+    expect(result?.content).toContain('command = "gh-mcp"');
+  });
+
+  test("TOML → JSON (codex → claude)", () => {
+    const result = translateMcp.codexToClaude(FIXTURE_TOML);
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("mcp.json");
+    const parsed = JSON.parse(result?.content as string);
+    expect(parsed.mcpServers.github.command).toBe("gh-mcp");
+  });
+
+  test("round-trip JSON → TOML → JSON preserves servers", () => {
+    const toToml = translateMcp.claudeToCodex(FIXTURE_JSON);
+    const backToJson = translateMcp.codexToClaude(toToml?.content as string);
+    const parsed = JSON.parse(backToJson?.content as string);
+    expect(Object.keys(parsed.mcpServers).sort()).toEqual(["github", "slack"]);
+    expect(parsed.mcpServers.github.command).toBe("gh-mcp");
+    expect(parsed.mcpServers.github.args).toEqual(["serve"]);
+  });
+
+  test("JSON → JSON preserves all fields (env, args)", () => {
+    const result = translateMcp.claudeToCursor(FIXTURE_JSON);
+    const parsed = JSON.parse(result?.content as string);
+    expect(parsed.mcpServers.github.env.GITHUB_TOKEN).toBe("test");
+    expect(parsed.mcpServers.github.args).toEqual(["serve"]);
+  });
+});

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -1,0 +1,331 @@
+/**
+ * src/migrate/migrate.ts
+ *
+ * Orchestrator for cross-agent configuration migration.
+ * Reads source configs, dispatches to translators, detects secrets,
+ * and writes to target agent config files.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import * as TOML from "@iarna/toml";
+import { atomicWrite, readIfExists } from "../agents/_utils";
+import { applyClaudeMd } from "../agents/claude";
+import { applyCodexAgentsMd } from "../agents/codex";
+import { applyCopilotInstructions } from "../agents/copilot";
+import { applyCursorRules } from "../agents/cursor";
+import type { AgentName } from "../agents/registry";
+import { AgentPaths } from "../config/paths";
+import { redactSecretLiterals } from "../core/sanitizer";
+import { getTranslator } from "./registry";
+import type { ConfigType, MigratedArtifact, MigrateOptions, MigrateResult } from "./types";
+
+const ALL_CONFIG_TYPES: ConfigType[] = ["global-rules", "mcp", "commands"];
+const ALL_AGENTS: AgentName[] = ["claude", "cursor", "codex", "copilot", "vscode"];
+
+/**
+ * Read configuration files from a source agent for a given config type.
+ * @param agent - Source agent to read from.
+ * @param type - Configuration type to read.
+ * @param filterName - If provided, only return artefacts matching this filename.
+ * @returns Array of { content, name } pairs. Never throws — returns [] on missing files.
+ */
+export async function readSourceArtefacts(
+  agent: AgentName,
+  type: ConfigType,
+  filterName?: string,
+): Promise<Array<{ content: string; name: string }>> {
+  const results: Array<{ content: string; name: string }> = [];
+
+  if (type === "global-rules") {
+    if (agent === "cursor") {
+      const raw = await readIfExists(AgentPaths.cursor.settingsJson);
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw) as Record<string, unknown>;
+          if (typeof parsed.rules === "string" && parsed.rules.trim()) {
+            results.push({ content: parsed.rules, name: "__cursor_rules__" });
+          }
+        } catch {
+          /* skip malformed settings.json */
+        }
+      }
+    } else {
+      const pathMap: Partial<Record<AgentName, string>> = {
+        claude: AgentPaths.claude.claudeMd,
+        codex: AgentPaths.codex.agentsMd,
+        copilot: AgentPaths.copilot.instructionsFile,
+      };
+      const filePath = pathMap[agent];
+      if (filePath) {
+        const content = await readIfExists(filePath);
+        if (content) {
+          const name = basename(filePath) ?? "rules.md";
+          results.push({ content, name });
+        }
+      }
+    }
+  }
+
+  if (type === "mcp") {
+    const pathMap: Partial<Record<AgentName, string>> = {
+      claude: AgentPaths.claude.mcpJson,
+      cursor: AgentPaths.cursor.mcpGlobal,
+      codex: AgentPaths.codex.configToml,
+      vscode: AgentPaths.vscode.mcpJson,
+    };
+    const filePath = pathMap[agent];
+    if (filePath) {
+      const content = await readIfExists(filePath);
+      if (content) {
+        const name = basename(filePath) ?? "mcp";
+        results.push({ content, name });
+      }
+    }
+  }
+
+  if (type === "commands") {
+    const dirMap: Partial<Record<AgentName, { dir: string; ext: string }>> = {
+      claude: { dir: AgentPaths.claude.commandsDir, ext: ".md" },
+      cursor: { dir: AgentPaths.cursor.commandsDir, ext: ".md" },
+      codex: { dir: AgentPaths.codex.rulesDir, ext: ".md" },
+      copilot: { dir: AgentPaths.copilot.promptsDir, ext: ".prompt.md" },
+    };
+    const entry = dirMap[agent];
+    if (entry) {
+      try {
+        const files = await readdir(entry.dir);
+        for (const f of files) {
+          if (!f.endsWith(entry.ext)) continue;
+          if (filterName && f !== filterName) continue;
+          const content = await readFile(join(entry.dir, f), "utf8").catch(() => null);
+          if (content) results.push({ content, name: f });
+        }
+      } catch {
+        /* directory missing — return empty */
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Write a migrated artefact to the target agent using existing apply functions.
+ * @param to - Target agent.
+ * @param type - Configuration type.
+ * @param targetName - Filename or sentinel (e.g., __cursor_rules__).
+ * @param content - Translated content to write.
+ * @param dryRun - If true, skip the write and return the planned artefact.
+ * @returns The MigratedArtifact describing what was (or would be) written, or null if unsupported.
+ */
+export async function applyMigrated(
+  to: AgentName,
+  type: ConfigType,
+  targetName: string,
+  content: string,
+  dryRun: boolean,
+): Promise<MigratedArtifact | null> {
+  if (type === "global-rules") {
+    if (targetName === "__cursor_rules__") {
+      const targetPath = AgentPaths.cursor.settingsJson;
+      if (!dryRun) await applyCursorRules(content);
+      return {
+        targetPath,
+        content,
+        description: `Cursor rules field in ${targetPath}`,
+      };
+    }
+    const pathMap: Partial<Record<AgentName, string>> = {
+      claude: AgentPaths.claude.claudeMd,
+      codex: AgentPaths.codex.agentsMd,
+      copilot: AgentPaths.copilot.instructionsFile,
+    };
+    const targetPath = pathMap[to];
+    if (!targetPath) return null;
+
+    const applyMap: Partial<Record<AgentName, (c: string) => Promise<void>>> = {
+      claude: applyClaudeMd,
+      codex: applyCodexAgentsMd,
+      copilot: applyCopilotInstructions,
+    };
+    const applyFn = applyMap[to];
+    if (!applyFn) return null;
+    if (!dryRun) await applyFn(content);
+    return {
+      targetPath,
+      content,
+      description: `${to} global rules written to ${targetPath}`,
+    };
+  }
+
+  if (type === "mcp") {
+    const pathMap: Partial<Record<AgentName, string>> = {
+      claude: AgentPaths.claude.mcpJson,
+      cursor: AgentPaths.cursor.mcpGlobal,
+      codex: AgentPaths.codex.configToml,
+      vscode: AgentPaths.vscode.mcpJson,
+    };
+    const targetPath = pathMap[to];
+    if (!targetPath) return null;
+
+    if (!dryRun) {
+      // Per-server merge: read existing target, merge source servers in
+      const existing = await readIfExists(targetPath);
+      if (existing) {
+        try {
+          if (to === "codex") {
+            // TOML merge: preserve non-MCP sections in config.toml
+            const existingParsed = TOML.parse(existing);
+            const incomingParsed = TOML.parse(content);
+            const existingMcp = (existingParsed.mcp ?? {}) as TOML.JsonMap;
+            const incomingMcp = (incomingParsed.mcp ?? {}) as TOML.JsonMap;
+            const existingServers = (existingMcp.servers ?? {}) as TOML.JsonMap;
+            const incomingServers = (incomingMcp.servers ?? {}) as TOML.JsonMap;
+            existingMcp.servers = { ...existingServers, ...incomingServers };
+            existingParsed.mcp = existingMcp;
+            content = TOML.stringify(existingParsed);
+          } else {
+            // JSON merge: Claude, Cursor, VS Code
+            const existingParsed = JSON.parse(existing) as Record<string, unknown>;
+            const incomingParsed = JSON.parse(content) as Record<string, unknown>;
+            const existingServers = (existingParsed.mcpServers ?? {}) as Record<string, unknown>;
+            const incomingServers = (incomingParsed.mcpServers ?? {}) as Record<string, unknown>;
+            existingParsed.mcpServers = { ...existingServers, ...incomingServers };
+            content = `${JSON.stringify(existingParsed, null, 2)}\n`;
+          }
+        } catch {
+          /* existing file corrupt — overwrite entirely */
+        }
+      }
+      await atomicWrite(targetPath, content);
+    }
+    return {
+      targetPath,
+      content,
+      description: `${to} MCP servers written to ${targetPath}`,
+    };
+  }
+
+  if (type === "commands") {
+    const dirMap: Partial<Record<AgentName, string>> = {
+      claude: AgentPaths.claude.commandsDir,
+      cursor: AgentPaths.cursor.commandsDir,
+      codex: AgentPaths.codex.rulesDir,
+      copilot: AgentPaths.copilot.promptsDir,
+    };
+    const dir = dirMap[to];
+    if (!dir) return null;
+
+    const targetPath = join(dir, targetName);
+    if (!dryRun) await atomicWrite(targetPath, content);
+    return {
+      targetPath,
+      content,
+      description: `${to} command written to ${targetPath}`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Execute a cross-agent configuration migration.
+ *
+ * Reads source config, translates via the registry, detects secrets in MCP
+ * content (aborts if found), and writes to target agent config files.
+ * Write errors are caught per-artefact without aborting remaining items.
+ *
+ * @param options - Migration options (from, to, type, name, dryRun).
+ * @returns Aggregate result with migrated, skipped, warnings, and errors.
+ */
+export async function performMigrate(options: MigrateOptions): Promise<MigrateResult> {
+  const result: MigrateResult = {
+    migrated: [],
+    skipped: [],
+    warnings: [],
+    errors: [],
+  };
+
+  const targetAgents: AgentName[] =
+    options.to === "all" ? ALL_AGENTS.filter((a) => a !== options.from) : [options.to];
+
+  const typesToMigrate: ConfigType[] = options.type ? [options.type] : ALL_CONFIG_TYPES;
+
+  for (const type of typesToMigrate) {
+    const sources = await readSourceArtefacts(options.from, type, options.name);
+    if (sources.length === 0) {
+      for (const target of targetAgents) {
+        result.skipped.push({
+          reason: "No source artefacts found",
+          pair: { from: options.from, to: target, type },
+        });
+      }
+      continue;
+    }
+
+    for (const target of targetAgents) {
+      const translator = getTranslator(options.from, target, type);
+      if (!translator) {
+        result.skipped.push({
+          reason: "No translator registered",
+          pair: { from: options.from, to: target, type },
+        });
+        continue;
+      }
+
+      for (const { content, name } of sources) {
+        const translated = translator(content, name);
+        if (!translated) {
+          result.skipped.push({
+            reason: "Translator returned null (empty or unsupported)",
+            pair: { from: options.from, to: target, type },
+          });
+          continue;
+        }
+
+        // Secret detection for MCP content — abort if secrets found
+        const finalContent = translated.content;
+        if (type === "mcp") {
+          try {
+            const parsed = JSON.parse(finalContent);
+            const redacted = redactSecretLiterals(parsed, "mcpServers");
+            if (redacted.warnings.length > 0) {
+              result.errors.push(
+                ...redacted.warnings.map((w) => `${w} — migration aborted for security`),
+              );
+              return result;
+            }
+          } catch {
+            // For TOML content, check the raw string
+            const redacted = redactSecretLiterals(finalContent, "mcpContent");
+            if (redacted.warnings.length > 0) {
+              result.errors.push(
+                ...redacted.warnings.map((w) => `${w} — migration aborted for security`),
+              );
+              return result;
+            }
+          }
+        }
+
+        try {
+          const artifact = await applyMigrated(
+            target,
+            type,
+            translated.targetName,
+            finalContent,
+            options.dryRun ?? false,
+          );
+          if (artifact) {
+            result.migrated.push(artifact);
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          result.errors.push(`Write failed for ${target}/${type}/${translated.targetName}: ${msg}`);
+        }
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -60,7 +60,7 @@ export async function readSourceArtefacts(
       if (filePath) {
         const content = await readIfExists(filePath);
         if (content) {
-          const name = basename(filePath) ?? "rules.md";
+          const name = basename(filePath) || "rules.md";
           results.push({ content, name });
         }
       }
@@ -78,7 +78,7 @@ export async function readSourceArtefacts(
     if (filePath) {
       const content = await readIfExists(filePath);
       if (content) {
-        const name = basename(filePath) ?? "mcp";
+        const name = basename(filePath) || "mcp";
         results.push({ content, name });
       }
     }
@@ -297,13 +297,18 @@ export async function performMigrate(options: MigrateOptions): Promise<MigrateRe
               return result;
             }
           } catch {
-            // For TOML content, check the raw string
-            const redacted = redactSecretLiterals(finalContent, "mcpContent");
-            if (redacted.warnings.length > 0) {
-              result.errors.push(
-                ...redacted.warnings.map((w) => `${w} — migration aborted for security`),
-              );
-              return result;
+            // For TOML content, parse it first then check for secrets
+            try {
+              const tomlParsed = TOML.parse(finalContent);
+              const redacted = redactSecretLiterals(tomlParsed, "mcpContent");
+              if (redacted.warnings.length > 0) {
+                result.errors.push(
+                  ...redacted.warnings.map((w) => `${w} — migration aborted for security`),
+                );
+                return result;
+              }
+            } catch {
+              // If TOML parsing also fails, content is malformed — skip secret check
             }
           }
         }

--- a/src/migrate/registry.ts
+++ b/src/migrate/registry.ts
@@ -1,0 +1,103 @@
+/**
+ * src/migrate/registry.ts
+ *
+ * Maps (from, to, configType) triples to translator functions.
+ * Each translator is a pure function registered declaratively — adding new
+ * agents requires only new register() calls, not changes to existing translators.
+ */
+
+import type { AgentName } from "../agents/registry";
+import type { ConfigType, Translator } from "./types";
+
+type RegistryKey = `${AgentName}\u2192${AgentName}:${ConfigType}`;
+
+const registry = new Map<RegistryKey, Translator>();
+
+/**
+ * Register a translator for a specific (from, to, type) triple.
+ * @param from - Source agent name.
+ * @param to - Target agent name.
+ * @param type - Configuration type to translate.
+ * @param fn - Pure function that performs the translation.
+ */
+export function register(from: AgentName, to: AgentName, type: ConfigType, fn: Translator): void {
+  registry.set(`${from}\u2192${to}:${type}`, fn);
+}
+
+/**
+ * Look up a registered translator for the given migration pair.
+ * @returns The translator function, or null if no translator is registered.
+ */
+export function getTranslator(from: AgentName, to: AgentName, type: ConfigType): Translator | null {
+  return registry.get(`${from}\u2192${to}:${type}`) ?? null;
+}
+
+/**
+ * List all registered translation pairs, optionally filtered by config type.
+ * @param type - If provided, only return pairs matching this config type.
+ * @returns Array of registered migration pairs.
+ */
+export function getSupportedPairs(
+  type?: ConfigType,
+): Array<{ from: AgentName; to: AgentName; type: ConfigType }> {
+  return [...registry.keys()]
+    .filter((k) => !type || k.endsWith(`:${type}`))
+    .map((k) => {
+      const [pair, t] = k.split(":");
+      const [from, to] = pair.split("\u2192") as [AgentName, AgentName];
+      return { from, to, type: t as ConfigType };
+    });
+}
+
+/** Clear all registrations. Intended for testing only. */
+export function __clearRegistryForTesting(): void {
+  registry.clear();
+}
+
+// ── Translator registrations per config type support matrix ──────────────────
+
+import { translateCommand } from "./translators/commands";
+import { translateGlobalRules } from "./translators/global-rules";
+import { translateMcp } from "./translators/mcp";
+
+// Global Rules (4 agents: Claude, Cursor, Codex, Copilot — VS Code excluded)
+register("claude", "cursor", "global-rules", translateGlobalRules.claudeToCursor);
+register("cursor", "claude", "global-rules", translateGlobalRules.cursorToClaude);
+register("claude", "codex", "global-rules", translateGlobalRules.claudeToCodex);
+register("codex", "claude", "global-rules", translateGlobalRules.codexToClaude);
+register("claude", "copilot", "global-rules", translateGlobalRules.claudeToCopilot);
+register("copilot", "claude", "global-rules", translateGlobalRules.copilotToClaude);
+register("cursor", "codex", "global-rules", translateGlobalRules.cursorToCodex);
+register("codex", "cursor", "global-rules", translateGlobalRules.codexToCursor);
+register("cursor", "copilot", "global-rules", translateGlobalRules.cursorToCopilot);
+register("copilot", "cursor", "global-rules", translateGlobalRules.copilotToCursor);
+register("codex", "copilot", "global-rules", translateGlobalRules.codexToCopilot);
+register("copilot", "codex", "global-rules", translateGlobalRules.copilotToCodex);
+
+// MCP (4 agents: Claude, Cursor, Codex, VS Code — Copilot excluded)
+register("claude", "cursor", "mcp", translateMcp.claudeToCursor);
+register("claude", "vscode", "mcp", translateMcp.claudeToVsCode);
+register("cursor", "claude", "mcp", translateMcp.cursorToClaude);
+register("cursor", "vscode", "mcp", translateMcp.cursorToVsCode);
+register("vscode", "claude", "mcp", translateMcp.vsCodeToClaude);
+register("vscode", "cursor", "mcp", translateMcp.vsCodeToCursor);
+register("claude", "codex", "mcp", translateMcp.claudeToCodex);
+register("cursor", "codex", "mcp", translateMcp.cursorToCodex);
+register("vscode", "codex", "mcp", translateMcp.vsCodeToCodex);
+register("codex", "claude", "mcp", translateMcp.codexToClaude);
+register("codex", "cursor", "mcp", translateMcp.codexToCursor);
+register("codex", "vscode", "mcp", translateMcp.codexToVsCode);
+
+// Commands (4 agents: Claude, Cursor, Codex, Copilot — VS Code excluded)
+register("claude", "cursor", "commands", translateCommand.claudeToCursor);
+register("cursor", "claude", "commands", translateCommand.cursorToClaude);
+register("claude", "codex", "commands", translateCommand.claudeToCodex);
+register("cursor", "codex", "commands", translateCommand.cursorToCodex);
+register("codex", "claude", "commands", translateCommand.codexToClaude);
+register("codex", "cursor", "commands", translateCommand.codexToCursor);
+register("claude", "copilot", "commands", translateCommand.claudeToCopilot);
+register("cursor", "copilot", "commands", translateCommand.cursorToCopilot);
+register("codex", "copilot", "commands", translateCommand.codexToCopilot);
+register("copilot", "claude", "commands", translateCommand.copilotToClaude);
+register("copilot", "cursor", "commands", translateCommand.copilotToCursor);
+register("copilot", "codex", "commands", translateCommand.copilotToCodex);

--- a/src/migrate/translators/commands.ts
+++ b/src/migrate/translators/commands.ts
@@ -1,0 +1,57 @@
+/**
+ * src/migrate/translators/commands.ts
+ *
+ * Pairwise translators for command/rule/prompt files between agents.
+ * All command formats are Markdown files — the only difference is the
+ * filename convention and target directory:
+ *   - Claude/Cursor: *.md
+ *   - Codex: *.md (in rules/ directory)
+ *   - Copilot: *.prompt.md
+ */
+
+import type { Translator } from "../types";
+
+/** Pass-through translator for agents with identical .md conventions. */
+const mdToMd: Translator = (content, sourceName) => {
+  const trimmed = content.trim();
+  if (!trimmed || !sourceName) return null;
+  return { content: `${trimmed}\n`, targetName: sourceName };
+};
+
+/** Convert .md command to Copilot's .prompt.md convention. */
+const mdToPromptMd: Translator = (content, sourceName) => {
+  const trimmed = content.trim();
+  if (!trimmed || !sourceName) return null;
+  const base = sourceName.endsWith(".md") ? sourceName.slice(0, -3) : sourceName;
+  return { content: `${trimmed}\n`, targetName: `${base}.prompt.md` };
+};
+
+/** Convert Copilot's .prompt.md back to standard .md convention. */
+const promptMdToMd: Translator = (content, sourceName) => {
+  const trimmed = content.trim();
+  if (!trimmed || !sourceName) return null;
+  const base = sourceName.endsWith(".prompt.md")
+    ? sourceName.slice(0, -".prompt.md".length)
+    : sourceName;
+  return { content: `${trimmed}\n`, targetName: `${base}.md` };
+};
+
+/**
+ * All commands translators indexed by direction for registry registration.
+ * Each function passes through Markdown content and adjusts the filename
+ * convention (*.md vs *.prompt.md) based on the target agent.
+ */
+export const translateCommand = {
+  claudeToCursor: mdToMd,
+  cursorToClaude: mdToMd,
+  claudeToCodex: mdToMd,
+  cursorToCodex: mdToMd,
+  codexToClaude: mdToMd,
+  codexToCursor: mdToMd,
+  claudeToCopilot: mdToPromptMd,
+  cursorToCopilot: mdToPromptMd,
+  codexToCopilot: mdToPromptMd,
+  copilotToClaude: promptMdToMd,
+  copilotToCursor: promptMdToMd,
+  copilotToCodex: promptMdToMd,
+};

--- a/src/migrate/translators/commands.ts
+++ b/src/migrate/translators/commands.ts
@@ -22,7 +22,11 @@ const mdToMd: Translator = (content, sourceName) => {
 const mdToPromptMd: Translator = (content, sourceName) => {
   const trimmed = content.trim();
   if (!trimmed || !sourceName) return null;
-  const base = sourceName.endsWith(".md") ? sourceName.slice(0, -3) : sourceName;
+  const base = sourceName.endsWith(".prompt.md")
+    ? sourceName.slice(0, -".prompt.md".length)
+    : sourceName.endsWith(".md")
+      ? sourceName.slice(0, -3)
+      : sourceName;
   return { content: `${trimmed}\n`, targetName: `${base}.prompt.md` };
 };
 

--- a/src/migrate/translators/global-rules.ts
+++ b/src/migrate/translators/global-rules.ts
@@ -1,0 +1,115 @@
+/**
+ * src/migrate/translators/global-rules.ts
+ *
+ * Pairwise translators for global rules between agents.
+ * All global-rules formats are Markdown — translation is wrapping/unwrapping,
+ * not semantic transformation. Cursor is special: its rules are stored as an
+ * inline string in settings.json, not a standalone file.
+ */
+
+import type { Translator } from "../types";
+
+/** Sentinel target name consumed by the orchestrator to route through applyCursorRules(). */
+const CURSOR_RULES_SENTINEL = "__cursor_rules__";
+
+// ── To/from Cursor (inline string in settings.json) ──────────────────────────
+
+const toCursor: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: trimmed, targetName: CURSOR_RULES_SENTINEL };
+};
+
+const fromCursor: Translator = (content, sourceName) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  const target = sourceName ?? "rules.md";
+  return { content: `# Rules (migrated from Cursor)\n\n${trimmed}\n`, targetName: target };
+};
+
+// ── Between file-based agents (Claude, Codex, Copilot) ───────────────────────
+
+const claudeToCodex: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: trimmed, targetName: "AGENTS.md" };
+};
+
+const codexToClaude: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: trimmed, targetName: "CLAUDE.md" };
+};
+
+const claudeToCopilot: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: trimmed, targetName: "instructions.md" };
+};
+
+const copilotToClaude: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: trimmed, targetName: "CLAUDE.md" };
+};
+
+const cursorToCodex: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return {
+    content: `# Rules (migrated from Cursor)\n\n${trimmed}\n`,
+    targetName: "AGENTS.md",
+  };
+};
+
+const codexToCursor: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: trimmed, targetName: CURSOR_RULES_SENTINEL };
+};
+
+const cursorToCopilot: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return {
+    content: `# Rules (migrated from Cursor)\n\n${trimmed}\n`,
+    targetName: "instructions.md",
+  };
+};
+
+const copilotToCursor: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: trimmed, targetName: CURSOR_RULES_SENTINEL };
+};
+
+const codexToCopilot: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: trimmed, targetName: "instructions.md" };
+};
+
+const copilotToCodex: Translator = (content) => {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: trimmed, targetName: "AGENTS.md" };
+};
+
+/**
+ * All global-rules translators indexed by direction for registry registration.
+ * Each function takes raw Markdown content and returns { content, targetName } or null.
+ */
+export const translateGlobalRules = {
+  claudeToCursor: toCursor,
+  cursorToClaude: fromCursor,
+  claudeToCodex,
+  codexToClaude,
+  claudeToCopilot,
+  copilotToClaude,
+  cursorToCodex,
+  codexToCursor,
+  cursorToCopilot,
+  copilotToCursor,
+  codexToCopilot,
+  copilotToCodex,
+};

--- a/src/migrate/translators/mcp.ts
+++ b/src/migrate/translators/mcp.ts
@@ -11,6 +11,7 @@
  */
 
 import * as TOML from "@iarna/toml";
+import { z } from "zod";
 import type { Translator } from "../types";
 
 interface McpServer {
@@ -20,16 +21,33 @@ interface McpServer {
   env?: Record<string, string>;
 }
 
+const McpServerSchema = z.object({
+  command: z.string().min(1),
+  args: z.array(z.string()).optional().default([]),
+  env: z.record(z.string(), z.string()).optional().default({}),
+});
+
+const JsonMcpSchema = z.object({
+  mcpServers: z.record(z.string(), McpServerSchema).default({}),
+});
+
+const TomlMcpSchema = z.object({
+  mcp: z
+    .object({
+      servers: z.record(z.string(), McpServerSchema).default({}),
+    })
+    .default({ servers: {} }),
+});
+
 // ── JSON parsing (Claude, Cursor, VS Code) ───────────────────────────────────
 
 function parseJsonMcp(raw: string): McpServer[] {
-  const parsed = JSON.parse(raw) as Record<string, unknown>;
-  const servers = (parsed.mcpServers ?? {}) as Record<string, Record<string, unknown>>;
-  return Object.entries(servers).map(([name, cfg]) => ({
+  const parsed = JsonMcpSchema.parse(JSON.parse(raw));
+  return Object.entries(parsed.mcpServers).map(([name, cfg]) => ({
     name,
-    command: cfg.command as string,
-    args: (cfg.args as string[] | undefined) ?? [],
-    env: (cfg.env as Record<string, string> | undefined) ?? {},
+    command: cfg.command,
+    args: cfg.args,
+    env: cfg.env,
   }));
 }
 
@@ -44,14 +62,13 @@ function serializeJsonMcp(servers: McpServer[]): string {
 // ── TOML parsing (Codex) ─────────────────────────────────────────────────────
 
 function parseTomlMcp(raw: string): McpServer[] {
-  const parsed = TOML.parse(raw) as Record<string, unknown>;
-  const mcp = (parsed.mcp ?? {}) as Record<string, unknown>;
-  const servers = (mcp.servers ?? {}) as Record<string, Record<string, unknown>>;
-  return Object.entries(servers).map(([name, cfg]) => ({
+  // Round-trip through JSON to convert TOML's special array/integer types to plain JS objects
+  const parsed = TomlMcpSchema.parse(JSON.parse(JSON.stringify(TOML.parse(raw))));
+  return Object.entries(parsed.mcp.servers).map(([name, cfg]) => ({
     name,
-    command: cfg.command as string,
-    args: (cfg.args as string[] | undefined) ?? [],
-    env: (cfg.env as Record<string, string> | undefined) ?? {},
+    command: cfg.command,
+    args: cfg.args,
+    env: cfg.env,
   }));
 }
 

--- a/src/migrate/translators/mcp.ts
+++ b/src/migrate/translators/mcp.ts
@@ -1,0 +1,131 @@
+/**
+ * src/migrate/translators/mcp.ts
+ *
+ * Pairwise translators for MCP server configurations.
+ * Claude/Cursor/VS Code use JSON { mcpServers: { name: { command, args, env } } }.
+ * Codex uses TOML [mcp.servers.name] with the same logical fields.
+ * The McpServer[] intermediate representation bridges the two formats.
+ *
+ * Secret detection is handled by the orchestrator, NOT the translators.
+ * Translators are pure format converters.
+ */
+
+import * as TOML from "@iarna/toml";
+import type { Translator } from "../types";
+
+interface McpServer {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+// ── JSON parsing (Claude, Cursor, VS Code) ───────────────────────────────────
+
+function parseJsonMcp(raw: string): McpServer[] {
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  const servers = (parsed.mcpServers ?? {}) as Record<string, Record<string, unknown>>;
+  return Object.entries(servers).map(([name, cfg]) => ({
+    name,
+    command: cfg.command as string,
+    args: (cfg.args as string[] | undefined) ?? [],
+    env: (cfg.env as Record<string, string> | undefined) ?? {},
+  }));
+}
+
+function serializeJsonMcp(servers: McpServer[]): string {
+  const mcpServers: Record<string, unknown> = {};
+  for (const s of servers) {
+    mcpServers[s.name] = { command: s.command, args: s.args, env: s.env };
+  }
+  return `${JSON.stringify({ mcpServers }, null, 2)}\n`;
+}
+
+// ── TOML parsing (Codex) ─────────────────────────────────────────────────────
+
+function parseTomlMcp(raw: string): McpServer[] {
+  const parsed = TOML.parse(raw) as Record<string, unknown>;
+  const mcp = (parsed.mcp ?? {}) as Record<string, unknown>;
+  const servers = (mcp.servers ?? {}) as Record<string, Record<string, unknown>>;
+  return Object.entries(servers).map(([name, cfg]) => ({
+    name,
+    command: cfg.command as string,
+    args: (cfg.args as string[] | undefined) ?? [],
+    env: (cfg.env as Record<string, string> | undefined) ?? {},
+  }));
+}
+
+function serializeTomlMcp(servers: McpServer[], existingToml?: string): string {
+  let base: TOML.JsonMap = {};
+  if (existingToml) {
+    try {
+      base = TOML.parse(existingToml);
+    } catch {
+      /* ignore corrupt TOML — start fresh */
+    }
+  }
+  const mcp = (base.mcp ?? {}) as TOML.JsonMap;
+  const serverMap: TOML.JsonMap = {};
+  for (const s of servers) {
+    serverMap[s.name] = {
+      command: s.command,
+      args: s.args ?? [],
+      env: s.env ?? {},
+    };
+  }
+  mcp.servers = serverMap;
+  base.mcp = mcp;
+  return TOML.stringify(base);
+}
+
+// ── Translator functions ─────────────────────────────────────────────────────
+
+const jsonToJson: Translator = (raw) => {
+  try {
+    const servers = parseJsonMcp(raw);
+    if (servers.length === 0) return null;
+    return { content: serializeJsonMcp(servers), targetName: "mcp.json" };
+  } catch {
+    return null;
+  }
+};
+
+const jsonToToml: Translator = (raw) => {
+  try {
+    const servers = parseJsonMcp(raw);
+    if (servers.length === 0) return null;
+    return { content: serializeTomlMcp(servers), targetName: "config.toml" };
+  } catch {
+    return null;
+  }
+};
+
+const tomlToJson: Translator = (raw) => {
+  try {
+    const servers = parseTomlMcp(raw);
+    if (servers.length === 0) return null;
+    return { content: serializeJsonMcp(servers), targetName: "mcp.json" };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * All MCP translators indexed by direction for registry registration.
+ * Each function parses source MCP config (JSON or TOML), extracts McpServer[] intermediate
+ * representation, and serialises to the target format.
+ */
+export const translateMcp = {
+  claudeToCursor: jsonToJson,
+  claudeToVsCode: jsonToJson,
+  cursorToClaude: jsonToJson,
+  cursorToVsCode: jsonToJson,
+  vsCodeToClaude: jsonToJson,
+  vsCodeToCursor: jsonToJson,
+  claudeToCodex: jsonToToml,
+  cursorToCodex: jsonToToml,
+  vsCodeToCodex: jsonToToml,
+  codexToClaude: tomlToJson,
+  codexToCursor: tomlToJson,
+  codexToVsCode: tomlToJson,
+};

--- a/src/migrate/types.ts
+++ b/src/migrate/types.ts
@@ -1,0 +1,56 @@
+/**
+ * src/migrate/types.ts
+ *
+ * Shared type definitions for the cross-agent configuration migration feature.
+ * See data-model.md for entity documentation and relationships.
+ */
+
+import type { AgentName } from "../agents/registry";
+
+/** Translatable configuration categories. Skills are out of scope for this feature. */
+export type ConfigType = "global-rules" | "mcp" | "commands";
+
+/** Identifies a specific directional translation between two agents for one config type. */
+export interface MigrationPair {
+  from: AgentName;
+  to: AgentName;
+  type: ConfigType;
+}
+
+/** A single file or config entry that was (or would be) written during migration. */
+export interface MigratedArtifact {
+  /** Absolute destination path on disk. */
+  targetPath: string;
+  /** Transformed content ready to write. */
+  content: string;
+  /** Human-readable summary of the transformation applied. */
+  description: string;
+}
+
+/** Aggregate outcome of a migration operation. */
+export interface MigrateResult {
+  /** Successfully translated and written (or previewed in dry-run) items. */
+  migrated: MigratedArtifact[];
+  /** Items not migrated, each with a reason and the pair that was attempted. */
+  skipped: Array<{ reason: string; pair: MigrationPair }>;
+  /** Non-fatal issues encountered during migration. */
+  warnings: string[];
+  /** Fatal issues that prevented migration (e.g., detected secrets, validation failures). */
+  errors: string[];
+}
+
+/**
+ * Pure function that converts source content to target format.
+ *
+ * @param sourceContent - Raw content read from the source agent's config file.
+ * @param sourceName - Filename of the source artefact (used for file-based types like commands).
+ * @returns Translated content and target filename, or null if the input is empty/untranslatable.
+ */
+export type Translator = (
+  sourceContent: string,
+  sourceName?: string,
+) => { content: string; targetName: string } | null;
+
+// MigrateOptions is defined by the Zod schema in src/config/schema.ts
+// and re-exported here for convenience.
+export type { MigrateOptions } from "../config/schema";


### PR DESCRIPTION
## Summary

Add `agentsync migrate` command that translates configuration (global rules, MCP servers, commands) from one AI agent's format to another. Supports all five registered agents (Claude, Cursor, Codex, Copilot, VS Code) with 36 directional translator pairs across 3 config types.

Closes #15

### Before — no cross-agent config sharing

```mermaid
flowchart LR
    classDef agent fill:#1a5276,color:#ffffff
    classDef action fill:#922b21,color:#ffffff

    Claude["Claude config"]:::agent
    Cursor["Cursor config"]:::agent
    Codex["Codex config"]:::agent
    Manual["Manual copy-paste<br/>and reformat"]:::action

    Claude -->|"manual"| Manual
    Manual -->|"manual"| Cursor
    Manual -->|"manual"| Codex
```

### After — single command migration

```mermaid
flowchart LR
    classDef agent fill:#1a5276,color:#ffffff
    classDef cmd fill:#1e8449,color:#ffffff

    Claude["Claude config"]:::agent
    Migrate["agentsync migrate<br/>--from claude --to all"]:::cmd
    Cursor["Cursor config"]:::agent
    Codex["Codex config"]:::agent
    Copilot["Copilot config"]:::agent
    VsCode["VS Code config"]:::agent

    Claude --> Migrate
    Migrate --> Cursor
    Migrate --> Codex
    Migrate --> Copilot
    Migrate --> VsCode
```

## Changes

### New files (14)
- **`src/migrate/types.ts`** — ConfigType, MigrationPair, MigratedArtifact, MigrateResult, Translator type definitions
- **`src/migrate/registry.ts`** — Translator registry mapping (from, to, type) triples to pure translator functions; 36 pairs registered
- **`src/migrate/migrate.ts`** — Orchestrator: readSourceArtefacts, applyMigrated (with per-server MCP merge for JSON + TOML), performMigrate with secret detection abort
- **`src/migrate/translators/global-rules.ts`** — 12 pairwise Markdown rules translators (Claude/Cursor/Codex/Copilot)
- **`src/migrate/translators/mcp.ts`** — 12 pairwise MCP translators (JSON mcpServers ↔ TOML mcp.servers)
- **`src/migrate/translators/commands.ts`** — 12 pairwise command file translators (*.md ↔ *.prompt.md)
- **`src/commands/migrate.ts`** — CLI command with Zod validation per constitution Principle IV
- **`docs/migrate.md`** — User-facing migration guide with Mermaid flow diagram and support matrix
- **6 test files** — 51 new tests covering translators, registry, orchestrator, CLI validation

### Modified files (4)
- **`src/cli.ts`** — Register `migrateCommand` in subCommands
- **`src/config/schema.ts`** — Add `MigrateOptionsSchema` Zod schema (agent name enum, config type enum, refine rules for same-agent and --name/--type dependency)
- **`docs/command-reference.md`** — Add migrate command documentation
- **`CLAUDE.md`** — Auto-generated agent context update

### Spec artifacts
- Full specification pipeline: spec.md, plan.md, research.md, data-model.md, contracts/cli-migrate.md, quickstart.md, tasks.md (31 tasks, all complete)

## Key design decisions

- **Translator registry pattern** — pure functions indexed by `(from→to:type)` key, no I/O in translators
- **Per-server MCP merge** — preserves target-only servers for both JSON (Claude/Cursor/VS Code) and TOML (Codex)
- **Secret detection aborts** — constitution Principle I: `redactSecretLiterals` applied to MCP content, migration aborts if secrets found
- **No vault dependency** — `migrate` works standalone via `AgentPaths`, no `agentsync init` required
- **No new runtime dependencies** — reuses existing `@iarna/toml`, `citty`, `@clack/prompts`, `zod`

## Test plan

- [x] 319 tests pass (51 new), 0 failures
- [x] `bun run check` (typecheck + lint + test) passes
- [x] Secret detection abort tested with `sk-` pattern fixture
- [x] MCP per-server merge tested for both JSON and TOML targets
- [x] Dry-run verified: no files written
- [x] `--to all` expansion verified: skips unsupported pairs with message
- [x] `--name` filtering verified: single artefact only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a migrate command to translate agent configuration (global rules, MCP servers, commands) across Claude, Cursor, Codex, Copilot, and VS Code.
  * Supports --type, --name, --to all, and --dry-run; overwrites colliding entries (source wins) and merges MCP servers by name; aborts on detected secret literals.

* **Documentation**
  * Added full command reference, guide, quickstart, spec, and contract docs for migration.

* **Tests**
  * Added extensive tests covering CLI parsing, translators, migration flows, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->