### PR TITLE
feat(skills): sync skill directories for Claude, Cursor, Codex + skill remove verb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,14 @@
 # agent-sync Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-06
+Auto-generated from all feature plans. Last updated: 2026-04-11
 
 ## Active Technologies
 - TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), @iarna/toml ^2.2.5 (Codex TOML), zod 4.x (validation) (20260406-125441-config-migration)
 - Local filesystem only (agent config files via `AgentPaths` from `src/config/paths.ts`) (20260406-125441-config-migration)
 - TypeScript 6.x, strict mode + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), zod 4.x (validation), simple-git 3.x, age-encryption 0.3.x, picocolors 1.1.x (new explicit dep) (20260406-164513-repo-housekeeping)
 - Local filesystem (agent config files via `AgentPaths`) (20260406-164513-repo-housekeeping)
+- TypeScript 6.x, strict mode (`"strict": true`), Bun ≥ 1.3.9 runtime + `citty` (CLI), `@clack/prompts` (output), `tar` v7 (archive), `age-encryption` (X25519 encryption), `simple-git` (vault Git ops), `zod` (schema validation), `picocolors` (terminal colours) (20260411-002222-agent-skills-sync)
+- Local filesystem only. Skill sources at `~/.claude/skills/`, `~/.cursor/skills/`, `~/.codex/skills/`, `~/.copilot/skills/`. Encrypted destinations at `<vaultDir>/<agent>/skills/<name>.tar.age`, wired through `AgentPaths` in `src/config/paths.ts` (20260411-002222-agent-skills-sync)
 
 - TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x (20260406-094347-stabilise-daemon)
 
@@ -26,10 +28,10 @@ bun run check
 TypeScript 6.x, strict mode (`"strict": true`): Follow standard conventions
 
 ## Recent Changes
+- 20260411-002222-agent-skills-sync: Added TypeScript 6.x, strict mode (`"strict": true`), Bun ≥ 1.3.9 runtime + `citty` (CLI), `@clack/prompts` (output), `tar` v7 (archive), `age-encryption` (X25519 encryption), `simple-git` (vault Git ops), `zod` (schema validation), `picocolors` (terminal colours)
 - 20260406-164513-repo-housekeeping: Added TypeScript 6.x, strict mode + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), zod 4.x (validation), simple-git 3.x, age-encryption 0.3.x, picocolors 1.1.x (new explicit dep)
 - 20260406-125441-config-migration: Added TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x (CLI), @clack/prompts 1.2.x (output), @iarna/toml ^2.2.5 (Codex TOML), zod 4.x (validation)
 
-- 20260406-094347-stabilise-daemon: Added TypeScript 6.x, strict mode (`"strict": true`) + citty 0.2.x, @clack/prompts 1.2.x, zod 4.x, simple-git 3.x, age-encryption 0.3.x
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Start here:
 
 ## What a vault means here
 
-The vault is a normal Git repository that stores encrypted artifacts such as `claude/CLAUDE.md.age` or `copilot/skills/<name>.tar.age`. AgentSync never pushes plaintext configs. Files that match hard never-sync patterns or contain literal secrets abort the push before encryption.
+The vault is a normal Git repository that stores encrypted artifacts such as `claude/CLAUDE.md.age`, `claude/skills/<name>.tar.age`, `codex/skills/<name>.tar.age`, `cursor/skills/<name>.tar.age`, and `copilot/skills/<name>.tar.age`. AgentSync never pushes plaintext configs. Files that match hard never-sync patterns or contain literal secrets abort the push before encryption.
+
+AgentSync never silently removes vault skills — removal is always an explicit user action via `agentsync skill remove <agent> <name>`. Local deletes, pulls, and status checks are all additive by construction, so no background operation can take a skill out of the vault.
 
 When you point a second machine at an existing vault, `init` now joins the remote history before writing machine-specific config. Sync commands also use one explicit fast-forward-only reconciliation rule, so divergent local history stops with recovery guidance instead of silently merging or printing a success-style footer.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,6 +73,90 @@ If the local vault diverged from the remote, the command flow stops before any a
 - `status` compares local snapshot content with decrypted vault files to show drift.
 - `doctor` checks key presence, config validity, remote reachability, vault hygiene, and daemon installation state.
 
+## Skills sync flow
+
+AgentSync treats per-user *skills* — directories under `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, and `~/.copilot/skills/` — as first-class artifacts. They ride the vault through a single shared module: the skills walker at `src/agents/skills-walker.ts`.
+
+Every skill-bearing agent adapter calls `collectSkillArtifacts(agent, skillsDir)` and inherits the same five gates in the same order. Each gate is a safety rule that maps back to a specific requirement:
+
+1. **Dot-skip** — any entry name starting with `.` is skipped silently. Protects vendor bundles like Codex's `.system/` directory (FR-017).
+2. **Root-symlink rejection** — if the skills root itself is a symlink, the walker returns an empty result with no warnings. Protects against a vendored-pool tree being pointed at the skills directory by accident (FR-016 outer tier).
+3. **Sentinel verification** — a skill directory must contain a *real* `SKILL.md` file. `lstat` is used so a symlinked sentinel fails naturally without a special case (FR-002 + FR-016 sentinel).
+4. **Never-sync interior scan** — every file inside the skill is run through `shouldNeverSync` from `src/core/sanitizer.ts`. Any hit emits a `never-sync inside skill: <path>` warning which `src/commands/push.ts` escalates to a fatal abort, so the entire push fails before any encryption work begins (FR-006).
+5. **Symlink-filtered tar** — the surviving skill tree is archived through `archiveDirectory(dir, { skipSymlinks: true })`. Symlinked files inside the skill are filtered out of the tar; the real files around them are archived normally (FR-016 inner tier).
+
+The filter's opt-in flag keeps the pre-existing Copilot agent-tarball code path bit-for-bit unchanged.
+
+```mermaid
+flowchart TD
+	LocalDir["Local skills dir<br/>~/.agent/skills"]:::action
+	RootCheck{"Root is a<br/>real directory"}:::decision
+	DotCheck{"Entry name<br/>starts with dot"}:::decision
+	Sentinel{"Real SKILL.md<br/>sentinel present"}:::decision
+	NeverSync{"Interior matches<br/>never-sync pattern"}:::decision
+	TarStep["archiveDirectory<br/>skipSymlinks true"]:::keep
+	EncStep["encryptString<br/>age recipients"]:::keep
+	VaultEntry["Vault namespace<br/>agent/skills/name.tar.age"]:::vault
+	Pull["pull command<br/>decrypts artifact"]:::keep
+	Restore["extractArchive<br/>into ~/.agent/skills/name"]:::keep
+	SkipSilent["Skipped silently<br/>FR-016 outer or FR-017"]:::skip
+	SkipSentinel["Skipped silently<br/>FR-002 sentinel missing"]:::skip
+	Abort["Fatal abort<br/>push gate escalates"]:::fail
+
+	LocalDir --> RootCheck
+	RootCheck -- no --> SkipSilent
+	RootCheck -- yes --> DotCheck
+	DotCheck -- yes --> SkipSilent
+	DotCheck -- no --> Sentinel
+	Sentinel -- no --> SkipSentinel
+	Sentinel -- yes --> NeverSync
+	NeverSync -- yes --> Abort
+	NeverSync -- no --> TarStep --> EncStep --> VaultEntry --> Pull --> Restore
+
+	classDef action fill:#dbeafe,color:#1e3a8a,stroke:#1e3a8a,stroke-width:1.5px;
+	classDef decision fill:#fef3c7,color:#78350f,stroke:#78350f,stroke-width:1.5px;
+	classDef keep fill:#dcfce7,color:#14532d,stroke:#14532d,stroke-width:1.5px;
+	classDef vault fill:#e0e7ff,color:#3730a3,stroke:#3730a3,stroke-width:1.5px;
+	classDef skip fill:#fde68a,color:#78350f,stroke:#78350f,stroke-width:1.5px;
+	classDef fail fill:#7f1d1d,color:#ffffff,stroke:#7f1d1d,stroke-width:1.5px;
+```
+
+### Vault-removal flow
+
+Skills are **additive-by-default** across the whole pipeline. A local delete never removes the vault entry — the only way to take a skill out of the vault is the explicit `agentsync skill remove <agent> <name>` verb at `src/commands/skill.ts`. That verb enforces two invariants: it only touches the vault file, never any local skill directory (FR-012); and any subsequent `pull` on another machine leaves that machine's local skill directory untouched because `applyXxxVault` is extract-only (FR-013).
+
+```mermaid
+flowchart TD
+	UserReq["User runs<br/>agentsync skill remove agent name"]:::action
+	ValidateAgent{"Agent is<br/>claude cursor codex copilot"}:::decision
+	Reconcile["GitClient<br/>reconcileWithRemote"]:::vault
+	StatFile{"Vault file<br/>agent/skills/name.tar.age exists"}:::decision
+	Unlink["unlink vault file<br/>commit with skill remove message"]:::vault
+	Push["git push origin branch"]:::vault
+	LocalA["Local skills on machine A<br/>untouched FR-012"]:::local
+	MachineB["Machine B runs<br/>agentsync pull"]:::action
+	ApplyExtract["applyXxxVault<br/>extract-only no unlink"]:::vault
+	LocalB["Local skill on machine B<br/>still present FR-013"]:::local
+	NotFound["Exit code 1<br/>Skill not found"]:::fail
+	UnknownAgent["Exit code 1<br/>Unknown agent rejected"]:::fail
+
+	UserReq --> ValidateAgent
+	ValidateAgent -- no --> UnknownAgent
+	ValidateAgent -- yes --> Reconcile --> StatFile
+	StatFile -- no --> NotFound
+	StatFile -- yes --> Unlink --> Push
+	Push --> LocalA
+	Push --> MachineB --> ApplyExtract --> LocalB
+
+	classDef action fill:#dbeafe,color:#1e3a8a,stroke:#1e3a8a,stroke-width:1.5px;
+	classDef decision fill:#fef3c7,color:#78350f,stroke:#78350f,stroke-width:1.5px;
+	classDef vault fill:#e0e7ff,color:#3730a3,stroke:#3730a3,stroke-width:1.5px;
+	classDef local fill:#dcfce7,color:#14532d,stroke:#14532d,stroke-width:1.5px;
+	classDef fail fill:#7f1d1d,color:#ffffff,stroke:#7f1d1d,stroke-width:1.5px;
+```
+
+This two-flow model is why AgentSync can add and remove skills independently on different machines without any central coordination — every removal is an intentional user action, and every pull is extract-only.
+
 ## Security boundaries
 
 - `src/core/encryptor.ts` is the boundary for age identity generation, recipient derivation, and string/file encryption.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -155,7 +155,7 @@ bunx --package @chrisleekr/agentsync agentsync skill remove copilot debug-flow
 
 **Signature**: `skill remove <agent> <name>` — both positional arguments are required. `<agent>` must be one of `claude`, `cursor`, `codex`, or `copilot`; `vscode` and any other value are rejected. `<name>` is the basename of the skill (no extension, no path separators).
 
-**Outcome on success**: the file `<vaultDir>/<agent>/skills/<name>.tar.age` is removed, a `skill remove(<agent>): <name>` commit is created, and the commit is pushed to the configured remote branch. The success log line includes the 7-character short SHA.
+**Outcome on success**: the file `<vaultDir>/<agent>/skills/<name>.tar.age` is removed, a `skill remove(<agent>): <name>` commit is created, and the commit is pushed to the configured remote branch. The success log line may include the 7-character short SHA as `(commit <sha7>)` when `readHeadShortSha` can invoke `git rev-parse` on the vault; it is omitted silently if git cannot be reached, because the SHA readout is a non-fatal UX helper.
 
 **Exit codes**:
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -137,7 +137,7 @@ bunx --package @chrisleekr/agentsync agentsync doctor
 - age-encryption module availability
 - remote reachability
 - obvious unencrypted sensitive files in the vault
-- readability of the per-agent skills directories under `~/.claude/skills/`, `~/.codex/skills/`, and `~/.cursor/skills/` (warns if a directory is missing or unreadable)
+- readability of the per-agent skills directories under `~/.claude/skills/`, `~/.codex/skills/`, and `~/.cursor/skills/` (`buildSkillsDirChecks` warns if a directory is missing, unreadable, a symbolic link per FR-016, or exists but is not a directory)
 - daemon service installation state
 
 ## skill remove

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -105,7 +105,7 @@ bunx --package @chrisleekr/agentsync agentsync pull --agent cursor
 - Pull uses the same fast-forward-only reconciliation rule as `push`, `key`, and daemon sync.
 - If local and remote vault history diverged, `pull` exits with a recovery message and no success footer.
 - If the private key is missing, the command cannot decrypt anything.
-- Pull is extract-only and never deletes an existing local skill directory, even when the matching vault artifact is gone (FR-013). The only way to remove a skill everywhere is the explicit `skill remove` verb.
+- Pull is extract-only and never deletes an existing local skill directory, even when the matching vault artifact is gone (FR-013). `skill remove` only removes the vault artifact; to complete the removal on this machine or any other machine, delete the local skill directory by hand (`rm -rf ~/.<agent>/skills/<name>`).
 
 ## status
 
@@ -164,7 +164,10 @@ bunx --package @chrisleekr/agentsync agentsync skill remove copilot debug-flow
 | `0` | File removed, commit landed, push succeeded | `Removed <agent>/<name> from vault (commit <sha7>)` |
 | `1` | Skill not found in vault | `Skill not found: <agent>/<name>` + `Looked for: <resolved path>` |
 | `1` | Unknown agent name | `Unknown agent: <provided>. Supported: claude, cursor, codex, copilot` |
-| `1` | Reconcile or git push failed | `Removal staged but not pushed: <git error>` with retry hint |
+| `1` | Reconcile with remote failed **before** the vault file was touched | `<upstream reconcile error>` — the vault working tree is unchanged; resolve the remote divergence and retry |
+| `1` | Git commit or push failed **after** the vault file was unlinked locally | `Removal staged but not pushed: <git error>` + hint to re-run `agentsync push` or `agentsync skill remove <agent> <name>` to finish the removal |
+
+See `specs/20260411-002222-agent-skills-sync/contracts/skill-remove-cli.md` for the authoritative row-by-row mapping; the table above mirrors that contract.
 
 **Safety guarantees (critical)**:
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -72,7 +72,7 @@ bunx --package @chrisleekr/agentsync agentsync push --agent claude
 
 **Needs**: initialized vault, configured recipients, readable local agent config.
 
-**Outcome**: encrypted `.age` or `.tar.age` artifacts are committed and pushed to the configured branch.
+**Outcome**: encrypted `.age` or `.tar.age` artifacts are committed and pushed to the configured branch. Per-user *skills* under `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, and `~/.copilot/skills/` are packaged through the shared skills walker and land in the matching vault namespace (`claude/skills/<name>.tar.age`, `codex/skills/<name>.tar.age`, `cursor/skills/<name>.tar.age`, `copilot/skills/<name>.tar.age`).
 
 **Caveats**:
 
@@ -80,6 +80,9 @@ bunx --package @chrisleekr/agentsync agentsync push --agent claude
 - If the local vault and remote vault have diverged, `push` stops before writing or encrypting new artifact content.
 - Push aborts when literal secrets are detected in supported config content.
 - Files matching never-sync patterns are skipped even if an agent adapter sees them.
+- Push aborts fatally when a never-sync file is discovered *inside* a skill directory (FR-006). Remove the file and re-run before retrying.
+- A top-level symlinked skill root or a symlinked `SKILL.md` sentinel is skipped silently, and symlinked helper files *inside* a skill are filtered out of the archive (FR-016).
+- Push is additive-by-default: deleting a skill locally does NOT remove it from the vault on any machine. Use `skill remove` for explicit removal (FR-011 / FR-012).
 
 ## pull
 
@@ -94,7 +97,7 @@ bunx --package @chrisleekr/agentsync agentsync pull --agent cursor
 
 **Needs**: initialized vault, readable private key, reachable Git remote.
 
-**Outcome**: supported local agent files are updated from the vault.
+**Outcome**: supported local agent files are updated from the vault, including any per-agent skills stored under `claude/skills/`, `codex/skills/`, `cursor/skills/`, and `copilot/skills/`.
 
 **Caveats**:
 
@@ -102,6 +105,7 @@ bunx --package @chrisleekr/agentsync agentsync pull --agent cursor
 - Pull uses the same fast-forward-only reconciliation rule as `push`, `key`, and daemon sync.
 - If local and remote vault history diverged, `pull` exits with a recovery message and no success footer.
 - If the private key is missing, the command cannot decrypt anything.
+- Pull is extract-only and never deletes an existing local skill directory, even when the matching vault artifact is gone (FR-013). The only way to remove a skill everywhere is the explicit `skill remove` verb.
 
 ## status
 
@@ -114,7 +118,7 @@ bunx --package @chrisleekr/agentsync agentsync status
 bunx --package @chrisleekr/agentsync agentsync status --verbose
 ```
 
-**Outcome**: table of synced, local-only, vault-only, changed, or error states.
+**Outcome**: table of synced, local-only, vault-only, changed, or error states. Skill artifacts (`<agent>/skills/<name>.tar.age`) appear alongside other vault entries and report drift exactly the same way any other artifact does.
 
 ## doctor
 
@@ -133,7 +137,40 @@ bunx --package @chrisleekr/agentsync agentsync doctor
 - age-encryption module availability
 - remote reachability
 - obvious unencrypted sensitive files in the vault
+- readability of the per-agent skills directories under `~/.claude/skills/`, `~/.codex/skills/`, and `~/.cursor/skills/` (warns if a directory is missing or unreadable)
 - daemon service installation state
+
+## skill remove
+
+**Why**: Remove one skill from the vault explicitly. This is the **only** operation that takes a skill out of the vault — every other AgentSync command is additive-by-default (FR-011 / FR-012).
+
+**Typical usage**:
+
+```bash
+bunx --package @chrisleekr/agentsync agentsync skill remove claude my-skill
+bunx --package @chrisleekr/agentsync agentsync skill remove codex review-helper
+bunx --package @chrisleekr/agentsync agentsync skill remove cursor polish-prompt
+bunx --package @chrisleekr/agentsync agentsync skill remove copilot debug-flow
+```
+
+**Signature**: `skill remove <agent> <name>` — both positional arguments are required. `<agent>` must be one of `claude`, `cursor`, `codex`, or `copilot`; `vscode` and any other value are rejected. `<name>` is the basename of the skill (no extension, no path separators).
+
+**Outcome on success**: the file `<vaultDir>/<agent>/skills/<name>.tar.age` is removed, a `skill remove(<agent>): <name>` commit is created, and the commit is pushed to the configured remote branch. The success log line includes the 7-character short SHA.
+
+**Exit codes**:
+
+| Code | Scenario | Output |
+| ---- | -------- | ------ |
+| `0` | File removed, commit landed, push succeeded | `Removed <agent>/<name> from vault (commit <sha7>)` |
+| `1` | Skill not found in vault | `Skill not found: <agent>/<name>` + `Looked for: <resolved path>` |
+| `1` | Unknown agent name | `Unknown agent: <provided>. Supported: claude, cursor, codex, copilot` |
+| `1` | Reconcile or git push failed | `Removal staged but not pushed: <git error>` with retry hint |
+
+**Safety guarantees (critical)**:
+
+- The command **never** touches any local skill directory on any machine, including the machine running the command (FR-012).
+- A subsequent `pull` on another machine leaves that machine's local skill directory **untouched** because `applyXxxVault` is extract-only (FR-013).
+- The command removes one skill at a time. `--all`, `--force`, and glob patterns are intentionally not supported.
 
 ## daemon
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -144,6 +144,27 @@ To finish removing the skill on the other laptop, delete the local skill directo
 rm -rf ~/.claude/skills/<name>   # or ~/.cursor/skills, ~/.codex/skills, ~/.copilot/skills
 ```
 
+## A single file I deleted inside a skill reappears after pull on another machine
+
+Symptom:
+
+- On machine A you deleted `helper.md` from a skill (not the whole skill), re-ran `push`, and the updated vault tar no longer contains it.
+- On machine B, after `pull`, `helper.md` is still present in the local skill directory.
+
+Cause: this is symmetric to the section above and comes from the same FR-013 rule. `applyXxxSkill` extracts the vault tar *on top of* the existing local skill directory instead of replacing it. Files that are in the local directory but no longer in the tar survive the extract unchanged. AgentSync makes this trade deliberately — the alternative (replace the directory on every pull) would silently destroy any local edits or in-progress files a user happened to have inside the skill between pulls.
+
+Next steps:
+
+1. On the affected machine, `rm` the stale file(s) manually inside the skill directory.
+
+   ```bash
+   rm ~/.claude/skills/<name>/helper.md   # or the equivalent path on cursor/codex/copilot
+   ```
+
+2. Run `agentsync status` to confirm the skill now matches the vault for that machine.
+
+Note: a future release may offer a `pull --replace-skills` flag for users who want vault-as-source-of-truth overwrite semantics, but the default will remain additive. Do not solve this by editing the vault directly or by running `git rm` inside the vault — both of those bypass the reconciliation logic.
+
 ## A vendored or symlinked skill did not sync
 
 Cause: FR-016's outer tier refuses to walk a skill root that is itself a symbolic link. This prevents a vendored pool outside the skills directory from being silently tar'd into the encrypted vault through a follow-the-link archival.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -94,6 +94,74 @@ Next step:
 
 - Treat the skip as intentional unless the file is clearly safe and the policy should change in `src/core/sanitizer.ts`.
 
+## My skill directory did not push
+
+Likely causes, in order of frequency:
+
+1. The directory is missing a `SKILL.md` sentinel file. AgentSync treats the presence of a real `SKILL.md` as the "this is a skill" marker — a directory without one is silently ignored (FR-002). Add the sentinel and re-run `push`.
+2. The `SKILL.md` file is a symbolic link. The walker uses `lstat` so a symlinked sentinel fails the "is a real file" check and the skill is skipped (FR-016 sentinel rule). Replace the symlink with a real file or move the directory so the sentinel can be a real file.
+3. The skill root itself is a symbolic link into a vendored pool. AgentSync refuses to follow the link because the outer tier of FR-016 forbids it. Make the skill root a real directory.
+4. The directory name starts with a dot. Top-level `.something` entries under the skills root are skipped silently to protect vendor bundles like Codex's `.system/` directory (FR-017). Rename the directory so its name does not start with a dot.
+
+## Push aborted because of a never-sync file inside a skill
+
+Symptom:
+
+```text
+Push aborted: 1 security issue(s) detected.
+[<agent>] never-sync inside skill: /Users/<you>/.<agent>/skills/<name>/auth.json
+```
+
+Cause: a file matching a never-sync pattern (e.g. `auth.json`, `credentials.json`, `.env*`) exists *inside* a skill directory. AgentSync escalates this to a fatal push abort rather than silently dropping the file, because the alternative would allow a crafted skill directory to smuggle credentials out of the never-sync safety net (FR-006).
+
+Next steps:
+
+1. Remove or rename the flagged file inside the skill directory.
+2. Verify the directory no longer contains anything matched by `NEVER_SYNC_PATTERNS` in `src/core/sanitizer.ts`.
+3. Re-run `push`.
+
+Do not bypass this by editing the vault manually.
+
+## I deleted a skill locally and it came back after pull
+
+This is working as designed. AgentSync is **additive-by-default**: a local delete never removes the vault entry, and the next `pull` will happily restore the skill from the vault (FR-011).
+
+If you want the skill gone for good on every machine, you must run the explicit removal verb:
+
+```bash
+bun run src/cli.ts skill remove <agent> <name>
+```
+
+That verb is the only operation that mutates the vault's skills namespace in the delete direction (FR-012).
+
+## I removed a skill from the vault but it is still on my other laptop
+
+Also working as designed. `skill remove` removes the vault artifact, but `pull` is extract-only and never deletes a local skill directory — even when the matching vault file is gone (FR-013). The safety reasoning is that a concurrent edit to the same skill on machine B should not silently vanish after machine A decides to remove it.
+
+To finish removing the skill on the other laptop, delete the local skill directory manually on that machine:
+
+```bash
+rm -rf ~/.claude/skills/<name>   # or ~/.cursor/skills, ~/.codex/skills, ~/.copilot/skills
+```
+
+## A vendored or symlinked skill did not sync
+
+Cause: FR-016's outer tier refuses to walk a skill root that is itself a symbolic link. This prevents a vendored pool outside the skills directory from being silently tar'd into the encrypted vault through a follow-the-link archival.
+
+Next steps:
+
+- If the vendored content really belongs to you and should sync, copy the tree into the skills directory as a real directory instead of linking to it.
+- If you do not want the vendored content in the vault, leave the symlink in place — it is already silently ignored.
+
+## A helper file inside my skill is missing on the other machine after pull
+
+Cause: the helper file was a symbolic link *inside* the skill directory. FR-016's inner tier filters symlink entries out of the tar archive at `archiveDirectory` time, so only the real files around the link are sent to the vault. This is intentional — symlinks inside a skill typically point at per-machine vendored state that must not leak across machines.
+
+Next steps:
+
+- If the helper file should sync, convert the symlink into a real file (`cp -L` is a convenient one-shot) and re-run `push`.
+- If the helper file is machine-specific and should not sync, accept the omission and re-create the link manually on the other machine.
+
 ## `status` shows local-only or vault-only entries
 
 - `local-only` means the machine has config that is not in the vault yet. Run `push` after reviewing the content.

--- a/specs/20260411-002222-agent-skills-sync/checklists/requirements.md
+++ b/specs/20260411-002222-agent-skills-sync/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Sync Agents' Skills
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Ready for `/speckit.plan`.
+- Four clarifications have been resolved across the 2026-04-11 session:
+  - **Cursor canonical skills path** → `~/.cursor/skills/` only (FR-010).
+  - **Deletion semantics** → additive-by-default push (FR-011), explicit single-skill vault-removal action (FR-012), pull-side no-delete guarantee on other machines (FR-013).
+  - **Symlink skip boundary** → skip the whole skill when the root is a symlink, and omit individual symlink files / sub-dirs when the root is real (FR-016). Partial-archive for real skills is an accepted tradeoff.
+  - **Top-level dot-entry handling** → silently skip any entry whose name begins with `.` at the top of a skills root, regardless of entry kind (FR-017).
+- Content Quality notes: the spec references concrete vault paths (`claude/skills/`, `codex/skills/`, `cursor/skills/`, `copilot/skills/`) and the `SKILL.md` sentinel. These are treated as data-contract / user-visible surface (they appear in the vault repository a user can browse), not implementation detail. They are kept in the spec because omitting them would make the requirements untestable.
+- The spec names one source file (`src/agents/copilot.ts`) in the Assumptions section as the reference pattern. This is a deliberate pointer for planners, not a prescription of implementation — the planner can decide whether to keep it when producing `plan.md`.
+- FR-016 introduces a partial-archive behavior for real skills that reference helper files via symlinks. This is an accepted tradeoff (documented in the `Real skill directory containing a symlinked helper file` edge case) — a skill that depends on a symlinked helper will restore on another machine without that helper and may behave differently. Planners and testers must treat "skill round-trips" as "real content round-trips, symlinks are dropped".

--- a/specs/20260411-002222-agent-skills-sync/contracts/skill-remove-cli.md
+++ b/specs/20260411-002222-agent-skills-sync/contracts/skill-remove-cli.md
@@ -1,0 +1,107 @@
+# Contract: `agentsync skill remove` CLI
+
+**Feature**: 20260411-002222-agent-skills-sync
+**Scope**: The user-facing signature, exit codes, and output format of the new `skill remove` CLI verb introduced by FR-012. Tests at `src/commands/__tests__/skill.test.ts` assert every row in this contract.
+
+---
+
+## Signature
+
+```text
+agentsync skill remove <agent> <name>
+```
+
+- `<agent>` — positional, required. One of: `claude`, `cursor`, `codex`, `copilot`. Any other string is a usage error (see exit codes).
+- `<name>` — positional, required. The basename of the skill in the vault. No path separators, no glob metacharacters. Exactly matches the `<name>` that would appear in `<vaultDir>/<agent>/skills/<name>.tar.age`.
+
+The command is registered under a citty command group called `skill`, so `agentsync skill --help` lists it (and leaves room for future `list` / `info` verbs without renaming anything).
+
+### Reserved for future use, not in scope
+
+- `agentsync skill list [<agent>]`
+- `agentsync skill info <agent> <name>`
+- `agentsync skill remove --all <agent>` or glob patterns — explicitly out of scope per FR-012's one-at-a-time rule.
+- `--dry-run` on `skill remove` — not in scope for v1. If added later, it MUST NOT touch the vault file and MUST NOT commit or push.
+
+---
+
+## Exit codes
+
+| Code | Scenario | Output behavior |
+| ---- | -------- | --------------- |
+| `0` | Removal succeeded (file deleted, commit landed, push succeeded) | `log.success("Removed <agent>/<name> from vault (commit <sha7>)")` |
+| `1` | Skill not found in vault for the given agent | `log.error("Skill not found: <agent>/<name>")` followed by `log.info("Looked for: <resolved vault path>")`. **No** Git operation, **no** file write |
+| `1` | Unknown agent name | `log.error("Unknown agent: <provided>. Supported: claude, cursor, codex, copilot")` |
+| `1` | `reconcileWithRemote` failed before deletion | Same error surface as `push` — forward the upstream guidance. **No** file write, **no** commit |
+| `1` | Git commit or push failed **after** the file was `unlink`ed locally | `log.error("Removal staged but not pushed: <git error>")`. The vault working tree has a staged deletion; running `skill remove` or `push` again will resolve it |
+
+Exit code `1` is reused for every error case to keep the surface narrow. Machine-readable output (JSON) is not in scope for v1.
+
+### What exit code `0` guarantees
+
+- The target `.age` file is absent from the remote branch named in `config.remote.branch`.
+- The local vault working tree is clean with respect to that file.
+- **Zero** local skill directories on the invoking machine were touched (FR-012).
+- **Zero** local skill directories on any other machine are affected until that machine pulls; even then, FR-013 guarantees the pull does not delete any local skill (see contracts/walker-interface.md for the pull-side no-op rule).
+
+---
+
+## Output format
+
+All output goes through `@clack/prompts`' `log` facility, matching every other command in this CLI. No raw `console.log` calls are permitted (Principle IV's `noConsole: error` rule).
+
+### Success output
+
+```text
+◇  Removed claude/my-skill from vault (commit a1b2c3d)
+```
+
+### Not-found output
+
+```text
+■  Skill not found: claude/my-skill
+◆  Looked for: /Users/<user>/.config/agentsync/vault/claude/skills/my-skill.tar.age
+```
+
+The resolved path is printed so the user can verify the agent and name spelling, especially in scripts where a typo is the most likely cause.
+
+### Git-error output
+
+```text
+■  Removal staged but not pushed: <git error as returned by simple-git>
+◆  Hint: run `agentsync push` or re-run `agentsync skill remove claude my-skill` to retry.
+```
+
+---
+
+## Inputs the command does NOT accept
+
+- `--force` — skill removal is already a deliberate single-target action; forcing adds nothing.
+- `--local` — removal is vault-only by construction (FR-012); there is nothing to make local.
+- `--all` — one skill at a time (FR-012).
+- `--agent` as a flag — the positional `<agent>` argument is the canonical form; flag form would create two ways to say the same thing.
+
+---
+
+## Preconditions the command MUST check before touching the vault
+
+1. `resolveRuntimeContext()` returns a valid vault dir.
+2. `loadConfig(resolveConfigPath(runtime.vaultDir))` parses cleanly.
+3. `<agent>` is a recognised agent name.
+4. The resolved `<vaultDir>/<agent>/skills/<name>.tar.age` path exists on disk.
+
+Failing (1) or (2) yields the same error surface as `push` failing on those preconditions — existing helpers are reused verbatim.
+
+Failing (3) or (4) yields exit code 1 with the messages defined above. The vault working tree is not mutated in either case.
+
+---
+
+## Pull-side guarantees (per FR-013)
+
+These are properties of the broader system that `skill remove` relies on — they are implemented in the existing `applyXxxVault` functions and not by `skill remove` itself. They are listed here so the contract is complete:
+
+- A subsequent `pull` on any machine MUST NOT delete the local skill directory for the removed `(agent, name)` pair.
+- A subsequent `pull` on a machine that did not have the skill locally MUST NOT restore it.
+- A subsequent `push` from any machine that also does not have the skill locally MUST NOT re-introduce it to the vault.
+
+These three properties together are what make `skill remove` safe to run without announcing to the team — no other machine's local files are affected.

--- a/specs/20260411-002222-agent-skills-sync/contracts/vault-paths.md
+++ b/specs/20260411-002222-agent-skills-sync/contracts/vault-paths.md
@@ -1,0 +1,94 @@
+# Contract: Vault Skill Namespace Layout
+
+**Feature**: 20260411-002222-agent-skills-sync
+**Scope**: Defines the exact filesystem layout this feature writes to, reads from, and removes from inside the encrypted vault repository. Any code that touches skill artifacts MUST honor these paths exactly.
+
+---
+
+## Canonical vault path template
+
+```text
+<vaultDir>/<agent>/skills/<name>.tar.age
+```
+
+Where:
+
+| Placeholder | Permitted values | Notes |
+| ----------- | ---------------- | ----- |
+| `<vaultDir>` | Absolute path returned by `resolveRuntimeContext()` | Cross-platform; the feature never hard-codes a vault location |
+| `<agent>` | `claude` \| `cursor` \| `codex` \| `copilot` | Exactly these four. `vscode` is not in this set — adding a `vscode/skills/` directory is a contract violation |
+| `<name>` | The basename of a real (non-symlink) directory under the agent's local skills root, containing a real (non-symlink) `SKILL.md` sentinel, whose name does not start with `.` | See the walker contract below for how this is computed |
+
+The tarball-then-age chain is fixed: the `.tar.age` suffix is the on-disk encoding of "base64-encoded gzipped tar of the skill directory, then encrypted with the vault's age recipients". No alternative suffix (e.g. `.tgz.age`, `.tar.gz.age`) is produced or read by this feature.
+
+---
+
+## Writing to the vault
+
+### What this feature writes
+
+- `push` (via `performPush` in `src/commands/push.ts`) MAY write files at the canonical template above, one per real user-created skill per supported agent.
+- `push` MUST NOT write any other file, directory, manifest, metadata blob, or tombstone under `<vaultDir>/<agent>/skills/`.
+- The existing Copilot path at `<vaultDir>/copilot/skills/<name>.tar.age` is unchanged by this feature in shape; only the walker that produces those paths is retrofitted (per research R2/R4/R7).
+
+### What this feature explicitly does not write
+
+- No `<vaultDir>/<agent>/skills/manifest.*`
+- No `<vaultDir>/<agent>/skills/index.json`
+- No `<vaultDir>/<agent>/skills/<name>.tombstone`
+- No `<vaultDir>/<agent>/skills/<name>/` (a directory at this path is a contract violation)
+- No `<vaultDir>/vscode/skills/` (VS Code is not a skill-bearing agent)
+
+---
+
+## Reading from the vault
+
+### On pull
+
+`applyClaudeVault`, `applyCursorVault`, `applyCodexVault`, and `applyCopilotVault` each read files from `<vaultDir>/<agent>/skills/` using the existing `readAgeFiles` helper pattern (see `src/agents/copilot.ts:234-245` for the reference). They MUST:
+
+- Iterate the `<vaultDir>/<agent>/skills/` directory if it exists; silently treat a missing directory as "no skills".
+- Select files whose name matches `^[^/]+\.tar\.age$` (i.e., a `.tar.age` file directly in the directory, not nested).
+- Ignore any file that does not match — do not warn, do not error. Forward compatibility: if a future feature adds a new shape under `<vaultDir>/<agent>/skills/` this feature's pull path must not crash on it.
+- Decrypt each selected file, base64-decode the plaintext, and pass it to the agent's `applyXxxSkill(<name>, <base64Tar>)` helper, which extracts the tar into `<agentSkillsRoot>/<name>/`.
+
+### On status
+
+`statusCommand` in `src/commands/status.ts` (unchanged per research R9) recursively collects every `.age` file under `<vaultDir>/<agent>` via `collectAgeFiles`. Skill artifacts are therefore picked up automatically. Status MUST NOT special-case the `skills/` sub-directory.
+
+---
+
+## Removing from the vault
+
+### On `skill remove <agent> <name>`
+
+- The command MUST resolve the target as `<vaultDir>/<agent>/skills/<name>.tar.age` using exactly the canonical template above — no path aliasing, no symlink resolution on the vault side, no glob expansion.
+- On file-not-found: exit with `process.exitCode = 1` and print the resolved path to help the user verify the agent/name spelling (see `contracts/skill-remove-cli.md`).
+- On file-found: `unlink` the file, commit with message exactly `skill remove(<agent>): <name>`, push to the remote branch from `config.remote.branch`.
+- The command MUST NOT delete any other file. Bulk removal is not in scope for this feature (FR-012).
+- The command MUST NOT touch `<agentSkillsRoot>` on any machine, including the one running the command.
+
+---
+
+## Collision guarantees
+
+- Two agents MAY each hold a skill named `my-skill`: `<vaultDir>/claude/skills/my-skill.tar.age` and `<vaultDir>/codex/skills/my-skill.tar.age` are distinct artifacts and do not interfere (FR-004).
+- The existing `copilot/skills/` namespace is independent of the three new ones. Existing Copilot artifacts written before this feature's retrofit remain valid; the walker retrofit only changes which skills get archived on the next push, not the vault layout.
+- A skill name MUST NOT contain path separators (`/` or `\`). The walker enforces this implicitly because it reads entries from `readdir` which returns basenames.
+
+---
+
+## Forbidden paths
+
+No code in this feature may write, read, or delete at any of the following paths:
+
+```text
+<vaultDir>/vscode/skills/           # VS Code is not a skill-bearing agent
+<vaultDir>/<agent>/skills/*.tgz     # Wrong suffix
+<vaultDir>/<agent>/skills/*.age     # Wrong suffix — missing .tar
+<vaultDir>/<agent>/skills/manifest* # No manifest file
+<vaultDir>/<agent>/skills/*.json    # No metadata JSON
+<vaultDir>/<agent>/skills/<name>/   # Directories under skills/ are forbidden
+```
+
+The reviewer's mental model: `<vaultDir>/<agent>/skills/` is a **flat directory of encrypted tarballs**, one per skill, nothing else. Any code or test that challenges that invariant should be questioned.

--- a/specs/20260411-002222-agent-skills-sync/contracts/walker-interface.md
+++ b/specs/20260411-002222-agent-skills-sync/contracts/walker-interface.md
@@ -98,8 +98,8 @@ The walker's test suite MUST cover at least these rows. Each row is an independe
 | 8 | Top-level `.DS_Store` regular file | 0 | `[]` |
 | 9 | Real skill `a/SKILL.md` + another real skill `b/SKILL.md` + symlinked root `c/` | 2 | `[]` |
 | 10 | Real skill whose interior contains a symlinked helper file | 1 | `[]` (the helper is omitted silently) |
-| 11 | Real skill containing a file whose path matches `NEVER_SYNC_PATTERNS` (e.g. `./credentials.json`) | 0 (the skill is not archived) | 1 warning with prefix `never-sync inside skill: ` |
-| 12 | Two real skills, one of which has a never-sync match | 0 for the matched skill, 1 for the clean one → `artifacts.length === 1` | 1 warning with prefix `never-sync inside skill: ` |
+| 11 | Real skill containing a file whose path matches `NEVER_SYNC_PATTERNS` (e.g. `./credentials.json`) | 0 (the skill is not archived) | 1 warning of the form `never-sync inside skill: <absolute path>` |
+| 12 | Two real skills, one of which has a never-sync match | 0 for the matched skill, 1 for the clean one → `artifacts.length === 1` | 1 warning of the form `never-sync inside skill: <absolute path>` |
 
 Row 12 is the important edge: the walker does not short-circuit on the first never-sync match, it collects the whole picture. The push gate then decides to escalate. This matches the "list every offender" UX from research R3.
 

--- a/specs/20260411-002222-agent-skills-sync/contracts/walker-interface.md
+++ b/specs/20260411-002222-agent-skills-sync/contracts/walker-interface.md
@@ -22,9 +22,10 @@
  *   5. The tar.gz archive produced for the entry omits every interior
  *      symlink while keeping every real file and real sub-directory    (FR-016 inner)
  *
- * @param agent        The agent namespace to write artifacts under. Only
- *                     skill-bearing agents are meaningful here; callers
- *                     that pass "vscode" get back an empty result.
+ * @param agent        The skill-bearing agent namespace to write artifacts
+ *                     under (`claude`, `cursor`, `codex`, `copilot`). The
+ *                     parameter type `SkillBearingAgent` excludes `vscode`
+ *                     at compile time, so no runtime no-op branch is needed.
  * @param skillsDir    Absolute path to the agent's skills root on disk.
  *                     A missing directory is NOT an error — the walker
  *                     returns { artifacts: [], warnings: [] }.
@@ -34,7 +35,7 @@
  *                     warnings for skills rejected at gate 4.
  */
 export async function collectSkillArtifacts(
-  agent: AgentName,
+  agent: SkillBearingAgent,
   skillsDir: string,
 ): Promise<SkillsWalkerResult>;
 ```

--- a/specs/20260411-002222-agent-skills-sync/contracts/walker-interface.md
+++ b/specs/20260411-002222-agent-skills-sync/contracts/walker-interface.md
@@ -1,0 +1,128 @@
+# Contract: Shared Skills Walker Interface
+
+**Feature**: 20260411-002222-agent-skills-sync
+**Module**: `src/agents/skills-walker.ts` (new)
+**Scope**: The exported surface of the walker, the invariants it upholds, and the behavioral guarantees that `claude.ts`, `cursor.ts`, `codex.ts`, and the `copilot.ts` retrofit all depend on.
+
+---
+
+## Exported surface
+
+```ts
+/**
+ * Walk an agent's local skills root and collect encrypted-ready tar artifacts
+ * for every directory that qualifies as a user-created skill.
+ *
+ * Gates applied in order:
+ *   1. Entry name does not start with "."                              (FR-017)
+ *   2. Entry is a real directory per lstat (not a symlink)             (FR-016 outer)
+ *   3. Entry contains a SKILL.md file that is itself a real regular
+ *      file per lstat (not a symlink)                                  (FR-002 + FR-016 sentinel)
+ *   4. No file inside the entry matches NEVER_SYNC_PATTERNS            (FR-006)
+ *   5. The tar.gz archive produced for the entry omits every interior
+ *      symlink while keeping every real file and real sub-directory    (FR-016 inner)
+ *
+ * @param agent        The agent namespace to write artifacts under. Only
+ *                     skill-bearing agents are meaningful here; callers
+ *                     that pass "vscode" get back an empty result.
+ * @param skillsDir    Absolute path to the agent's skills root on disk.
+ *                     A missing directory is NOT an error — the walker
+ *                     returns { artifacts: [], warnings: [] }.
+ *
+ * @returns            SkillsWalkerResult with one artifact per qualifying
+ *                     skill and zero or more `never-sync inside skill: `
+ *                     warnings for skills rejected at gate 4.
+ */
+export async function collectSkillArtifacts(
+  agent: AgentName,
+  skillsDir: string,
+): Promise<SkillsWalkerResult>;
+```
+
+The walker is the **only** function that owns the five gates. Agent adapters call it once per agent, spread its output into their own `SnapshotResult`, and return. They do not re-implement any of the gates themselves.
+
+---
+
+## Invariants the walker MUST uphold
+
+### Silence on non-failures (R7, FR-017)
+
+- Entries skipped by gate 1 (dot-prefixed) MUST NOT produce any warning, log line, or artifact. `artifacts.length` goes down; `warnings.length` does not go up.
+- Entries skipped by gate 2 (symlink root) MUST NOT produce any warning, log line, or artifact.
+- Entries skipped by gate 3 (missing or symlinked `SKILL.md`) MUST NOT produce any warning, log line, or artifact.
+- An entire skill directory that archives successfully but contains interior symlinks MUST produce exactly one artifact and zero warnings. The interior symlinks are silently omitted from the tarball (FR-016 inner tier).
+
+### Noisy only on the one failure that aborts the whole push (R3, FR-006)
+
+- A never-sync match inside a real, otherwise-qualifying skill directory MUST produce:
+  - **Zero** artifacts for that specific skill (the walker refuses to archive).
+  - Exactly one entry in `warnings`, prefixed with `"never-sync inside skill: "` followed by the absolute path of the offending file.
+- Multiple never-sync hits across different skills MUST produce multiple warning entries — one per offending path — so the user can fix them all in a single cycle instead of discovering them one at a time.
+- The walker MUST NOT throw on a never-sync hit. The push gate in `src/commands/push.ts` converts the warning to a fatal error.
+
+### Missing directory = no-op, not an error (FR-009)
+
+- If `skillsDir` does not exist, is not a directory, or cannot be read due to permissions, the walker MUST return `{ artifacts: [], warnings: [] }` without throwing.
+- The walker MUST NOT create the directory as a side-effect.
+
+### `lstat` is the only stat-family syscall used for "is it a symlink?" decisions (R4)
+
+- `stat` (which follows symlinks) MUST NOT be used to check whether a directory entry is a symlink.
+- `lstat` is authoritative for gate 2 (root), gate 3 (sentinel), and gate 5 (interior walk).
+- Using `fs/promises` `lstat` is preferred; `lstatSync` is acceptable inside the tar `filter` callback where async is unavailable.
+
+### Output paths match the vault path contract
+
+- Every `SkillArtifact.vaultPath` produced by the walker MUST match the template `<agent>/skills/<name>.tar.age`, where `<agent>` is the walker's input argument and `<name>` is the basename of the directory that passed all five gates. See `contracts/vault-paths.md`.
+
+### Base64 deterministic encoding
+
+- `SkillArtifact.plaintext` MUST be `buffer.toString("base64")` where `buffer` is the result of `archiveDirectory(skillDir, { skipSymlinks: true })`. This matches the existing Copilot convention at `src/agents/copilot.ts:95` so status-command SHA-256 comparisons behave identically across all four agents.
+
+---
+
+## Behavioral matrix (for tests at `src/agents/__tests__/skills-walker.test.ts`)
+
+The walker's test suite MUST cover at least these rows. Each row is an independent fixture directory that the test creates inside a tmp dir, passes to `collectSkillArtifacts("claude", tmpDir)`, and asserts on the returned shape.
+
+| # | Fixture | Expected `artifacts.length` | Expected `warnings` |
+| - | ------- | --------------------------- | ------------------- |
+| 1 | Empty tmp dir | 0 | `[]` |
+| 2 | Missing tmp dir (not created) | 0 | `[]` |
+| 3 | Real skill `my-skill/SKILL.md` + `my-skill/README.md` | 1 | `[]` |
+| 4 | Real skill `my-skill/` with no `SKILL.md` | 0 | `[]` |
+| 5 | Real skill `my-skill/` where `SKILL.md` is a symlink to another file | 0 | `[]` |
+| 6 | Top-level symlink `my-skill -> /tmp/other/my-skill` with valid target | 0 | `[]` |
+| 7 | Top-level `.system/` directory containing a real skill | 0 | `[]` |
+| 8 | Top-level `.DS_Store` regular file | 0 | `[]` |
+| 9 | Real skill `a/SKILL.md` + another real skill `b/SKILL.md` + symlinked root `c/` | 2 | `[]` |
+| 10 | Real skill whose interior contains a symlinked helper file | 1 | `[]` (the helper is omitted silently) |
+| 11 | Real skill containing a file whose path matches `NEVER_SYNC_PATTERNS` (e.g. `./credentials.json`) | 0 (the skill is not archived) | 1 warning with prefix `never-sync inside skill: ` |
+| 12 | Two real skills, one of which has a never-sync match | 0 for the matched skill, 1 for the clean one → `artifacts.length === 1` | 1 warning with prefix `never-sync inside skill: ` |
+
+Row 12 is the important edge: the walker does not short-circuit on the first never-sync match, it collects the whole picture. The push gate then decides to escalate. This matches the "list every offender" UX from research R3.
+
+---
+
+## What the walker does NOT do
+
+- The walker does NOT call `archiveDirectory` with `skipSymlinks: false`. The `skipSymlinks: true` flag is always passed (R2).
+- The walker does NOT encrypt. Encryption is performed by `performPush` after the walker returns.
+- The walker does NOT write any file. It reads from disk, builds in-memory `SkillArtifact` objects, and returns them.
+- The walker does NOT commit, push, or touch any Git state.
+- The walker does NOT deduplicate skills across agents. Each agent adapter calls the walker once with its own `skillsDir`, and the vault namespace isolation (`<agent>/skills/`) keeps results from colliding.
+- The walker does NOT emit log lines at any level. All user-visible output is the responsibility of the push command (for warnings) and `log` utility helpers in the command layer.
+
+---
+
+## Relationship to existing agent adapters
+
+After this feature lands, each of `snapshotClaude`, `snapshotCursor`, `snapshotCodex`, and `snapshotCopilot` will:
+
+1. Do its current non-skill work (instructions, commands, rules, MCP, etc.) as today.
+2. Call `collectSkillArtifacts(<agent>, AgentPaths.<agent>.skillsDir)`.
+3. Spread `walker.artifacts` into its own `artifacts` array.
+4. Spread `walker.warnings` into its own `warnings` array.
+5. Return `{ artifacts, warnings }`.
+
+For Copilot specifically, step 2 replaces the existing inline skill-collection block at `src/agents/copilot.ts:82-101`. The block is removed; the walker takes over. This is the retrofit that brings Copilot into FR-016 / FR-017 compliance without duplicating logic.

--- a/specs/20260411-002222-agent-skills-sync/data-model.md
+++ b/specs/20260411-002222-agent-skills-sync/data-model.md
@@ -130,26 +130,34 @@ if (w.startsWith("Redacted literal secret") || w.startsWith("never-sync inside s
 
 ---
 
-## Entity 6: `RemovalOutcome` (new type for `skill remove`)
+## Entity 6: `SkillRemoveResult` (new type for `skill remove`)
 
 ```ts
 /**
- * Result shape for the `skill remove <agent> <name>` command.
- * Modelled as a tagged union so the CLI layer can decide exit code +
- * output format without re-parsing a message string.
+ * Result shape for the `skill remove <agent> <name>` command, as exported
+ * from `src/commands/skill.ts`. Modelled as a discriminated union on the
+ * `status` field so the CLI layer can decide exit code + output format
+ * without re-parsing a message string. The authoritative row-by-row
+ * mapping to exit codes and log calls lives in
+ * `contracts/skill-remove-cli.md`.
  */
-type RemovalOutcome =
-  | { kind: "removed"; agent: AgentName; name: string; vaultPath: string; commitSha: string }
-  | { kind: "not-found"; agent: AgentName; name: string; vaultPath: string }
-  | { kind: "git-error"; agent: AgentName; name: string; vaultPath: string; error: string };
+export type SkillRemoveResult =
+  | { status: "success"; path: string; commitSha: string | null }
+  | { status: "unknown-agent"; provided: string; supported: readonly string[] }
+  | { status: "not-found"; path: string }
+  | { status: "reconcile-error"; error: string }
+  | { status: "git-error"; path: string; error: string };
 ```
+
+> **Spec note**: an earlier draft of this document used a `kind`-discriminated type called `RemovalOutcome` with only three variants (`removed` / `not-found` / `git-error`). The implementation needed two additional states (`reconcile-error` before any unlink, `unknown-agent` before any runtime work) to drive distinct exit-code messages, and the discriminant was renamed to `status` to match the rest of the codebase's result conventions. `contracts/skill-remove-cli.md` already documented the five-variant surface; this entry is the data-model sibling that was previously drifting.
 
 ### Invariants
 
-- `kind: "removed"` MUST only be emitted after the commit has landed AND the push has succeeded (or the user passed `--dry-run`, which is the only case where `commitSha` may be the empty string — see contracts/skill-remove-cli.md for whether `--dry-run` is in scope).
-- `kind: "not-found"` MUST drive `process.exitCode = 1` and MUST print the vault path it looked for, so the user can verify they typed the right agent and skill name (FR-012).
-- `kind: "not-found"` MUST NOT cause any Git operation, file write, or file delete. The vault state is unchanged on this outcome.
-- `kind: "git-error"` is reserved for the narrow window between successful `unlink` of the vault file and a failed `git push`. In this state, the vault working tree has a staged deletion that the user can resolve by re-running `skill remove` or `push`. The error string MUST include the `git` exit code or message to help the user debug. FR-013's pull-side guarantee is unaffected because the vault HEAD has not advanced.
+- `status: "success"` MUST only be emitted after the commit has landed AND the push has succeeded. `commitSha` is `null` when the remote had already removed the file during the pre-unlink reconcile (nothing new to commit) — in that case the removal is idempotently considered a success.
+- `status: "not-found"` MUST drive `process.exitCode = 1` and MUST print the vault path it looked for, so the user can verify they typed the right agent and skill name (FR-012). It MUST NOT cause any Git operation, file write, or file delete.
+- `status: "unknown-agent"` MUST be returned BEFORE any runtime context resolution or config loading. This keeps the error path free of side effects even when the user types `vscode` or a typo.
+- `status: "reconcile-error"` is emitted when `GitClient.reconcileWithRemote` fails before the target file is touched. The vault working tree is unchanged; the user must resolve the remote divergence and retry. The CLI log line is the raw reconcile error message — there is NO `Removal staged but not pushed:` prefix because nothing has been staged.
+- `status: "git-error"` is reserved for the narrow window between successful `unlink` of the vault file and a failed `git commit` or `git push`. In this state, the vault working tree has a staged deletion that the user can resolve by re-running `skill remove` or `push`. The error string MUST include the `git` exit code or message to help the user debug. FR-013's pull-side guarantee is unaffected because the vault HEAD has not advanced.
 
 ### State machine (CLI command → RemovalOutcome)
 

--- a/specs/20260411-002222-agent-skills-sync/data-model.md
+++ b/specs/20260411-002222-agent-skills-sync/data-model.md
@@ -1,0 +1,260 @@
+# Data Model: Sync Agents' Skills
+
+**Branch**: `20260411-002222-agent-skills-sync`
+**Date**: 2026-04-11
+**Purpose**: Name the concrete TypeScript types this feature introduces or touches, the invariants each must uphold, and the lifecycle/state transitions that cross the walker → archiver → encryptor → vault → decryptor → apply boundary. "Data model" here is strictly type- and invariant-level — no implementation code.
+
+---
+
+## Entity 1: `Skill` (on-disk, conceptual)
+
+A `Skill` is a filesystem concept, not a TypeScript type. It exists at `<agentSkillsRoot>/<name>/` and is the unit of archival, encryption, and restoration.
+
+### Invariants a directory MUST satisfy to be recognised as a Skill
+
+- `name` MUST NOT begin with `.` (FR-017).
+- The entry at `<agentSkillsRoot>/<name>` MUST resolve via `lstat` as a real directory, not a symbolic link (FR-016 outer tier, R4).
+- The entry `<agentSkillsRoot>/<name>/SKILL.md` MUST exist AND MUST resolve via `lstat` as a real regular file, not a symbolic link (FR-002 + FR-016 sentinel guard).
+- No file or sub-directory path under `<agentSkillsRoot>/<name>/` MAY match any entry in `NEVER_SYNC_PATTERNS` from `src/core/sanitizer.ts` (FR-006). If any does, the Skill exists on disk but is treated as an **abort-the-operation** condition in the push pipeline; see `SkillWalkWarning` below.
+
+### What is archived
+
+The complete directory tree at `<agentSkillsRoot>/<name>/`, **minus** any file or sub-directory whose `lstat` identifies it as a symbolic link (FR-016 inner tier, R2). The archive is a deterministic `tar.gz` produced with `{ gzip: true, cwd: skillDir, portable: true }` so that the same directory tree produces the same bytes for status-hash comparison (R9 caveat).
+
+### Identity and uniqueness
+
+Within one agent's namespace, the `name` (basename of the directory) is the unique key. Across agents, the `(agent, name)` pair is the unique key. The vault reflects this: `<vaultDir>/<agent>/skills/<name>.tar.age` is the only path that can hold the artifact for `(agent, name)`.
+
+---
+
+## Entity 2: `AgentName` (existing, unchanged)
+
+```ts
+type AgentName = "cursor" | "claude" | "codex" | "copilot" | "vscode";
+```
+
+Defined in `src/agents/registry.ts`. This feature does **not** add a new agent. Skills sync applies to `claude`, `cursor`, `codex`, and `copilot` only — `vscode` does not have a skills concept and its adapter remains untouched. The walker helper will assert at call sites (via TypeScript narrowing) that it only receives a skill-capable agent name; at runtime the agents that don't wire it up simply never call `collectSkillArtifacts`.
+
+---
+
+## Entity 3: `SkillArtifact` (new type alias)
+
+```ts
+/**
+ * A SnapshotArtifact specialised for skill directories.
+ * Structurally identical to SnapshotArtifact — this alias exists only to
+ * make call sites self-documenting and to give future work a place to
+ * attach skill-specific metadata without a type refactor.
+ */
+type SkillArtifact = SnapshotArtifact;
+```
+
+### Invariants
+
+- `SkillArtifact.vaultPath` MUST match the regex `^(claude|cursor|codex|copilot)/skills/[^/]+\.tar\.age$`. No nested paths, no alternative extensions (FR-004).
+- `SkillArtifact.sourcePath` MUST be the absolute path to the real (non-symlink) skill directory on disk.
+- `SkillArtifact.plaintext` MUST be the base64 encoding of a deterministic `tar.gz` of the skill tree (minus interior symlinks), consistent with the existing Copilot convention at `src/agents/copilot.ts:95`.
+- `SkillArtifact.warnings` MUST NOT contain a `"never-sync inside skill: "` entry — if the walker detected a never-sync violation, it does NOT emit an artifact for that skill at all (R3), so any `SkillArtifact` reaching Phase 2 of push is clean by construction.
+
+### State transitions
+
+```text
+[candidate dir on disk]
+    ↓  walker passes all five gates (name not ".", lstat real dir, SKILL.md real file, no interior never-sync, tar produced)
+[SkillArtifact with plaintext = base64(tar.gz)]
+    ↓  performPush Phase 2 encrypts
+[encrypted .age text]
+    ↓  git write + commit + push
+[<vaultDir>/<agent>/skills/<name>.tar.age in vault tree]
+    ↓  pull on another machine: git fetch + reconcile
+[encrypted .age text on machine B]
+    ↓  applyXxxVault decrypts → base64-decodes → extractArchive
+[restored real directory at <agentSkillsRoot>/<name>/ on machine B]
+```
+
+No reverse transition exists through this feature. The only way a `SkillArtifact` leaves the vault is via `skill remove` (see Entity 6 below), which operates on the encrypted vault file directly and does not round-trip a `SkillArtifact` instance.
+
+---
+
+## Entity 4: `SkillsWalkerResult` (new type)
+
+```ts
+/**
+ * The shape returned by the shared skills walker. This is intentionally
+ * structurally identical to SnapshotResult so call sites can spread the
+ * walker's output directly into their own SnapshotResult.
+ */
+interface SkillsWalkerResult {
+  artifacts: SkillArtifact[];
+  warnings: string[];
+}
+```
+
+### Invariants
+
+- `artifacts` contains one entry per **Skill on disk that passed all walker gates**. Symlinked roots, dot-prefixed entries, directories without a real `SKILL.md`, and directories whose interior walk found a never-sync match are all **absent** from `artifacts`.
+- `warnings` contains zero or more strings. Walker-produced warnings use the prefix `"never-sync inside skill: "` followed by the absolute path that matched and the pattern it matched. No other prefixes are produced by the walker — dot-skip and symlink-skip are silent (FR-017, R7).
+- `artifacts` and `warnings` are independent: a single push can produce both (for example, three valid skills get archived AND one skill is rejected for a never-sync hit; the push will still abort before encrypting the three valid skills because the push gate escalates any walker warning with the never-sync prefix to fatal — R3).
+
+### Relationship to existing types
+
+`SkillsWalkerResult` is assignment-compatible with `SnapshotResult`. Each agent adapter will spread the walker output into its own `SnapshotResult`:
+
+```ts
+const walker = await collectSkillArtifacts("claude", AgentPaths.claude.skillsDir);
+artifacts.push(...walker.artifacts);
+warnings.push(...walker.warnings);
+```
+
+No new top-level registry entry is required.
+
+---
+
+## Entity 5: `SkillWalkWarning` (convention, not a type)
+
+A **convention**, not a TypeScript nominal type: any string in `SnapshotResult.warnings` that starts with `"never-sync inside skill: "` is a `SkillWalkWarning`. The push gate at `src/commands/push.ts:80-98` currently matches the prefix `"Redacted literal secret"` to escalate a snapshot warning to a fatal push error. This feature adds a second prefix match:
+
+```ts
+if (w.startsWith("Redacted literal secret") || w.startsWith("never-sync inside skill: ")) {
+  secretErrors.push(`[${agent.name}] ${w}`);
+}
+```
+
+(Pseudocode — actual patch lives in Phase 2 tasks.)
+
+### Invariants
+
+- Once a `SkillWalkWarning` lands in `SnapshotResult.warnings`, the corresponding push MUST NOT write any `.age` file for any agent, not just the offending one. This is already how the existing secret gate behaves — the whole push is aborted on any match.
+- The warning text MUST name the offending absolute path so the user can `rm` or `git-ignore` the file. Principle I's security-first stance is that ambiguous abort messages are worse than no abort.
+- The warning text MUST NOT name the pattern that matched, to avoid exposing a map of "paths AgentSync deliberately avoids" to logs that might be shipped to third-party observability.
+
+---
+
+## Entity 6: `RemovalOutcome` (new type for `skill remove`)
+
+```ts
+/**
+ * Result shape for the `skill remove <agent> <name>` command.
+ * Modelled as a tagged union so the CLI layer can decide exit code +
+ * output format without re-parsing a message string.
+ */
+type RemovalOutcome =
+  | { kind: "removed"; agent: AgentName; name: string; vaultPath: string; commitSha: string }
+  | { kind: "not-found"; agent: AgentName; name: string; vaultPath: string }
+  | { kind: "git-error"; agent: AgentName; name: string; vaultPath: string; error: string };
+```
+
+### Invariants
+
+- `kind: "removed"` MUST only be emitted after the commit has landed AND the push has succeeded (or the user passed `--dry-run`, which is the only case where `commitSha` may be the empty string — see contracts/skill-remove-cli.md for whether `--dry-run` is in scope).
+- `kind: "not-found"` MUST drive `process.exitCode = 1` and MUST print the vault path it looked for, so the user can verify they typed the right agent and skill name (FR-012).
+- `kind: "not-found"` MUST NOT cause any Git operation, file write, or file delete. The vault state is unchanged on this outcome.
+- `kind: "git-error"` is reserved for the narrow window between successful `unlink` of the vault file and a failed `git push`. In this state, the vault working tree has a staged deletion that the user can resolve by re-running `skill remove` or `push`. The error string MUST include the `git` exit code or message to help the user debug. FR-013's pull-side guarantee is unaffected because the vault HEAD has not advanced.
+
+### State machine (CLI command → RemovalOutcome)
+
+```text
+  [invoke: skill remove <agent> <name>]
+              │
+              ▼
+   [resolve vaultDir + path]
+              │
+              ▼
+   [agent name valid?] ── no ──▶ kind: not-found (or hard error — TBD in contract)
+              │
+              yes
+              ▼
+   [<vaultDir>/<agent>/skills/<name>.tar.age exists?]
+              │
+     no ──────┴───── yes
+      │               │
+      ▼               ▼
+  kind: not-found   [reconcile with remote]
+                        │
+                        ▼
+                   [unlink file]
+                        │
+                        ▼
+                   [commit]
+                        │
+                        ▼
+                   [push to remote]
+                        │
+             success ──┴── error
+                │            │
+                ▼            ▼
+        kind: removed   kind: git-error
+```
+
+No pull-side state transition exists for `RemovalOutcome`. Other machines discover the removal implicitly on their next `pull`, and their local filesystem is not modified (FR-013).
+
+---
+
+## Entity 7: `AgentPaths` (existing type, extended)
+
+```ts
+// src/config/paths.ts — extended shape (conceptual; keys added, not changed)
+export const AgentPaths = {
+  claude: {
+    claudeMd: string;
+    settingsJson: string;
+    commandsDir: string;
+    agentsDir: string;
+    mcpJson: string;
+    credentials: string;
+    skillsDir: string;          // NEW — ~/.claude/skills/
+  },
+  cursor: {
+    mcpGlobal: string;
+    commandsDir: string;
+    settingsJson: string;
+    skillsDir: string;          // NEW — ~/.cursor/skills/ (FR-010)
+  },
+  codex: {
+    root: string;
+    agentsMd: string;
+    configToml: string;
+    rulesDir: string;
+    authJson: string;
+    skillsDir: string;          // NEW — join(CODEX_HOME, "skills")
+  },
+  copilot: {
+    // ... existing including skillsDir
+  },
+  vscode: {
+    // ... no skillsDir; intentionally omitted
+  },
+};
+```
+
+### Invariants
+
+- Every newly added `skillsDir` is an absolute path. `HOME` and `CODEX_HOME` are resolved at module-load time, same as the existing entries.
+- No conditional / platform-branched values on the new entries — skills roots are POSIX-shaped under `$HOME` on all three target platforms.
+- The `vscode` entry **MUST NOT** grow a `skillsDir`; adding one would imply this feature covers VS Code, which it does not.
+
+---
+
+## Cross-cutting invariant: vault namespace isolation
+
+For every `(agent, name)` pair, **exactly one** path in the vault is valid:
+
+```text
+<vaultDir>/<agent>/skills/<name>.tar.age
+```
+
+Where `<agent> ∈ {claude, cursor, codex, copilot}`. This is enforced implicitly by the walker (which hard-codes its own agent into the output path) and explicitly by `skill remove` (which builds the path from the same template).
+
+No code in this feature may write to, read from, or delete files at any other path under `<vaultDir>/<agent>/skills/`. In particular: no `metadata.json`, no `manifest.toml`, no `.tombstone` files. FR-013's pull-side guarantee depends on the vault containing ONLY encrypted skill artifacts and nothing else, because `applyXxxVault` filters to `.age` files and would silently ignore (or worse, crash on) any other shape.
+
+---
+
+## Types this feature **does not** introduce
+
+Explicitly non-goals, listed here so a reviewer can tell at a glance what was deliberately left out:
+
+- No new `Manifest` type listing skills. The vault's ground truth is its directory listing.
+- No new `Tombstone` type marking a previously-synced skill as deleted. FR-013 forbids it.
+- No per-skill `Metadata` type with author, version, tags, etc. Skills are opaque tarballs.
+- No new `NeverSyncPattern` type. `NEVER_SYNC_PATTERNS` in `src/core/sanitizer.ts` stays the single source of truth for excluded paths.
+- No new `AgentName` variant. VS Code does not grow skill support.

--- a/specs/20260411-002222-agent-skills-sync/data-model.md
+++ b/specs/20260411-002222-agent-skills-sync/data-model.md
@@ -93,7 +93,7 @@ interface SkillsWalkerResult {
 ### Invariants
 
 - `artifacts` contains one entry per **Skill on disk that passed all walker gates**. Symlinked roots, dot-prefixed entries, directories without a real `SKILL.md`, and directories whose interior walk found a never-sync match are all **absent** from `artifacts`.
-- `warnings` contains zero or more strings. Walker-produced warnings use the prefix `"never-sync inside skill: "` followed by the absolute path that matched and the pattern it matched. No other prefixes are produced by the walker — dot-skip and symlink-skip are silent (FR-017, R7).
+- `warnings` contains zero or more strings. Walker-produced warnings use the prefix `"never-sync inside skill: "` followed by the absolute path that matched. No other prefixes are produced by the walker — dot-skip and symlink-skip are silent (FR-017, R7).
 - `artifacts` and `warnings` are independent: a single push can produce both (for example, three valid skills get archived AND one skill is rejected for a never-sync hit; the push will still abort before encrypting the three valid skills because the push gate escalates any walker warning with the never-sync prefix to fatal — R3).
 
 ### Relationship to existing types

--- a/specs/20260411-002222-agent-skills-sync/plan.md
+++ b/specs/20260411-002222-agent-skills-sync/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Sync Agents' Skills
+
+**Branch**: `20260411-002222-agent-skills-sync` | **Date**: 2026-04-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/20260411-002222-agent-skills-sync/spec.md`
+
+## Summary
+
+Extend AgentSync so that user-created skill directories for Claude, Cursor, and Codex round-trip through the encrypted vault the same way Copilot skills already do, plus harden the existing Copilot pipeline with the same rules. User-created means: top-level entry under `<agent>/skills/` is a **real** directory (not a symlink into a vendored pool), its name does **not** start with `.`, and it contains a **real** (not symlinked) `SKILL.md` sentinel. The feature also introduces a deliberate, per-skill vault-removal action so users can take a single skill out of the vault without deleting their local copy, plus a strict "pull never deletes a local skill" guarantee on the other side.
+
+The technical approach reuses every existing primitive: `tar` for archiving, `age` for encryption, `SnapshotArtifact` for the push pipeline, and the registry-driven agent iteration in `commands/push.ts` and `commands/pull.ts`. The only new cross-cutting piece is a shared skills-walker helper that encodes FR-002 / FR-006 / FR-016 / FR-017 in one place, so Claude, Cursor, Codex, and Copilot all apply identical rules. The new CLI verb is the one surface that is genuinely new: `agentsync skill remove <agent> <name>`, with a non-zero "not found" exit path.
+
+## Technical Context
+
+**Language/Version**: TypeScript 6.x, strict mode (`"strict": true`), Bun ≥ 1.3.9 runtime
+**Primary Dependencies**: `citty` (CLI), `@clack/prompts` (output), `tar` v7 (archive), `age-encryption` (X25519 encryption), `simple-git` (vault Git ops), `zod` (schema validation), `picocolors` (terminal colours)
+**Storage**: Local filesystem only. Skill sources at `~/.claude/skills/`, `~/.cursor/skills/`, `~/.codex/skills/`, `~/.copilot/skills/`. Encrypted destinations at `<vaultDir>/<agent>/skills/<name>.tar.age`, wired through `AgentPaths` in `src/config/paths.ts`
+**Testing**: `bun test`. New tests live in `src/agents/__tests__/`, `src/core/__tests__/`, and `src/commands/__tests__/` following the existing `*.test.ts` convention next to the code under test
+**Target Platform**: macOS, Linux, Windows (inherits AgentSync's cross-platform constraints; skill walker uses `lstat` which is supported on all three)
+**Project Type**: single-project CLI + background daemon (Bun)
+**Performance Goals**: No new targets. Skills are tar'd synchronously inside the existing push pipeline. A skills root with ≤ 100 real skills of ≤ 10 MB each should complete the walk and archive phase in well under the existing push timeout. No streaming or chunking changes are in scope
+**Constraints**: Must inherit AgentSync's existing security guarantees unchanged — nothing in this feature bypasses `NEVER_SYNC_PATTERNS`, nothing writes plaintext to disk outside atomic writes, and nothing follows symlinks into vendored pools. Partial-archive behavior for real skills containing symlink helpers is a documented, explicit tradeoff (spec edge case)
+**Scale/Scope**: Four agents (Claude, Cursor, Codex, Copilot — Copilot is a retrofit), one new CLI verb (`skill remove`), one shared walker helper, ~10–15 new tests, four doc updates (`command-reference.md`, `architecture.md`, `troubleshooting.md`, `README.md`) including two new Mermaid diagrams
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate | Verdict | Notes |
+| --------- | ---- | ------- | ----- |
+| I. Security-First Credential Handling | Every new code path MUST encrypt before leaving the machine; never-sync patterns MUST block before encryption; no new recipient types | **Pass** | FR-006 explicitly requires never-sync to run before the tar is encrypted. The walker will pre-scan interior files against `shouldNeverSync` and emit a warning the existing push gate (`push.ts:80-98`) catches and escalates to a fatal error, matching how `"Redacted literal secret"` warnings are handled today. No new recipients, no new keys, no new crypto library |
+| II. Test Coverage (NON-NEGOTIABLE) | Runtime-source feature — automated tests required for success + ≥1 error path; ≥70% coverage on new modules; security-critical files stay ≥90% | **Pass** | Test plan (Phase 1 quickstart) enumerates 11 test targets covering: happy-path round-trip per agent (success), symlinked-root skip, dot-entry skip, interior symlink omission, SKILL.md-is-symlink sentinel rejection, never-sync inside skill abort (security error path), explicit vault removal success, vault removal not-found error path. The walker helper is a new module requiring its own unit tests. `sanitizer.ts` and `encryptor.ts` are unchanged, so their ≥90% floor is unaffected |
+| III. Cross-Platform Daemon Reliability | No new daemon code unless justified; any new path lookup MUST go through `src/config/paths.ts` | **Pass** | No daemon changes. Three new entries (`claude.skillsDir`, `cursor.skillsDir`, `codex.skillsDir`) are added to `AgentPaths` in `src/config/paths.ts`. `lstat` behavior on Windows: symlinks are represented as reparse points and `lstat` correctly identifies them via `isSymbolicLink()` on Bun / Node's Windows port, so the rule is platform-consistent |
+| IV. Code Quality with Biome | `bunx biome ci .` passes with zero errors; no `any`; Zod at trust boundaries | **Pass** | New files typed end-to-end. No new trust boundaries cross this feature (the skill walker consumes local filesystem paths, which are not Zod-validated anywhere else in the codebase today). `useConst` and `noUnusedVariables` enforced. No new imports that Biome can't organise |
+| V. Documentation Standards | JSDoc on all new exported symbols; Mermaid diagram where a workflow is materially clearer visually; docs land in the same commit as code | **Pass** | All new exports from the walker helper and the `skill remove` command will have `@param`, `@returns`, `@throws` JSDoc. FR-015 requires two Mermaid diagrams in `docs/architecture.md`: (1) the sync flow for the extended skills path, (2) the vault-removal flow. Both will follow the project's GitHub-compatible Mermaid rules (inline `:::className`, single `subgraph`, `<br/>` for line breaks, no parentheses in node labels, WCAG-AA class definitions) |
+
+**Documentation-only exemption**: **Not applicable**. This feature adds runtime source, CLI surface, and changes observable behavior for `push`, `pull`, and a new `skill remove` verb. The automated-test requirement is fully in force.
+
+**Diagram validation impact**: Two Mermaid diagrams land in `docs/architecture.md`. Both will be validated by the standard `bun run check` plus the project's existing Mermaid review process before merge.
+
+**Net verdict**: All gates pass. **No entries in the Complexity Tracking table.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/20260411-002222-agent-skills-sync/
+├── plan.md                      # This file
+├── research.md                  # Phase 0 output — decisions on walker shape, tar filter, CLI verb placement, never-sync composition
+├── data-model.md                # Phase 1 output — Skill, SkillArtifact, SkillsWalkerResult, RemovalOutcome
+├── quickstart.md                # Phase 1 output — manual cross-machine walkthrough the spec requires
+├── contracts/
+│   ├── vault-paths.md           # Per-agent vault namespace layout + file naming
+│   ├── skill-remove-cli.md      # CLI signature, exit codes, output format for `agentsync skill remove`
+│   └── walker-interface.md      # Input + output shape of the shared skills walker
+└── checklists/
+    └── requirements.md          # Already present — quality checklist from /speckit.specify
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── agents/
+│   ├── _utils.ts                # EXTEND: export SkillsWalkerResult type and helper (or add new skills-walker.ts — see research.md)
+│   ├── claude.ts                # EXTEND: snapshotClaude now also walks AgentPaths.claude.skillsDir; export applyClaudeSkill; extend applyClaudeVault to decrypt claude/skills/*.tar.age
+│   ├── cursor.ts                # EXTEND: snapshotCursor now walks AgentPaths.cursor.skillsDir (the canonical path locked by FR-010); mirror applyCursorSkill + applyCursorVault extension
+│   ├── codex.ts                 # EXTEND: snapshotCodex walks AgentPaths.codex.skillsDir; applyCodexSkill + applyCodexVault extension
+│   ├── copilot.ts               # RETROFIT: existing skill walker switched to the shared helper so it inherits FR-016 (symlink) and FR-017 (dot-skip) rules
+│   ├── registry.ts              # No change — registry iterates existing AgentDefinition entries; new skill logic lives inside each agent's snapshot/apply
+│   └── __tests__/
+│       ├── claude.test.ts       # EXTEND: skill snapshot + apply tests; symlink/dot-skip/interior-symlink/SKILL.md-symlink edge cases; never-sync inside skill error path
+│       ├── cursor.test.ts       # EXTEND: same surface; include the "skills-cursor is never touched" assertion from US3 scenario 3
+│       ├── codex.test.ts        # EXTEND: same surface; include a `.system/` top-level dot-skip assertion
+│       └── copilot.test.ts      # EXTEND: regression tests for the retrofit — symlink and dot-skip behavior after the walker swap
+├── commands/
+│   ├── push.ts                  # EXTEND: Phase-1 gate now also catches walker-emitted "never-sync inside skill" warnings and escalates to fatal, mirroring the existing secret-literal path (push.ts:80-98)
+│   ├── pull.ts                  # No code change — already iterates agent.apply(); new skill restores come "for free" via the extended applyXxxVault functions
+│   ├── status.ts                # No code change — already iterates snapshot artifacts + collects vault .age files recursively (status.ts:22-42 and status.ts:136-154), so new tar.age entries surface automatically
+│   ├── doctor.ts                # EXTEND: add readability checks for each new skillsDir
+│   ├── skill.ts                 # NEW: citty subcommand group exposing `skill remove` (and room for future verbs)
+│   └── __tests__/
+│       ├── skill.test.ts        # NEW: success path, not-found error path, leave-local-alone assertion
+│       ├── push.test.ts         # EXTEND or ADD: never-sync inside skill aborts with fatal and writes zero .age files
+│       └── integration.test.ts  # EXTEND: cross-machine skills round-trip (tmp vault + two mock homes)
+├── config/
+│   ├── paths.ts                 # EXTEND: add skillsDir to claude, cursor, codex entries
+│   └── __tests__/
+│       └── paths.test.ts        # EXTEND: assertion for the three new entries on mac / linux branches
+├── core/
+│   ├── tar.ts                   # EXTEND: archiveDirectory gains an opt-in `skipSymlinks` flag that installs a sync `filter` rejecting symlink entries (using lstatSync on the entry path)
+│   ├── sanitizer.ts             # No change to NEVER_SYNC_PATTERNS or exports (the walker composes shouldNeverSync at the interior-walk step)
+│   └── __tests__/
+│       └── tar.test.ts          # EXTEND: symlink-skip filter behavior; real file preservation inside a symlinked-root walk
+└── cli.ts                       # EXTEND: register the new `skill` subcommand group on the root citty command
+
+docs/
+├── architecture.md              # EXTEND: module map entry for the skills walker; two new Mermaid diagrams (sync flow + vault-removal flow)
+├── command-reference.md         # EXTEND: push/pull/status/doctor entries mention the new skill coverage; new section documenting `skill remove`
+├── troubleshooting.md           # EXTEND: 6 new entries as enumerated in the spec's Documentation Impact section
+└── README.md                    # EXTEND: "What a vault means here" block names claude/cursor/codex/copilot skills namespaces; new one-line safety note about removal being explicit
+```
+
+**Structure Decision**: Single-project layout. The feature fits cleanly into the existing `src/agents/`, `src/commands/`, `src/config/`, `src/core/` split. No new top-level directory is needed. The shared skills walker can live either as an additional export from `src/agents/_utils.ts` (same layer as `SnapshotArtifact`) or as its own `src/core/skills-walker.ts` module — Phase 0 research resolves which.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations. This table is intentionally left empty.

--- a/specs/20260411-002222-agent-skills-sync/plan.md
+++ b/specs/20260411-002222-agent-skills-sync/plan.md
@@ -108,3 +108,97 @@ docs/
 > **Fill ONLY if Constitution Check has violations that must be justified**
 
 No violations. This table is intentionally left empty.
+
+## Phase 8 — PR #26 Review Fixes (2026-04-11)
+
+This phase lands **after** the original feature PR (commit `47c6773`) and addresses 8 unresolved CodeRabbit review threads plus 3 missed issues identified during review validation. It ships as a single fix-up commit on the same branch (`20260411-002222-agent-skills-sync`) — no new spec, no new branch. Reasoning: every item is a localized bug fix or doc drift, none of them change the feature's surface area, and splitting them into per-item commits would make the review history noisier than the fix itself.
+
+Grouping is **by severity** so a reader can stop at the High tier and still be confident the merge-blocking issues are addressed. The Needs-Clarification item is deliberately NOT a code change — it is a design question that belongs in the PR thread.
+
+### Re-check of Constitution gates for this phase
+
+| Principle | Impact of fixes | Verdict |
+| --------- | --------------- | ------- |
+| I. Security-First Credential Handling | **New validation layer added** for vault-derived skill names (see High tier below). This tightens the existing surface; it does not weaken any gate. `NEVER_SYNC_PATTERNS` and `encryptString` are not touched | **Pass — strengthened** |
+| II. Test Coverage (NON-NEGOTIABLE) | Adds ≥ 4 new adversarial-filename tests (one per agent) + tightens 2 existing walker assertions. Coverage on `claude.ts` / `codex.ts` / `cursor.ts` / `copilot.ts` stays ≥ 70%; security-critical files unchanged | **Pass** |
+| III. Cross-Platform Daemon Reliability | No daemon changes. `doctor.ts` fix is a `stat()` add — same syscall shape as the rest of `doctor` | **Pass** |
+| IV. Code Quality with Biome | The new `validateSkillName` helper is a ~10-line pure function with no `any`, no new deps | **Pass** |
+| V. Documentation Standards | 4 doc-only fixes (command-reference, walker-interface, data-model, README-untouched). All keep the existing JSDoc / Mermaid standards | **Pass** |
+
+**Net verdict**: No new complexity entries. The security validator is new code but it narrows an existing attack surface, it does not create a new one.
+
+### High (merge-blocking) — 1 fix covering 4 files
+
+**H1. Validate vault-derived skill names before filesystem writes** — addresses CodeRabbit comment on `src/agents/codex.ts:148-153` + missed-issue expansion to the 3 sibling agents.
+
+- **Bug**: `applyXxxSkill` functions in `claude.ts`, `codex.ts`, `cursor.ts`, `copilot.ts` all derive `skillName` from a vault filename via `basename(name, ".tar.age")` and pass it directly to `join(skillsRoot, skillName)`. A vault file literally named `...tar.age` yields `skillName === ".."` → `join(skillsRoot, "..")` = parent of skillsRoot. `mkdir({recursive: true})` is a no-op (parent exists) and `extractArchive` then writes tar entries into the agent's config root (e.g. `~/.codex/AGENTS.md`). The existing tar-slip filter in `src/core/tar.ts:92-98` defends against traversing entry paths but does **not** sanitize the `cwd` argument — so a compromised vault can overwrite the user's real agent config.
+- **Root cause**: No validation at the trust boundary between `readdir` results (attacker-controlled-ish in a compromised vault) and filesystem writes.
+- **Fix**: Add a new `validateSkillName(name)` helper in `src/agents/skills-walker.ts` (same module that already owns the walker gates, so skill-name policy lives in one place). Call it from all 4 `applyXxxSkill` functions. Also add a resolved-path `startsWith(skillsRoot + sep)` boundary check so a future bug in `validateSkillName` can't escape the root.
+- **Files**:
+  - `src/agents/skills-walker.ts` — export new helper (kept narrow so `applyXxxSkill` doesn't pull walker transitive deps)
+  - `src/agents/claude.ts`, `codex.ts`, `cursor.ts`, `copilot.ts` — one call-site each
+- **Tests**: See M6 below for the regression tests that lock this down.
+
+### Medium — 6 fixes
+
+**M1. `docs/command-reference.md:108` — drop the "everywhere" promise** (CodeRabbit comment r3067300721)
+
+The `pull` caveat currently says "The only way to remove a skill **everywhere** is the explicit `skill remove` verb." This directly contradicts the section 60 lines below (lines 169-173) which says the command "never touches any local skill directory on any machine" and that pulls are "extract-only". Rewrite to clarify that `skill remove` removes the vault artifact only; to finish removal on another machine the user must manually `rm -rf` the local directory.
+
+**M2. `docs/command-reference.md:167` — split reconcile vs git-error exit-code rows** (CodeRabbit comment r3067300722)
+
+The exit-code table has one row labeled "Reconcile or git push failed | Removal staged but not pushed: <git error>". Reading `src/commands/skill.ts:184-196` shows these two branches produce **different** messages:
+- `reconcile-error` → `log.error(result.error)` (no "staged" prefix — nothing has been unlinked yet)
+- `git-error` → `log.error("Removal staged but not pushed: ${result.error}")` + retry hint
+
+Split into two rows. The authoritative source is already correct at `specs/.../contracts/skill-remove-cli.md:35-36`; only the user-facing doc drifted.
+
+**M3. `specs/.../contracts/walker-interface.md:37` — narrow `agent` param type** (CodeRabbit comment r3067300724)
+
+Contract documents `agent: AgentName` with a runtime no-op clause for `"vscode"`, but `src/agents/skills-walker.ts:71` actually exports `collectSkillArtifacts(agent: SkillBearingAgent, ...)` which excludes `vscode` at the type level. Update the doc block to match.
+
+**M4. `specs/.../data-model.md:141-145` — rename `kind` → `status` and add missing variants** (CodeRabbit comment r3067300725 + missed-issue expansion)
+
+Spec defines `RemovalOutcome` with a 3-variant `kind` discriminated union (`removed` / `not-found` / `git-error`). Implementation at `src/commands/skill.ts:21-26` uses a 5-variant `status` union (`success` / `unknown-agent` / `not-found` / `reconcile-error` / `git-error`). Rename and add the missing variants. Sibling contract `skill-remove-cli.md` already has all 5 cases — add a cross-reference so the two spec files point at the same source of truth.
+
+**M5. `src/agents/__tests__/skills-walker.test.ts:173,193` — tighten warning-count assertions** (CodeRabbit comment r3067300726)
+
+Rows 11 and 12 of the behavioral matrix each seed exactly one offending file. The tests assert `warnings.length >= 1`, which would still pass if the walker started duplicating warnings. The contract at `walker-interface.md:57-60` promises "exactly one entry in warnings… per offending path". Replace with `toHaveLength(1)`.
+
+**M6. New adversarial-filename regression tests** (missed-issue expansion of H1)
+
+Add one test per agent in `claude.test.ts`, `codex.test.ts`, `cursor.test.ts`, `copilot.test.ts` that seeds a vault dir with files literally named `.tar.age`, `..tar.age`, `...tar.age` and asserts `applyXxxVault` rejects them (throws or skips) and no file is written outside the agent's skills root. This locks down the H1 fix against regression.
+
+### Low — 1 fix
+
+**L1. `src/commands/doctor.ts:42-51` — verify skillsDir is a directory** (CodeRabbit comment r3067300729)
+
+`buildSkillsDirChecks` uses `access(dir, R_OK)` which passes for any readable file, not just directories. A user who `touch`ed `~/.claude/skills` (instead of `mkdir`) would get a green "pass" row even though `snapshotClaude` would return empty. Replace with `stat()` + `isDirectory()` check; treat "exists but not a directory" as warn with a distinct `detail` message.
+
+### Needs Clarification — 1 design decision, 0 code changes
+
+**NC1. `applyXxxSkill` overlay vs replacement semantics** (CodeRabbit comment r3067300728, cursor.ts only but applies to all 4)
+
+Reviewer flagged that extracting a skill tar on top of an existing local directory leaves stale files (files present locally but not in the tar). Proposed fix: `rm -rf` the target before `mkdir`+extract.
+
+**Why this is a design question, not a bug**:
+- The reviewer's fix directly conflicts with FR-011 "additive by default" and the broader spirit of FR-013 "extract-only on pull". If a user has edits to `helper.md` locally that haven't been pushed yet, `rm -rf` + extract would silently destroy them.
+- The current overlay behavior preserves local edits at the cost of drift between vault tar contents and local directory contents when the upstream author deletes a file from a skill.
+- Neither "preserve drift" nor "destroy local edits to get consistency" is unambiguously correct. The spec does not currently decide this case.
+
+**What this phase does**: Leave code unchanged. Post a reply on the CodeRabbit thread explaining the FR-011/FR-013 tension and asking for direction. If a decision lands ("we want full replacement; drift is worse than lost edits"), open a follow-up issue for the change — it is a behavior change to a stable feature and deserves its own commit.
+
+### Implementation order (enforced by task dependencies)
+
+1. **H1 (validator + wiring)** first, because M6 tests depend on it.
+2. **M6 (adversarial tests)** next, to lock down H1 before any other change touches the same files.
+3. **M1–M5 + L1** in any order — they are independent.
+4. **Doc items (M1, M2, M3, M4)** plus **M5 (walker test tightening)** and **L1 (doctor)** land in the same commit as H1+M6.
+5. **NC1** reply happens after the commit, on the PR thread itself. No code change.
+
+### Test strategy for this phase
+
+- `bun run check` must stay green (393 → ≥397 pass, 0 fail, 850+ expect calls).
+- New adversarial-filename tests for M6 must each assert a concrete negative: no file written outside `skillsRoot`, no `mkdir` performed at a traversal target.
+- M5 tightening converts 2 `toBeGreaterThanOrEqual(1)` calls to `toHaveLength(1)` — no new tests, just tightened assertions.
+- `bun run check` after every file-group change, not only at the end, so a regression is bisectable to the edit that caused it.

--- a/specs/20260411-002222-agent-skills-sync/quickstart.md
+++ b/specs/20260411-002222-agent-skills-sync/quickstart.md
@@ -1,0 +1,290 @@
+# Quickstart: Sync Agents' Skills
+
+**Feature**: 20260411-002222-agent-skills-sync
+**Purpose**: The reviewer-runnable manual walkthrough that the spec's Documentation Impact section requires. This is the procedure a reviewer follows on their own machine (or two machines) to validate that the feature behaves as the spec promises. Automated tests cover most of the surface; this walkthrough is the cross-machine round trip the test suite cannot exercise inside CI.
+
+---
+
+## Prerequisites
+
+- Bun ≥ 1.3.9 installed
+- An AgentSync vault you control, with at least one age recipient configured
+- Two machines (call them **A** and **B**) both checked out at the feature branch `20260411-002222-agent-skills-sync`. A single machine with two separate `$HOME` directories also works
+- Both machines have run `bun install` and `bun run check` and seen them pass
+
+---
+
+## 1. Verify the new path entries exist (≈ 30 seconds)
+
+On both machines, run:
+
+```bash
+bun -e 'import("./src/config/paths").then(m => console.log(m.AgentPaths.claude.skillsDir, m.AgentPaths.cursor.skillsDir, m.AgentPaths.codex.skillsDir, m.AgentPaths.copilot.skillsDir))'
+```
+
+**Pass**: Four paths print, ending in `.claude/skills`, `.cursor/skills`, `.codex/skills`, `.copilot/skills`.
+**Fail**: Any field is `undefined` → FR-010 / R6 not in place.
+
+---
+
+## 2. Build a representative skills root on machine A (≈ 2 minutes)
+
+The goal is one tmp skills root for each agent, containing the eight cases the walker must handle: real skill, dot-prefixed dir, dot-prefixed file, symlinked root, real skill with symlinked sentinel, real skill with interior symlink helper, real skill with no `SKILL.md`, and a real skill that triggers a never-sync hit (separate test — see step 5).
+
+Pick one agent (Claude is the easiest because the path is `~/.claude/skills/`) and create the following:
+
+```text
+~/.claude/skills/
+├── alpha/                   # qualifying real skill
+│   ├── SKILL.md
+│   └── notes.md
+├── beta/                    # qualifying real skill with an interior symlink helper
+│   ├── SKILL.md
+│   └── helper.md -> /tmp/some-shared-helper.md     # this file should be omitted from the tar
+├── gamma/                   # disqualified — SKILL.md is itself a symlink
+│   └── SKILL.md -> /tmp/vendored-pool/SKILL.md
+├── delta -> /tmp/vendored-pool/delta               # disqualified — top-level symlinked root
+├── epsilon/                 # disqualified — no SKILL.md sentinel
+│   └── README.md
+├── .system/                 # disqualified — top-level dot-prefixed dir
+│   └── ignored.md
+└── .DS_Store                # disqualified — top-level dot-prefixed file
+```
+
+Make sure `/tmp/vendored-pool/delta/` and `/tmp/some-shared-helper.md` actually exist so the symlinks resolve. The test is "what does AgentSync do?", not "what does the OS do with broken links".
+
+---
+
+## 3. Run `agentsync push` and verify the vault contents (≈ 1 minute)
+
+```bash
+bun run src/cli.ts push
+```
+
+**Expected stdout**: a success line such as `Pushed 2 encrypted artifact(s).` (the `2` covers `alpha` and `beta`; everything else was correctly rejected).
+
+Then inspect the vault directly:
+
+```bash
+ls -la "$AGENTSYNC_VAULT_DIR/claude/skills/"
+```
+
+**Pass**: Exactly two `.tar.age` files: `alpha.tar.age` and `beta.tar.age`.
+**Fail (any of)**:
+
+- A `gamma.tar.age` exists → FR-016 sentinel-symlink rejection broken (R4).
+- A `delta.tar.age` exists → FR-016 outer-tier (root symlink) rejection broken.
+- An `epsilon.tar.age` exists → FR-002 sentinel rule broken.
+- A `.system.tar.age` or `.DS_Store.tar.age` exists → FR-017 dot-skip broken.
+- Any warning printed → FR-017 / FR-016 silence requirement violated (R7).
+
+Now decrypt and inspect `beta.tar.age` to confirm the interior-symlink rule:
+
+```bash
+bun run src/cli.ts pull            # round-trip the artifact through decrypt
+ls -la ~/.claude/skills/beta/
+```
+
+**Pass**: `beta/` contains `SKILL.md`. It does NOT contain `helper.md` (the symlinked helper was correctly omitted).
+**Fail**: `helper.md` is present → FR-016 inner-tier rule broken.
+
+---
+
+## 4. Cross-machine round trip on machine B (≈ 2 minutes)
+
+On machine B, ensure `~/.claude/skills/` is empty:
+
+```bash
+ls ~/.claude/skills/ 2>/dev/null || echo "(empty)"
+```
+
+Then pull:
+
+```bash
+bun run src/cli.ts pull
+```
+
+**Pass**: `~/.claude/skills/alpha/` and `~/.claude/skills/beta/` now exist on machine B. `alpha/notes.md` and `beta/SKILL.md` round-tripped. `beta/helper.md` is absent on B too (proves the interior symlink was never archived in step 3).
+**Fail**: Any qualifying skill missing or any disqualified skill present.
+
+---
+
+## 5. Never-sync inside skill — security abort path (≈ 1 minute)
+
+On machine A, add a never-sync file inside one of the qualifying skills:
+
+```bash
+touch ~/.claude/skills/alpha/credentials.json
+```
+
+(`credentials.json` is not in the literal `NEVER_SYNC_PATTERNS` list — substitute `auth.json`, `.credentials.json`, or any other pattern actually present in `src/core/sanitizer.ts:NEVER_SYNC_PATTERNS`. As of the feature branch the canonical example is `auth.json`.)
+
+Run push:
+
+```bash
+bun run src/cli.ts push
+```
+
+**Pass**: Push exits with non-zero status, prints an error naming the offending absolute path, and the vault `claude/skills/alpha.tar.age` is **unchanged from the previous commit** (i.e., the bad version was never written).
+**Fail**: Push succeeds, or `claude/skills/alpha.tar.age` was overwritten with a new commit, or the error message does not name the offending file.
+
+Clean up:
+
+```bash
+rm ~/.claude/skills/alpha/credentials.json
+```
+
+---
+
+## 6. Default-additive guarantee (FR-011) — local delete is harmless (≈ 1 minute)
+
+On machine A, delete `alpha` locally and push:
+
+```bash
+rm -rf ~/.claude/skills/alpha
+bun run src/cli.ts push
+```
+
+**Pass**: Push exits 0. `Pushed 0 encrypted artifact(s).` or similar. The vault still contains `claude/skills/alpha.tar.age` from the earlier commit. Run `bun run src/cli.ts pull` and watch `~/.claude/skills/alpha/` come back from the vault.
+**Fail**: The vault no longer contains `alpha.tar.age` after the push → FR-011 broken.
+
+---
+
+## 7. Explicit vault removal (FR-012, FR-013) — the safety escape hatch (≈ 2 minutes)
+
+Run the new command:
+
+```bash
+bun run src/cli.ts skill remove claude alpha
+```
+
+**Pass**: Command exits 0 with `Removed claude/alpha from vault (commit <sha7>)`. The file `<vaultDir>/claude/skills/alpha.tar.age` is gone. The local directory `~/.claude/skills/alpha/` on machine A is **still present** (the command does not touch local files).
+**Fail (any of)**:
+
+- The local `~/.claude/skills/alpha/` was deleted → FR-012's "never touches local" guarantee broken.
+- The vault file is still present → command did not actually remove it.
+- Exit code is non-zero on success.
+
+Now go to machine B (which still has `alpha/` locally from step 4) and pull:
+
+```bash
+bun run src/cli.ts pull
+ls ~/.claude/skills/alpha/
+```
+
+**Pass**: `alpha/` is still on machine B. Pull did not delete it (FR-013).
+**Fail**: `alpha/` was deleted from machine B → FR-013 broken.
+
+Try to remove a non-existent skill:
+
+```bash
+bun run src/cli.ts skill remove claude does-not-exist
+echo "exit: $?"
+```
+
+**Pass**: Exit code `1`. Error message names the resolved vault path it looked for. No Git operation occurred.
+**Fail**: Exit code `0`, or an attempted commit was made.
+
+---
+
+## 8. Status command surfaces the new artifacts (FR-007) (≈ 30 seconds)
+
+```bash
+bun run src/cli.ts status
+```
+
+**Pass**: The output table includes one or more rows with `agent: claude` and a `file` column ending in `.claude/skills/<name>` for each currently-synced skill, with status `synced` (or `local-changed` if you've edited a skill since the last push). The format matches the existing Copilot rows.
+**Fail**: No skill rows appear, or skill rows appear but in a different format from Copilot.
+
+---
+
+## 9. Doctor command checks the new directories (FR-008) (≈ 30 seconds)
+
+```bash
+bun run src/cli.ts doctor
+```
+
+**Pass**: The output includes a check row for each new `skillsDir` (Claude, Cursor, Codex). The check passes when the directory is readable, warns when it does not exist.
+**Fail**: No new doctor rows appear at all → FR-008 not implemented.
+
+---
+
+## 10. Repeat steps 2–4 for Cursor and Codex (≈ 5 minutes)
+
+Run steps 2 through 4 again with `~/.cursor/skills/` and `~/.codex/skills/`. The expected behavior is identical, with one additional Cursor-specific check:
+
+After the Cursor push, verify that `<vaultDir>/cursor/skills-cursor/` does NOT exist:
+
+```bash
+ls "$AGENTSYNC_VAULT_DIR/cursor/skills-cursor/" 2>/dev/null && echo "FAIL" || echo "PASS"
+```
+
+**Pass**: The directory does not exist (FR-010 — Cursor skills are scoped to `~/.cursor/skills/` only).
+**Fail**: Anything under `cursor/skills-cursor/` exists in the vault.
+
+For Codex, additionally verify the dot-skip rule applies to your machine's actual `~/.codex/skills/.system/` if it exists:
+
+```bash
+ls "$AGENTSYNC_VAULT_DIR/codex/skills/" | grep -F .system && echo "FAIL" || echo "PASS"
+```
+
+**Pass**: No `.system*` artifact in the vault.
+**Fail**: Any `.system`-named artifact present.
+
+---
+
+## 11. Smoke-test the Copilot retrofit (≈ 2 minutes)
+
+This is the regression check that ensures the walker swap did not change Copilot behavior for non-symlink skills. On machine A:
+
+```bash
+mkdir -p ~/.copilot/skills/zeta
+echo "# zeta" > ~/.copilot/skills/zeta/SKILL.md
+ln -s /tmp/vendored-pool/old-skill ~/.copilot/skills/eta   # symlink — must be skipped now
+bun run src/cli.ts push
+ls "$AGENTSYNC_VAULT_DIR/copilot/skills/"
+```
+
+**Pass**: `zeta.tar.age` exists. `eta.tar.age` does NOT exist.
+**Fail**: `eta.tar.age` exists → Copilot retrofit broken.
+
+---
+
+## Final cleanup
+
+```bash
+rm -rf ~/.claude/skills/{alpha,beta,gamma,delta,epsilon,.system,.DS_Store}
+rm -rf ~/.cursor/skills/{alpha,beta,gamma,delta,epsilon,.system,.DS_Store}
+rm -rf ~/.codex/skills/{alpha,beta,gamma,delta,epsilon,.system,.DS_Store}
+rm -rf ~/.copilot/skills/{zeta,eta}
+rm -rf /tmp/vendored-pool /tmp/some-shared-helper.md
+```
+
+If any test machine still has `~/.claude/skills/` populated with your real skills, do NOT run the cleanup blindly — only remove the fixture names you created in steps 2 / 10 / 11.
+
+---
+
+## What this walkthrough proves
+
+| Spec item | Step that proves it |
+| --------- | ------------------- |
+| FR-001 (push collects skills for all agents) | 3 + 10 |
+| FR-002 (SKILL.md sentinel) | 3 (epsilon disqualification) |
+| FR-003 (atomic single-unit archive) | 4 (alpha and beta restored intact on machine B) |
+| FR-004 (per-agent vault namespace) | 3 + 10 |
+| FR-005 (pull restores to canonical local path) | 4 |
+| FR-006 (never-sync inside skill aborts) | 5 |
+| FR-007 (status surfaces all-agent skills) | 8 |
+| FR-008 (doctor checks new dirs) | 9 |
+| FR-009 (missing dirs are no-ops) | 1 (no errors when running on a fresh box) |
+| FR-010 (Cursor canonical path) | 10 (skills-cursor exclusion) |
+| FR-011 (additive default) | 6 |
+| FR-012 (explicit vault removal) | 7 |
+| FR-013 (pull never deletes local) | 7 (machine B step) |
+| FR-016 (two-tier symlink rule) | 3 (delta + beta interior) + 11 (Copilot retrofit) |
+| FR-017 (top-level dot-skip) | 3 (.system, .DS_Store) + 10 (Codex .system) |
+| SC-001 / SC-002 (round-trip parity) | 4 + 10 |
+| SC-006 / SC-007 (additive + explicit removal) | 6 + 7 |
+| SC-008 / SC-009 / SC-010 (symlink and dot-entry coverage) | 3 + 7 + 10 + 11 |
+
+If every step passes, the feature is ready for `/speckit.tasks` (or, if already at `/speckit.tasks` time, ready for review).

--- a/specs/20260411-002222-agent-skills-sync/research.md
+++ b/specs/20260411-002222-agent-skills-sync/research.md
@@ -1,0 +1,218 @@
+# Research: Sync Agents' Skills
+
+**Branch**: `20260411-002222-agent-skills-sync`
+**Date**: 2026-04-11
+**Purpose**: Resolve every open engineering decision before writing data-model, contracts, and tests. There are no `[NEEDS CLARIFICATION]` markers in the spec (the `/speckit.clarify` session resolved Q1–Q4), so this document instead pins down the *implementation* decisions the plan deliberately deferred: walker placement, tar filter shape, never-sync composition inside the walker, CLI verb placement, and the FR-016 SKILL.md-sentinel `lstat` change.
+
+All decisions below follow the format:
+
+- **Decision** — what we will do
+- **Rationale** — why, grounded in the spec and the existing codebase
+- **Alternatives considered** — what else we evaluated and why we passed
+
+---
+
+## R1. Where does the shared skills walker live?
+
+**Decision**: Create a new module `src/agents/skills-walker.ts` that exports one async function `collectSkillArtifacts(agent: AgentName, skillsDir: string): Promise<SnapshotResult>`. Import it from the four agent adapters (`claude.ts`, `cursor.ts`, `codex.ts`, `copilot.ts`). Keep `src/agents/_utils.ts` focused on the canonical `SnapshotArtifact` / `SnapshotResult` types and the `readIfExists` / `atomicWrite` / `collect` helpers — do not bloat it.
+
+**Rationale**:
+
+- The walker encodes four distinct rules (FR-002 sentinel, FR-006 never-sync-inside-skill, FR-016 two-tier symlink, FR-017 top-level dot-skip) that together are too big to inline into four agent adapters without copy-paste drift. The spec specifically worries about drift (SC-008 / SC-009 / SC-010 all assume uniform behavior across agents).
+- `_utils.ts` already has a single responsibility: shared snapshot types and tiny file helpers. Adding a 100-line walker there muddies that boundary.
+- Co-locating the walker under `src/agents/` (rather than `src/core/`) signals that it's an agent-adapter concern and not a reusable crypto/tar primitive. `src/core/` is reserved for things like `encryptor.ts`, `sanitizer.ts`, `tar.ts`, `git.ts` — cross-cutting primitives. The walker is specifically about agent skill directories.
+
+**Alternatives considered**:
+
+- **Put it in `src/agents/_utils.ts`**: rejected — `_utils.ts` is intentionally small and type-only-plus-tiny-helpers; adding the walker there couples unrelated concerns and makes tree-shaking noisier.
+- **Put it in `src/core/skills-walker.ts`**: rejected — `src/core/` modules are consumed by multiple layers (commands, daemon, agents). The walker is only ever called from agent adapters, so placing it there invents a boundary that doesn't exist.
+- **Inline the rules into each agent**: rejected — four agents means four places to update when a new rule lands; SC-008/009/010 explicitly require identical behavior across agents, which is exactly what a shared helper guarantees cheaply.
+
+---
+
+## R2. How does the walker archive a skill without following symlinks?
+
+**Decision**: Extend `src/core/tar.ts::archiveDirectory` with an optional `skipSymlinks: boolean` parameter (defaulting to `false` so current callers are unchanged). When `true`, install a synchronous `filter` callback on the `tar.create` call that uses `lstatSync` on the absolute resolved path and returns `false` when `stat.isSymbolicLink()` is true. The walker always passes `skipSymlinks: true`.
+
+**Rationale**:
+
+- `tar` v7's `create()` accepts a `filter: (path: string, stat: Stats) => boolean` callback. The `stat` argument provided by tar is from `lstat` internally, so a direct `stat.isSymbolicLink()` check is sufficient — we don't need a second syscall per entry in the common case.
+- Having a single option on `archiveDirectory` keeps the API surface tight. The alternative — walking the directory ourselves and feeding tar an explicit file list — would duplicate tar's own directory walk and is slower for large skills.
+- The default stays `false` because the existing `archiveDirectory` callers (Copilot agents under `copilot/agents/<name>.tar.age`, per `copilot.ts:104-120`) are about *vendor agent directories*, not skills, and they do not currently need the symlink rule. Keeping the default preserves their behavior bit-for-bit.
+- The Copilot *skills* retrofit (plan.md structure section) will switch to the new shared walker and therefore inherit `skipSymlinks: true` automatically, so Copilot skills gain FR-016 compliance without touching `archiveDirectory`'s default.
+
+**Alternatives considered**:
+
+- **Hardcode `skipSymlinks: true` in `archiveDirectory`**: rejected — the Copilot agents use-case and any future non-skill caller would silently lose the ability to archive symlink entries. Not a safe retrofit.
+- **Pre-walk the directory with `readdir + lstat` and pass an explicit file list to `tar.create`**: rejected — reimplements tar's own walk, doubles the syscall budget on large skills, and adds a second place where the "is it a symlink?" check can diverge from the walker's outer check.
+- **Use tar's `follow: false`**: not an option — `tar` v7's `follow` flag controls whether symlinks are *dereferenced* when reading file contents, not whether they're skipped. With `follow: false` (the default) symlinks are archived as symlink entries, which is exactly what FR-016 forbids.
+
+---
+
+## R3. How does the walker enforce FR-006 (never-sync inside a skill)?
+
+**Decision**: Before calling `archiveDirectory`, the walker performs its own interior `readdir` + `lstat` walk over the (real) skill directory. For every **file** encountered, it runs `shouldNeverSync(absPath)` from `src/core/sanitizer.ts`. On any match, the walker does NOT throw — instead, it records a warning with a dedicated prefix (`never-sync inside skill: `) on the would-be `SnapshotArtifact.warnings` array. The walker still emits the artifact *without* that skill's tar (so `artifacts` does not grow) and appends the warning to the top-level `SnapshotResult.warnings`. The push pipeline's Phase-1 gate (`src/commands/push.ts:80-98`) then matches the new prefix the same way it currently matches `"Redacted literal secret"` and escalates to a fatal error.
+
+**Rationale**:
+
+- The existing push pipeline has exactly one place that decides "this operation must not complete": the secret-literal gate in `performPush` at `push.ts:80-98`. Reusing that gate for never-sync-inside-skill keeps abort logic in one place.
+- Returning a warning (rather than throwing) lets the walker continue collecting other real skills so the eventual error message can list *every* offending path in one push, instead of aborting on the first one. Users fixing never-sync violations generally prefer a complete list.
+- Using the `shouldNeverSync` glob engine unchanged means `NEVER_SYNC_PATTERNS` remains the single source of truth per Principle I of the constitution. No new never-sync logic is introduced.
+- Skipping the tar emission for the offending skill (as opposed to including it and relying on the gate to catch it) is a belt-and-braces defense: even if someone removes the gate later, no never-sync content ever reaches `archiveDirectory` or `encryptString`.
+
+**Alternatives considered**:
+
+- **Throw from the walker on never-sync hit**: rejected — loses the "list every offender" UX, and `snapshotClaude` / `snapshotCursor` / `snapshotCodex` are not currently expected to throw; introducing a new throwing contract is a larger blast radius than needed.
+- **Let `archiveDirectory` use a tar filter that rejects never-sync paths**: rejected — moves the rule into `tar.ts` which is a low-level primitive; Principle I wants never-sync decisions made at the sanitization boundary, not inside archival.
+- **Add a new global gate inside `performPush` that walks interior skill contents again**: rejected — does the work twice. The walker already has the directory listing open.
+
+---
+
+## R4. How does the walker enforce FR-016's SKILL.md-is-symlink edge case?
+
+**Decision**: The walker uses `lstat` (not `stat`) when checking the `SKILL.md` sentinel. A symlink named `SKILL.md` fails the sentinel check, so the skill is skipped silently — identical to "no sentinel present". This plugs the back door where a vendored skill could otherwise masquerade as user-created by being a real directory whose only skill marker is a symlink into the shared pool.
+
+**Rationale**:
+
+- `stat` follows symlinks and would report "yes, the symlinked `SKILL.md` is a regular file", passing the sentinel check. `lstat` does not follow the link, so `stat.isFile()` is `false` for a symlink entry — failing the sentinel check is automatic.
+- The spec edge case "Real skill directory whose SKILL.md sentinel itself is a symlink" explicitly requires skipping, and ties the requirement to FR-016's vendored-pool avoidance intent. No special-case code needed — it falls out naturally if the walker uses `lstat` consistently.
+- This fixes a latent issue in the current Copilot implementation at `copilot.ts:12-20` where `fileExists` uses `stat` and `copilot.ts:86-89` checks `skillDirStat?.isDirectory()` from `stat` — a symlink to a directory would pass both. The retrofit in the plan swaps to the new walker and eliminates this silently.
+
+**Alternatives considered**:
+
+- **Keep `stat` and add a second explicit `lstat` call to assert it's not a symlink**: rejected — two syscalls where one suffices, and leaves the "is symlink" check as a bolt-on rather than the natural consequence of using `lstat` throughout.
+- **Add a runtime guard that rejects when the resolved target is outside the skills root**: rejected — doable but much more code, and doesn't catch the case of a symlink to another path inside the same skills root.
+
+---
+
+## R5. Where does the `skill remove` CLI verb live?
+
+**Decision**: Create `src/commands/skill.ts` that exports a citty *command group* named `skillCommand` with `remove` as a subcommand (`agentsync skill remove <agent> <name>`). Register the group on the root CLI in `src/cli.ts` alongside `init`, `push`, `pull`, `status`, `doctor`, `daemon`, `key`. Leave room in the group for future verbs (`list`, `info`) without committing to them now — the command file starts with exactly one subcommand.
+
+**Rationale**:
+
+- All existing command modules are single-file per top-level verb (`init.ts`, `push.ts`, `pull.ts`, `status.ts`, `doctor.ts`, `daemon.ts`, `key.ts`, `migrate.ts`). A command group (one file with sub-verbs) is a small new pattern but is cleaner than creating `skill-remove.ts` at the top level, because FR-012's action is genuinely "a verb on skills", not a peer of `push`.
+- citty supports command groups via `subCommands: { remove: removeSubCommand }` on a parent `defineCommand` call. The root CLI already uses `subCommands` (see `cli.ts`) so the integration is trivial.
+- Putting the group in its own file keeps the CLI surface discoverable: `agentsync skill --help` will list all skill verbs, matching the "one-place-to-look" UX of the rest of the CLI.
+
+**Alternatives considered**:
+
+- **Top-level `agentsync skill-remove <agent> <name>`**: rejected — the dash verb is inconsistent with the rest of the CLI and closes the door on adding `skill list` / `skill info` later without a second name-break.
+- **Merge it into `push` as `push --remove <agent>:<name>`**: rejected — violates FR-012's explicit requirement that removal be "distinct from `push`". The whole safety argument of Q2 is that you cannot remove a skill while running a push.
+- **Put it under `key` or `doctor`**: rejected — those verbs are about keys and diagnostics, not content lifecycle. Wrong semantic home.
+
+---
+
+## R6. How are new `skillsDir` entries added to `AgentPaths`?
+
+**Decision**: Extend `src/config/paths.ts` by adding a `skillsDir` field to each of the `claude`, `cursor`, `codex` entries. The values are `join(HOME, ".claude", "skills")`, `join(HOME, ".cursor", "skills")`, and `join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "skills")`. The Copilot entry already has `skillsDir` and stays as is. No platform branching is required — skills roots are POSIX-shaped under the user's home on all three platforms.
+
+**Rationale**:
+
+- Constitution Principle III requires path lookups to go through `paths.ts`. These are the only places the walker will read.
+- The Codex entry must honor `CODEX_HOME` the same way the existing `agentsMd`, `configToml`, `rulesDir` entries do (`paths.ts:30-36`) — consistency with the existing Codex paths avoids a second source of truth for "where is Codex's home?".
+- Cursor's canonical path is locked to `~/.cursor/skills/` by FR-010 of the spec, so the mirror directory `~/.cursor/skills-cursor/` intentionally is not in `paths.ts`. If a future feature wants it, it gets its own path.
+
+**Alternatives considered**:
+
+- **Computed via a helper like `resolveSkillsDir(agent)`**: rejected — one-line `join` calls in a const object are the project's established pattern; indirection through a helper would be the only function of its kind here.
+
+---
+
+## R7. How does the walker mark an "already-symlinked root" skill in the walker result?
+
+**Decision**: Symlinked roots are skipped **silently** — they do not appear in `artifacts`, they do not appear in `warnings`, and they produce no log output. Same for dot-prefixed entries (FR-017). The only thing that reaches `SnapshotResult.warnings` from the walker is a genuine failure condition: never-sync match inside a real skill (R3).
+
+**Rationale**:
+
+- The spec is explicit: FR-016 says "no artifact is written for it, and its link target is never followed or archived" and does not ask for a warning. FR-017 says "silent: no warning, no log, no error". Emitting even a `warn` would violate the letter of the spec.
+- A quiet skip also matches the existing Copilot sentinel-skip behavior at `copilot.ts:89` — "not a valid skill directory" silently continues.
+- Noise in the push output would train users to ignore warnings, which is the opposite of what the secret-literal and never-sync gates need to work.
+
+**Alternatives considered**:
+
+- **Emit an `info`-level log listing every skipped entry and its reason**: rejected — explicitly forbidden by FR-017's "silently". Can be added later as a `--verbose` flag if users actually ask for it.
+- **Return skipped-entry counts in `SnapshotResult`**: rejected — the `SnapshotResult` type is shared across all agents and growing it for one feature's diagnostic is scope creep. Tests can observe skip behavior by asserting `artifacts.length` directly.
+
+---
+
+## R8. How does `skill remove` locate, delete, and propagate?
+
+**Decision**: `skill remove <agent> <name>` resolves the target as `<vaultDir>/<agent>/skills/<name>.tar.age` (using the same path convention as `snapshotCopilot` produces today and the new agents will produce). It:
+
+1. Resolves `runtime.vaultDir` via the existing `resolveRuntimeContext()` helper (same as every other command).
+2. Validates `<agent>` is a known `AgentName` (hard-coded list: `claude`, `cursor`, `codex`, `copilot`), exiting with a clear error if not.
+3. Checks the target file exists with `stat` / `access`. If not, prints `Skill '<name>' not found in vault for agent '<agent>'` and exits with `process.exitCode = 1`. No Git operation, no commit, no push.
+4. On exists: runs `reconcileWithRemote` (same pattern as `performPush`), deletes the file with `unlink`, commits with message `skill remove(<agent>): <name>`, and pushes via `simple-git`.
+5. On any Git failure: leaves the vault file deleted (the commit did not land) and prints the Git error. Running the command again will reconcile and succeed.
+6. Never touches any local path. `AgentPaths.<agent>.skillsDir` is NOT read by `skill remove` at all.
+
+**Rationale**:
+
+- FR-012 demands: one agent + one name, non-zero on not-found, no local files touched. All four are covered by this flow.
+- FR-013 demands: other machines' `pull` must not delete the local skill. This is satisfied implicitly — `applyXxxVault` only iterates `.age` files present in the vault; a file that has been deleted from the vault simply isn't iterated, so `applyXxxSkill` is never called for it, so nothing on the local machine changes. No new pull-side code is required.
+- Reusing `resolveRuntimeContext` and the existing `simple-git` `reconcileWithRemote` pattern keeps the new command's error surface identical to `push` and avoids bespoke Git handling that Principle III forbids.
+
+**Alternatives considered**:
+
+- **Have `skill remove` also overwrite the vault file with a tombstone that `pull` then uses to delete locally**: rejected — directly violates FR-013 (pull must not delete local). Also adds a new vault artifact format.
+- **Have `skill remove` refuse to run if the vault has uncommitted changes**: rejected — not required by the spec; the `reconcileWithRemote` fast-forward-only rule already covers the interesting safety properties.
+- **Have `skill remove` accept `--all` or glob patterns**: rejected — FR-012 explicitly restricts the command to exactly one skill at a time, precisely to avoid the "bad habit → data loss" pattern flagged in the spec's insights.
+
+---
+
+## R9. How does status surface the new skill artifacts without code changes?
+
+**Decision**: No change to `src/commands/status.ts`. The existing implementation at `status.ts:22-42` (`collectAgeFiles`) recursively walks the vault directory and picks up every `.age` file, and at `status.ts:136-154` it compares them against the per-agent snapshot artifact list. When the agent adapters start emitting `claude/skills/<name>.tar.age`-style entries from `snapshot()`, the status pipeline compares them as ordinary artifacts (by plaintext SHA-256) and reports `synced`, `local-changed`, or `vault-only` automatically.
+
+**Rationale**:
+
+- Reuses code that has already been tested and shipped for Copilot skills. Any bug here is a bug in the existing status command, not a new bug introduced by this feature.
+- FR-007 requires drift to surface "in the same place and format that Copilot skill drift is already surfaced today" — the best way to guarantee that is to not add a skill-specific code path to status at all.
+- The `SnapshotArtifact.plaintext` for a skill is the base64-encoded tar (same pattern as `copilot.ts:95`). Base64 of a stable tar is deterministic for the same directory tree, so the SHA-256 comparison is valid.
+
+**Alternatives considered**:
+
+- **Add a skill-specific status row format that lists interior files**: rejected — adds a new display mode inconsistent with the rest of status, and violates "same place and format" from FR-007.
+
+**Caveat to verify in Phase 2 (tasks)**: tar determinism. `tar.create` with `portable: true` already strips variable metadata like UID/GID, but mtime of individual files can still vary depending on when the directory was last touched. The existing Copilot skill hashing has not been observed to flap in practice, so the assumption is that the plaintext hash is stable enough for status — but the task breakdown must include a test that archives the same directory twice and asserts byte equality of the resulting base64. If that test fails, the fix is to add `mtime: new Date(0)` or similar to the `tar.create` options, which is a localized change in `src/core/tar.ts`.
+
+---
+
+## R10. Documentation diagrams — what do the two Mermaid diagrams show?
+
+**Decision**: Both diagrams live in `docs/architecture.md` under a new "Skills sync flow" section.
+
+- **Diagram 1 (sync flow)**: Shows the path from `~/.<agent>/skills/<name>/` through the walker's gates (root-symlink skip, dot-skip, SKILL.md sentinel, never-sync interior check, interior-symlink skip) into `archiveDirectory` → `encryptString` → vault `<agent>/skills/<name>.tar.age` → pull → decrypt → `extractArchive` → restored local skill directory. Nodes styled with three classes: `keep` (green, survives all gates), `skip` (amber, filtered by walker), `fail` (red, never-sync abort path).
+- **Diagram 2 (vault-removal flow)**: Shows the `skill remove` path from user invocation through reconcile → `unlink` → commit → push → remote vault. Then a parallel branch showing machine B running `pull` and leaving its local skill directory untouched. Three-node class palette: `action` (user request), `vault` (vault-side effect), `local` (local-side no-op).
+
+Both diagrams follow the project's GitHub-compatible Mermaid rules from `~/.claude/CLAUDE.md`: `classDef` pairs with WCAG 2 AA contrast, `<br/>` for line breaks (not `\n`), no parentheses in node labels, inline `:::className` syntax, single `subgraph` per diagram, descriptive node IDs of ≥ 3 characters.
+
+**Rationale**:
+
+- FR-015 requires two diagrams covering these two flows specifically. Splitting them into two instead of one megadiagram keeps each diagram below the "review without reverse-engineering" ceiling Principle V enforces.
+- The skill walker has five gates between the user's directory and the vault file. Prose alone obscures the order — a diagram makes the order testable against the code.
+
+**Alternatives considered**:
+
+- **One combined diagram for both flows**: rejected — too many nodes, breaks Mermaid readability on GitHub, violates Principle V's "small enough to review" rule.
+- **No diagrams, prose only**: rejected — FR-015 explicitly requires them, and Principle V's criterion ("visual explanation materially improves comprehension") is met here.
+
+---
+
+## Summary of resolved decisions
+
+| # | Decision | Module(s) touched |
+| - | -------- | ----------------- |
+| R1 | New shared walker at `src/agents/skills-walker.ts` | `src/agents/skills-walker.ts` (new), agent adapters |
+| R2 | `archiveDirectory` gains opt-in `skipSymlinks` flag via tar `filter` callback | `src/core/tar.ts` |
+| R3 | Walker emits `never-sync inside skill:` warnings; push gate escalates to fatal | `src/agents/skills-walker.ts`, `src/commands/push.ts` |
+| R4 | Walker uses `lstat` throughout; symlinked `SKILL.md` fails sentinel naturally | `src/agents/skills-walker.ts` |
+| R5 | New `skill` command group in `src/commands/skill.ts` with `remove` subverb | `src/commands/skill.ts` (new), `src/cli.ts` |
+| R6 | `paths.ts` gains `skillsDir` fields on claude/cursor/codex entries | `src/config/paths.ts` |
+| R7 | Symlinked roots and dot-entries skipped silently — no warnings, no logs | `src/agents/skills-walker.ts` |
+| R8 | `skill remove` resolves `<vaultDir>/<agent>/skills/<name>.tar.age`, git-deletes, never touches local | `src/commands/skill.ts` |
+| R9 | Status command unchanged; existing `collectAgeFiles` picks up new artifacts automatically | (verify with a tar-determinism regression test) |
+| R10 | Two Mermaid diagrams in `docs/architecture.md` (sync flow + vault-removal flow) | `docs/architecture.md` |
+
+No `NEEDS CLARIFICATION` remains. Ready for Phase 1.

--- a/specs/20260411-002222-agent-skills-sync/spec.md
+++ b/specs/20260411-002222-agent-skills-sync/spec.md
@@ -1,0 +1,178 @@
+# Feature Specification: Sync Agents' Skills
+
+**Feature Branch**: `20260411-002222-agent-skills-sync`
+**Created**: 2026-04-11
+**Status**: Draft
+**Input**: User description: "sync agents' skills"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Claude skills follow me to a new laptop (Priority: P1)
+
+A developer has built up a library of Claude skills under `~/.claude/skills/` on their primary workstation. They buy a new laptop, install AgentSync, run `pull` against their existing vault, and every skill they authored appears in the same place on the new machine — ready to use in the next Claude session.
+
+**Why this priority**: Claude is the primary daily driver for most AgentSync users, and skills are the richest per-user configuration Claude exposes. Today this is the biggest silent gap in AgentSync's "one encrypted source of truth" promise: CLAUDE.md, commands, and sub-agents sync, but a user's skills vanish on a fresh machine. Closing this gap is the single highest-value piece of the feature.
+
+**Independent Test**: Populate `~/.claude/skills/my-skill/SKILL.md` on machine A, run `push`, initialize a fresh vault checkout on machine B, run `pull`, and confirm the same skill tree exists at `~/.claude/skills/my-skill/` on machine B with identical contents.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Claude skill directory exists at `~/.claude/skills/<name>/` containing a `SKILL.md` file, **When** the user runs `push`, **Then** an encrypted artifact for that skill appears under `claude/skills/` in the vault and the operation reports one Claude skill included.
+2. **Given** the vault contains a Claude skill artifact the local machine does not have, **When** the user runs `pull`, **Then** the skill directory is restored under `~/.claude/skills/<name>/` with every file from the original snapshot.
+3. **Given** a directory under `~/.claude/skills/` that has no `SKILL.md` sentinel, **When** the user runs `push`, **Then** that directory is skipped with no warning and no artifact is written to the vault.
+4. **Given** a Claude skill was updated on another machine, **When** the user runs `status`, **Then** the drift is surfaced alongside the existing Claude artifacts (CLAUDE.md, commands, sub-agents) instead of being invisible.
+5. **Given** the entry `~/.claude/skills/<name>` is a symlink that points into a shared pool (for example `/srv/.../shared/skills/<name>`), **When** the user runs `push`, **Then** no artifact is written to `claude/skills/` for that name and the symlink target is neither read nor followed.
+6. **Given** a real directory at `~/.claude/skills/<name>` with a valid `SKILL.md` sentinel plus one symlinked helper file inside, **When** the user runs `push` and a second machine runs `pull`, **Then** the skill is restored on the second machine with every real file intact and the symlinked helper omitted.
+
+---
+
+### User Story 2 - Codex skills sync alongside Codex configuration (Priority: P2)
+
+A developer uses Codex as a secondary agent and keeps per-task skills under `~/.codex/skills/`. When they push their AgentSync vault, those skills travel with Codex's `AGENTS.md`, `config.toml`, and rules — they do not have to manually copy directories to reach parity on a second machine.
+
+**Why this priority**: Codex is already a fully supported agent in AgentSync (snapshot, apply, status, and never-sync are wired up), so leaving its skills behind is the same gap as Claude's — only for a smaller user slice. Once the Claude pattern is validated, applying the same shape to Codex is a direct extension with no new domain modelling, which is why it is P2 rather than P1.
+
+**Independent Test**: Place a valid skill under `~/.codex/skills/<name>/SKILL.md` on machine A, push, pull on machine B, and verify the skill directory contents match bit-for-bit.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Codex skill directory with a `SKILL.md` sentinel, **When** the user runs `push`, **Then** an encrypted artifact for that skill is written under `codex/skills/` in the vault.
+2. **Given** the vault contains a Codex skill artifact the local machine lacks, **When** the user runs `pull`, **Then** the skill directory is restored under `~/.codex/skills/<name>/`.
+3. **Given** a Codex skill directory contains a file whose path matches an existing never-sync pattern, **When** the user runs `push`, **Then** the push aborts with the same guidance AgentSync already gives for other never-sync violations, rather than silently bundling the sensitive file into the archive.
+
+---
+
+### User Story 3 - Cursor skills round-trip without hand-copying (Priority: P3)
+
+A developer who uses Cursor relies on a set of skills stored under `~/.cursor/skills/`. After pointing a second machine at the same AgentSync vault, those Cursor skills are present on the second machine after `pull`.
+
+**Why this priority**: Cursor's skills layout is not yet wired up in AgentSync at all (only commands, MCP, and settings are), so this is new agent surface rather than an extension of an existing pattern. It is ranked P3 because Cursor skills are the least common artifact among current AgentSync users, and the feature should ship the higher-certainty Claude and Codex slices first before extending to Cursor.
+
+**Independent Test**: Create `~/.cursor/skills/<name>/SKILL.md` on machine A, run `push` on machine A, run `pull` on machine B, and verify the skill directory is restored at `~/.cursor/skills/<name>/` with identical contents.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Cursor skill directory with a `SKILL.md` sentinel at `~/.cursor/skills/<name>/`, **When** the user runs `push`, **Then** an encrypted artifact is written under `cursor/skills/` in the vault.
+2. **Given** the vault contains a Cursor skill artifact, **When** the user runs `pull`, **Then** the skill directory is restored at `~/.cursor/skills/<name>/`.
+3. **Given** a directory exists at `~/.cursor/skills-cursor/` with skill-like contents, **When** the user runs `push`, **Then** nothing from `skills-cursor/` is snapshotted — this feature intentionally scopes Cursor skills to `~/.cursor/skills/` only.
+
+---
+
+### Edge Cases
+
+- **No skills directory at all**: The agent's home (e.g. `~/.codex/skills/`) does not exist yet. Push must succeed without error and simply skip that agent's skill contribution, matching existing AgentSync behavior for missing optional directories.
+- **Empty skills directory**: The directory exists but contains no entries. Push must succeed and write zero skill artifacts.
+- **Directory without `SKILL.md` sentinel**: A sub-directory under `skills/` does not contain `SKILL.md`. It must be skipped with no artifact and no warning, matching the existing Copilot rule.
+- **Never-sync path match inside a skill directory**: A file path inside a skill matches a hard never-sync pattern. Push must abort before the skill is encrypted so the sensitive file never reaches the vault, matching AgentSync's existing never-sync guarantee.
+- **Vendored skill symlinked at the skills root**: The entry `~/.claude/skills/<name>` (or the Cursor / Codex equivalent) is itself a symlink into a shared pool (for example `/srv/…/shared/skills/<name>`). FR-016 requires that the walker skip this entry entirely — it is neither followed nor archived, and no artifact is written to the vault for that name. On pull, the local machine is not forced to recreate a symlink — only real user-created skills round-trip.
+- **Real skill directory containing a symlinked helper file**: The skill root at `~/.claude/skills/<name>` is a real directory, but a single file inside it (for example `references/shared-template.md`) is a symlink. FR-016 requires the walker to archive the rest of the skill while omitting the symlinked file. Pull on another machine restores the skill without the symlinked helper, and the skill may therefore behave differently on the restored machine if it depended on that helper — this is an accepted tradeoff of the partial-archive rule, documented so users are not surprised.
+- **Real skill directory whose SKILL.md sentinel itself is a symlink**: The skill root is a real directory but `SKILL.md` is a symlink. FR-002's sentinel check MUST be symlink-aware: a symlinked `SKILL.md` does NOT satisfy the sentinel requirement, so the skill is treated as "no sentinel" and skipped with no artifact, matching the vendored-pool avoidance intent of FR-016.
+- **Dot-prefixed entry directly under a skills root**: The agent's skills root contains an entry whose name begins with `.` (for example `~/.codex/skills/.system/`, or a stray `~/.claude/skills/.DS_Store`). FR-017 requires the walker to skip the entry entirely and silently — no artifact, no warning, no sentinel check. This applies whether the entry is a file, a real directory, or a symlink; no further inspection is performed.
+- **Dot-prefixed file nested deep inside a real user skill**: The skill root at `~/.claude/skills/my-skill/` is a real user-created directory that happens to contain a `references/.DS_Store` file deep inside. FR-017 applies only at the top level of the skills root, so this nested dot-file is NOT automatically skipped by FR-017; it is archived along with the rest of the skill unless FR-016 (symlink rule) or the never-sync engine drops it first. The feature does not try to cleanse interior macOS or tool metadata — that is the user's responsibility within their own skill directory.
+- **Locally deleted skill**: A skill that existed in a prior push has been deleted locally. By default `push` is additive and never removes the artifact from the vault, so other machines keep receiving the skill on `pull` until the user explicitly removes it from the vault (FR-012). This means an accidental local `rm -rf` can never silently erase skills across machines.
+- **Explicit vault removal of a skill that other machines still have locally**: A user has explicitly removed a skill from the vault (FR-012). On any other machine whose local skills directory still contains that skill, `pull` MUST leave the local copy in place — removing from the vault does not imply auto-deleting machines that already had the skill.
+- **Explicit vault removal of a skill that is not in the vault**: The user asks to remove a skill that is not currently stored in the vault for the requested agent. The operation MUST exit with a clear "not found" message and a non-zero status, rather than silently succeeding, so the user can notice typos in agent or skill names.
+- **Large skill directory**: A skill directory is unusually large (for example hundreds of megabytes). Behavior should match any other large artifact AgentSync already snapshots — the feature introduces no new size ceiling and no new chunking strategy.
+- **Collision with Copilot's existing `copilot/skills/` path**: The vault already contains `copilot/skills/<name>.tar.age`. The new agent namespaces (`claude/skills/`, `codex/skills/`, `cursor/skills/`) must not interfere with or overwrite the Copilot path.
+- **Apply side, existing local skill with same name**: A skill with the same name already exists on the target machine under the local skills path. The apply path must replace it with the vault version, consistent with how AgentSync already treats other synced artifacts.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The push workflow MUST collect skill directories for each supported agent (Claude, Codex, and Cursor) in addition to the existing Copilot skill collection, so a single `push` run snapshots skills from every agent that has any.
+- **FR-002**: A directory under an agent's skills root MUST be treated as a skill only when it contains a real (non-symlink) `SKILL.md` sentinel file. The push pipeline MUST NOT archive a directory that lacks this sentinel; pull restores whatever the walker previously archived, so the sentinel rule is enforced **once at archival time** and inherited by every subsequent pull. Directories without a real `SKILL.md` therefore never enter the vault and never reach a destination machine through this feature.
+- **FR-003**: Each collected skill MUST be archived as a single unit before encryption, so that the full skill tree (SKILL.md plus any supporting files and sub-directories) is restored atomically on apply.
+- **FR-004**: Encrypted skill artifacts for each agent MUST live under an agent-specific vault namespace (`claude/skills/`, `codex/skills/`, `cursor/skills/`) that is distinct from the existing `copilot/skills/` path, so that two agents can each have a skill named `my-skill` without collision.
+- **FR-005**: The pull workflow MUST restore each encrypted skill artifact to the canonical local skills directory for its agent, creating any missing parent directories, so that a fresh machine gets an identical layout to the source machine.
+- **FR-006**: Any file path inside a candidate skill directory that matches AgentSync's existing never-sync rules MUST cause the push to abort before the skill is encrypted, using the same error surface as other never-sync violations.
+- **FR-007**: The status command MUST surface drift for skills of every supported agent, not only Copilot, so that a user can tell from `status` alone whether their skill tree is in sync.
+- **FR-008**: The doctor command MUST include each newly supported skills directory in its existence and readability checks so that a misconfigured local environment is reported in the same place as other agent paths.
+- **FR-009**: Missing skills directories (for example, `~/.codex/skills/` not existing on a machine that never uses Codex) MUST be treated as "no skills contributed" and MUST NOT cause push, pull, status, or doctor to fail.
+- **FR-010**: The canonical Cursor skills source path that AgentSync snapshots and restores MUST be `~/.cursor/skills/`. Any other plausible Cursor directory (for example `~/.cursor/skills-cursor/`) MUST NOT be read or written by this feature.
+- **FR-011**: The default push workflow MUST be additive with respect to skills. Deleting a skill directory locally and then running `push` MUST NOT remove the corresponding artifact from the vault, so an accidental local `rm -rf` can never silently erase skills across the user's other machines.
+- **FR-012**: Users MUST be able to explicitly remove a named skill artifact from the vault for a named agent, as a deliberate action that is distinct from `push`. The operation MUST target exactly one skill at a time, MUST NOT touch the local skills directory on the machine that initiates it, MUST report "not found" with a non-zero status when the requested skill is not present in the vault for that agent, and MUST leave skill artifacts for other agents and other skill names untouched.
+- **FR-013**: When an explicit vault removal (FR-012) has taken effect and another machine runs `pull`, the pull MUST NOT delete the corresponding local skill directory on that other machine. Pull-side behavior for vault removals is "do not propagate the deletion locally", preserving the safety guarantee that AgentSync never deletes local skill files as a side-effect of someone else's action.
+- **FR-014**: The feature MUST document the new vault namespaces, the `SKILL.md`-sentinel rule, the default-additive push semantics (FR-011), and the explicit vault-removal action (FR-012, FR-013) in the command reference and architecture guide, so a reader of `docs/` can tell what ends up in the vault and how to take things out of it without reading source.
+- **FR-015**: The architecture guide MUST include a Mermaid diagram showing the end-to-end skill flow (local skills directory → sentinel check → tar archive → age encryption → vault namespace → pull → atomic restore) for the newly supported agents, and a second Mermaid diagram showing the vault-removal action (explicit user request → vault namespace entry removed → next pull on another machine leaves the local skill in place), so reviewers can validate both data paths without walking code.
+- **FR-016**: The skill collection walker MUST apply a two-tier symlink rule. First, when iterating the entries directly under an agent's skills root, any entry whose root is a symlink (regardless of where it points) MUST be skipped entirely — no artifact is written for it, and its link target is never followed or archived. Second, when walking a real (non-symlink) skill directory, any individual file or sub-directory inside it that is a symlink MUST be omitted from the archive while the surrounding real content is still archived. The net effect: vendored skills that users have symlinked into their local skills root from a shared pool never reach the vault, and real user-created skills still sync even when they reference a helper file via a symlink — minus that specific link entry.
+- **FR-017**: When iterating the entries directly under an agent's skills root, the walker MUST skip any entry whose name begins with `.` (a leading dot), regardless of whether that entry is a file, a real directory, or a symlink. Skipping is silent: no warning, no log, no error, and no artifact written. This rule is applied at the top level of the skills root only, so a dot-entry nested deep inside a real user skill is not affected by this rule — only the interior-symlink rule from FR-016 applies there. The net effect: vendor-shipped directories like `~/.codex/skills/.system/`, macOS metadata files like `.DS_Store`, tool-managed manifests like `.cursor-managed-skills-manifest.json`, and any stray `.git/` someone version-controls into a skills root are all excluded from the vault without having to be named individually.
+
+### Key Entities *(include if feature involves data)*
+
+- **Skill**: A self-contained, per-agent bundle of instructions and supporting files, identified by its directory name and validated by the presence of a `SKILL.md` sentinel file. Every other file inside the directory is considered part of the skill and must round-trip.
+- **Agent skills root**: The per-agent parent directory under which individual skill directories live (`~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, and the already-wired `~/.copilot/skills/`). This is the only place AgentSync looks for skills for that agent.
+- **Vault skill namespace**: The per-agent path inside the encrypted vault where skill artifacts are written (`claude/skills/`, `codex/skills/`, `cursor/skills/`, alongside the existing `copilot/skills/`). Each namespace is independent so that two agents can host a skill with the same name.
+- **Skill artifact**: One encrypted, archived file in the vault that represents exactly one skill for exactly one agent. Restoring this artifact on another machine recreates the full skill directory for that agent.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After running `push` on machine A and `pull` on machine B against the same vault, every skill that had a `SKILL.md` sentinel on machine A — across Claude, Codex, Cursor, and the already-supported Copilot — is present on machine B with identical file contents and identical directory layout.
+- **SC-002**: A user setting up a new laptop can reach full skill parity with their primary machine by running only `init` and `pull` — with zero manual file copying, zero scp/rsync, and zero editing of any skill file by hand.
+- **SC-003**: Running `status` on a machine whose skills have drifted from the vault surfaces that drift for Claude, Codex, and Cursor skills in the same place and format that Copilot skill drift is already surfaced today.
+- **SC-004**: A `push` that encounters a never-sync file path inside any agent's skill directory aborts before any skill artifact is written to the vault, and the abort message points the user to the offending path. No encrypted skill artifact containing a never-sync file is ever created.
+- **SC-005**: Running `push` or `pull` on a machine that has no skills directory for one or more agents succeeds with exit code 0, contributes zero skill artifacts for those agents, and does not log a warning about the missing directory.
+- **SC-006**: Deleting a skill directory locally and then running `push` leaves the vault artifact for that skill unchanged, and a subsequent `pull` on the same machine restores the deleted skill from the vault — proving the additive-by-default guarantee of FR-011.
+- **SC-007**: After the user explicitly removes a named skill from the vault (FR-012), the next `push` from any machine does not re-introduce it, the next `pull` on any machine that did not have the skill locally does not restore it, and the next `pull` on any machine that still has the skill locally leaves the local copy in place — proving FR-013.
+- **SC-008**: Given a skills root that contains a mix of real user-created skill directories and top-level symlinked entries pointing into a shared pool, `push` produces zero vault artifacts for any symlinked entry and one artifact for each real skill — proving the root-level half of FR-016. Given a real skill whose interior contains a symlinked helper file, the resulting vault artifact unpacks on pull to a directory that contains every real file from the source and zero symlink entries — proving the interior half of FR-016.
+- **SC-009**: After a successful push from a machine whose skills root contains symlinked vendored entries, inspecting the encrypted vault artifacts for that agent reveals no file, path, or content originating from the symlink target tree — confirming that vendored pools are never leaked into the vault even indirectly through tar-follow or path traversal.
+- **SC-010**: Given a skills root that contains any combination of a real user skill, a top-level dot-prefixed directory (for example `.system/`), a top-level dot-prefixed file (for example `.DS_Store`), and a top-level dot-prefixed symlink, `push` produces exactly one vault artifact — the one for the real user skill — and zero artifacts for any dot-prefixed entry, confirming FR-017's top-level dot-skip rule across all three entry kinds.
+
+## Assumptions
+
+- Copilot, Claude, Codex, and Cursor are already supported agents in AgentSync; this feature extends the existing snapshot and apply architecture rather than introducing new agents.
+- The Copilot skills pipeline in `src/agents/copilot.ts` is the reference implementation: its `SKILL.md` sentinel rule, tar-then-encrypt shape, and `<agent>/skills/<name>.tar.age` vault path are the pattern the other agents will follow.
+- Default push for skills is strictly additive (FR-011), and the only way a skill leaves the vault is the explicit vault-removal action introduced in FR-012. There is no implicit "mirror deletes on push" mode anywhere in this feature.
+- Never-sync pattern matching already runs on absolute source paths; applying it to skill directory contents is a matter of walking the directory before archival, not a new matching engine.
+- The existing fast-forward-only reconciliation rule across init, pull, push, key, and daemon already covers the new skill artifacts because they live inside the same vault repository — no new conflict model is needed.
+- The explicit vault-removal action (FR-012) is authoritative only for the vault: it deliberately never touches local skill directories on any machine, including the machine that initiates it, so users can safely remove stale skills from the vault without worrying about losing their local working copy.
+- Symlinked top-level skill entries are assumed to be vendored content sourced from a shared pool outside the user's personal configuration (confirmed on the reference machine: `~/.claude/skills/migrate-jest-to-vitest` and siblings link into `/srv/.../luxgroup/skills/skills/...`). The feature's intent is to sync only skills the user created locally, so FR-016 treats "root entry is a symlink" as "not a user-created skill" and skips it unconditionally.
+- Dot-prefixed top-level entries under a skills root are assumed to be vendor-, tool-, or OS-managed metadata that the user did not hand-author as a skill (confirmed on the reference machine: `~/.codex/skills/.system/` is a Codex-shipped bundle). FR-017 skips them without attempting to distinguish "vendored" from "user-created" by any means beyond the leading-dot naming convention, which is the universal Unix signal for hidden/system content.
+- This feature is not documentation-only under the constitution: it ships runtime source code changes across several agent adapters, so it requires automated tests for both the happy path and at least one error path (the canonical error case is a never-sync violation inside a skill directory; a second required error case is FR-012's "skill not found in vault" branch).
+
+## Clarifications
+
+### Session 2026-04-11
+
+- Q: When should a symlink cause AgentSync to skip a skill? → A: Skip the whole skill when the skill root is itself a symlink; inside a real skill root, omit individual symlink files and sub-directories from the archive but still sync the surrounding real content (Option B — partial archive allowed for real skills). FR-016 encodes the rule; edge cases "Vendored skill symlinked at the skills root", "Real skill directory containing a symlinked helper file", and "Real skill directory whose SKILL.md sentinel itself is a symlink" make the rule testable; SC-008 and SC-009 make it measurable.
+- Q: How should AgentSync handle hidden / dot-prefixed entries directly under an agent's skills root (for example `~/.codex/skills/.system/` or a stray `.DS_Store`)? → A: Skip any entry whose name begins with `.` at the top level of the skills root, silently and without warning, regardless of whether it is a file, a real directory, or a symlink (Option A — unconditional top-level dot-skip). FR-017 encodes the rule; edge cases "Dot-prefixed entry directly under a skills root" and "Dot-prefixed file nested deep inside a real user skill" delimit its scope; SC-010 proves it.
+
+#### Question 1: Cursor canonical skills path — RESOLVED
+
+**Question**: Which Cursor directory is the canonical "Cursor skills" source that AgentSync should snapshot for User Story 3, given the host filesystem shows both `~/.cursor/skills/` and `~/.cursor/skills-cursor/` with different contents?
+
+**Answer**: Option A — `~/.cursor/skills/` only.
+
+**Impact on the spec**:
+
+- User Story 3 is now scoped to exactly `~/.cursor/skills/`; its acceptance scenarios name that path concretely instead of referring to a "canonical path".
+- FR-010 locks in `~/.cursor/skills/` as the only Cursor skills source. `~/.cursor/skills-cursor/` is explicitly not read or written by this feature.
+- User Story 3 has a new acceptance scenario asserting that `~/.cursor/skills-cursor/` content is ignored, so a future reviewer cannot mistake the omission for a bug.
+
+#### Question 2: Deletion semantics for removed skills — RESOLVED
+
+**Question**: When a user deletes a skill locally and then pushes, what should happen on another machine's next pull?
+
+**Answer**: Option A with an explicit escape hatch — default push is strictly additive (a local delete never affects the vault), AND there is a separate, deliberate action the user can take to remove a skill from the vault when they truly want it gone. The removal action is distinct from `push` so that a stray `rm -rf` on any machine can never silently propagate to other machines.
+
+**Impact on the spec**:
+
+- FR-011 locks in strict additive-by-default push for skills.
+- FR-012 introduces the explicit vault-removal action: targets one agent + skill name at a time, leaves local files alone on every machine, and reports "not found" with non-zero status when the requested skill is not in the vault.
+- FR-013 specifies pull-side behavior when an explicit removal has taken effect: other machines that still have the skill locally keep their copy, so no local file is ever deleted as a side-effect of someone else's action.
+- Two new edge cases ("Explicit vault removal of a skill that other machines still have locally", "Explicit vault removal of a skill that is not in the vault") make the removal semantics testable.
+- SC-006 proves additive-by-default (local delete + push + pull restores the skill).
+- SC-007 proves that explicit vault removal propagates "nothing is in the vault anymore" without ever deleting a local file.
+- Assumptions now explicitly state that there is no implicit "mirror deletes on push" mode anywhere in this feature, so planners cannot re-introduce one by accident.
+
+## Documentation Impact
+
+This feature is a runtime source-code change across several agent adapters, so it does not qualify for the documentation-only testing exception. It still carries concrete documentation updates that reviewers must validate:
+
+- **docs/command-reference.md**: Update the `push`, `pull`, `status`, and `doctor` entries so the reader can see that skills now round-trip for Claude, Codex, and Cursor (not only Copilot). Name the new vault namespaces (`claude/skills/`, `codex/skills/`, `cursor/skills/`). Document the new explicit vault-removal action introduced in FR-012, including: that it targets exactly one agent + skill name, that it never touches any local skill directory, and that it exits non-zero with "not found" when the requested skill is not in the vault.
+- **docs/architecture.md**: Update the module map and sync flow sections so skills are no longer a Copilot-only branch. Add the two Mermaid diagrams required by FR-015: (1) the end-to-end sync flow (local skills directory → `SKILL.md` sentinel check → tar archive → age encryption → per-agent vault namespace → pull → atomic restore) and (2) the vault-removal flow (explicit user request → vault namespace entry removed → next pull on another machine leaves the local skill in place). Both diagrams must follow the GitHub-compatible Mermaid rules in the project conventions (inline `:::className` styles, single `subgraph`, `<br/>` instead of `\n`, no parentheses in node labels, high-contrast WCAG AA class definitions).
+- **docs/troubleshooting.md**: Add six new entries: (1) "my skills did not push" → point at the `SKILL.md` sentinel rule and FR-002; (2) "my push aborted because of a never-sync file inside a skill" → point at FR-006 and the existing never-sync guidance; (3) "I deleted a skill locally and it came back after pull" → point at the additive-by-default guarantee in FR-011 and direct the reader to the explicit vault-removal action; (4) "I removed a skill from the vault but it is still on my other laptop" → point at FR-013 (pull never deletes local skill files as a side-effect of someone else's removal); (5) "my vendored / symlinked skill did not sync" → point at FR-016's root-symlink skip rule and explain that this is intentional (only real, user-created skills round-trip); (6) "a helper file inside my skill is missing on the other machine after pull" → point at FR-016's interior-symlink omission rule and the `Real skill directory containing a symlinked helper file` edge case.
+- **Manual walkthrough reviewers must validate** (because automated tests cannot cover the cross-machine round trip): push on machine A with at least one skill per supported agent, pull on machine B with an empty local skills directory for each agent, diff the restored trees against the originals, confirm `status` reports clean afterwards, then exercise the FR-012 removal action and confirm FR-013's "do not delete local" guarantee on machine B. Record this walkthrough in the feature's plan or quickstart artifact.
+- **README.md**: If the "What a vault means here" section still cites only `copilot/skills/<name>.tar.age` as the skill example, extend it to name the new namespaces so the top-of-repo description does not silently lie about coverage. Add a one-line note that AgentSync never silently deletes vault skills: removal is always an explicit user action.

--- a/specs/20260411-002222-agent-skills-sync/tasks.md
+++ b/specs/20260411-002222-agent-skills-sync/tasks.md
@@ -1,0 +1,236 @@
+---
+description: "Task list for the agent-skills-sync feature"
+---
+
+# Tasks: Sync Agents' Skills
+
+**Input**: Design documents from `/specs/20260411-002222-agent-skills-sync/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: This feature ships runtime source code changes across several agent adapters and a new CLI verb. It does **not** qualify for the constitution's documentation-only exception (recorded in plan.md Constitution Check). **Automated tests are required** for both the success path and at least one error or edge-case path of every new module, plus the manual cross-machine walkthrough in `quickstart.md`. TDD ordering is observed: every implementation task is preceded by a failing test task.
+
+**Organization**: Tasks are grouped by user story so each story (Claude P1, Codex P2, Cursor P3) can be implemented, tested, and shipped independently. The `skill remove` verb (FR-012/FR-013) is cross-cutting and lives in its own phase between the user stories and Polish.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Maps to a user story from spec.md (US1, US2, US3). Setup, Foundational, Cross-cutting, and Polish phases have NO story label
+- All file paths are absolute or repo-rooted; LLMs executing a task must not have to guess where to write
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the feature branch is in a buildable state before any code changes land. AgentSync's repo, dependencies, and Bun toolchain are already in place — there is no scaffolding work to do.
+
+- [X] T001 Verify the feature branch baseline by running `bun install` followed by `bun run check` from the repo root and confirming both succeed before any task in Phase 2 begins. Record the resulting commit SHA in the PR description as the "pre-feature green commit" so regressions introduced by later phases are easy to bisect.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the shared infrastructure that every user story and the cross-cutting `skill remove` verb consume: the new `AgentPaths.<agent>.skillsDir` entries, the `archiveDirectory` symlink filter, the shared `skills-walker` module, the push-side never-sync gate extension, the Copilot retrofit (which is the safety regression check that proves the walker honors FR-016/FR-017), and the doctor extension for the new directories.
+
+**⚠️ CRITICAL**: No user story phase (US1/US2/US3) and no cross-cutting `skill remove` work may begin until Phase 2 is complete. The walker is the single source of truth for FR-002/FR-006/FR-016/FR-017, and every story consumes it.
+
+- [X] T002 Extend `src/config/paths.ts` to add `skillsDir` to the `claude`, `cursor`, and `codex` entries. Use `join(HOME, ".claude", "skills")`, `join(HOME, ".cursor", "skills")` (the FR-010 canonical path), and `join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "skills")` respectively. Do NOT add a `skillsDir` to the `vscode` entry (data-model.md cross-cutting invariant). The Copilot entry already has `skillsDir`; leave it untouched.
+- [X] T003 [P] Extend `src/config/__tests__/paths.test.ts` with assertions that `AgentPaths.claude.skillsDir`, `AgentPaths.cursor.skillsDir`, and `AgentPaths.codex.skillsDir` are non-empty strings ending in `/skills` (after the join). Include a regression assertion that `AgentPaths.vscode` does NOT contain a `skillsDir` key, so an accidental future addition fails this test.
+- [X] T004 [P] Extend `src/core/__tests__/tar.test.ts` with three failing tests for `archiveDirectory(dir, { skipSymlinks: true })`. (1) **Symlink filter**: a tmp dir containing one real `SKILL.md`, one symlinked file (`./helper.md` → `/tmp/something`), and one symlinked sub-directory (`./refs` → `/tmp/elsewhere`); extracting the resulting tar to a fresh tmp dir yields exactly `SKILL.md` and no other entries. (2) **Default behavior preserved**: calling `archiveDirectory(dir)` without the flag still archives symlink entries unchanged so existing Copilot agent tarballs are not regressed. (3) **Tar determinism for status hash stability** (closes the research R9 caveat): build a fixture, call `archiveDirectory(dir, { skipSymlinks: true })` twice in the same test, and assert `Buffer.equals(buf1, buf2)`. If this assertion fails on Bun's tar v7, the fix is to pass `mtime: new Date(0)` (or equivalent) to the `tarCreate` options so file mtimes do not leak into the gzip stream — the property is required by SC-003 because the status command's SHA-256 comparison depends on `archiveDirectory` producing identical bytes for the same directory tree.
+- [X] T005 Extend `src/core/tar.ts::archiveDirectory` with an opt-in `options?: { skipSymlinks?: boolean }` parameter. When `options.skipSymlinks === true`, install a synchronous `filter: (path, stat) => !stat.isSymbolicLink()` callback on the `tarCreate` call. The default (`undefined` or `false`) preserves the current behavior bit-for-bit. Update the JSDoc on the function to document the new parameter, including the rationale that the flag is opt-in to keep the existing Copilot agent-tarball callers (`copilot.ts:104-120`) unchanged. Verify T004 now passes.
+- [X] T006 [P] Create `src/agents/__tests__/skills-walker.test.ts` with the 12-row behavioral matrix from `contracts/walker-interface.md`. Each row is an independent fixture under a tmp dir built with `node:fs/promises` and (where needed) `symlink`. Assert on `result.artifacts.length` and the prefix(es) of `result.warnings`. Row 12 (multiple skills, one with a never-sync match) is the most important — it MUST assert that `artifacts.length === 1` (the clean skill is collected) AND that `warnings` contains exactly one `"never-sync inside skill: "` entry (the dirty skill is reported but not archived). All assertions on `warnings` MUST use `expect(...).toStartWith(...)` to lock the prefix without coupling to the absolute path text.
+- [X] T007 Create `src/agents/skills-walker.ts` exporting `collectSkillArtifacts(agent: AgentName, skillsDir: string): Promise<SkillsWalkerResult>`. Implement the five gates in order from `contracts/walker-interface.md`: (1) skip names starting with `.`; (2) skip entries that fail `lstat().isDirectory()` (this rejects both files and symlinks naturally); (3) skip when `<dir>/SKILL.md` is missing or fails `lstat().isFile()`; (4) walk the interior with `readdir` + `lstat`, run `shouldNeverSync` on every file path, and on any match emit a `"never-sync inside skill: <abs-path>"` warning AND skip the artifact for that skill; (5) call `archiveDirectory(skillDir, { skipSymlinks: true })` to produce the tar. Output `vaultPath: \`${agent}/skills/${name}.tar.age\``, `sourcePath: <abs skill dir>`, `plaintext: tarBuffer.toString("base64")`. Add full JSDoc per Constitution Principle V. Verify T006 passes.
+- [X] T008 [P] Extend `src/commands/__tests__/push.test.ts` (create the file if absent under `src/commands/__tests__/`) with a failing test that builds a Claude skills root containing one valid skill plus one skill whose interior contains a file matching a `NEVER_SYNC_PATTERNS` entry (use `auth.json` as the canonical example since it appears literally in `src/core/sanitizer.ts`). Run `performPush({ dryRun: false })` against a tmp vault, then assert: the function returned `{ pushed: 0, fatal: true }`, the `errors` array contains a string starting with `"Push aborted"`, and zero `.age` files exist under `<tmpVault>/claude/skills/`. The test must run with `__setPushAgentsForTesting` to limit the agents iterated.
+- [X] T009 Extend `src/commands/push.ts` Phase-1 gate (the loop at `push.ts:80-98` that currently matches `"Redacted literal secret"`) so it ALSO matches the prefix `"never-sync inside skill: "` and escalates those warnings to `secretErrors`. Update the abort message preamble so the user sees a distinct phrase for never-sync hits versus literal secrets, then the same `secretErrors` list. Verify T008 passes.
+- [X] T010 [P] Extend `src/agents/__tests__/copilot.test.ts` with three new failing tests against the retrofitted walker behavior: (1) a top-level symlinked skill root produces zero artifacts; (2) a top-level `.system/` directory produces zero artifacts; (3) a real skill containing one symlinked helper file inside produces exactly one artifact whose tar contains the real files but not the symlinked helper. Use the same test scaffolding the existing `snapshotCopilot` tests use (they already mutate `testCopilotPaths` under a tmp dir).
+- [X] T011 Retrofit `src/agents/copilot.ts::snapshotCopilot` by replacing the inline skill collection block at `copilot.ts:82-101` with a single `const skillsResult = await collectSkillArtifacts("copilot", AgentPaths.copilot.skillsDir);` call followed by `artifacts.push(...skillsResult.artifacts)` and `warnings.push(...skillsResult.warnings)`. Delete the now-unused `fileExists` helper at `copilot.ts:12-20` (it was a `stat`-based check that the walker no longer needs). Verify T010 passes AND every existing copilot test still passes (this is the no-regression check).
+- [X] T012 [P] Extend `src/commands/__tests__/integration.test.ts` (or create `src/commands/__tests__/doctor.test.ts` if it does not yet exist; check first) with a failing test that runs `doctorCommand`'s logic against a tmp `$HOME` containing a readable `~/.claude/skills/`, a readable `~/.codex/skills/`, and a missing `~/.cursor/skills/`, and asserts the resulting checks list contains one `pass` row per readable skills directory and one `warn` row for the missing one. Each row's `name` MUST be agent-specific (e.g., `"Claude skills directory"`).
+- [X] T013 Extend `src/commands/doctor.ts` with three new check rows immediately after the existing "Claude settings.json" check block: one for each of `AgentPaths.claude.skillsDir`, `AgentPaths.codex.skillsDir`, `AgentPaths.cursor.skillsDir`. Each check uses `access(path, constants.R_OK)` to mirror the existing pattern, returns `pass` when readable, `warn` when missing or unreadable, and includes the absolute path in `detail`. Do NOT add a row for Copilot — it already has its directory wired through other paths and FR-008 is scoped to the *new* dirs. Verify T012 passes. (Anchor by textual marker, not line number — line numbers drift.)
+- [X] T035 [P] Extend `src/commands/__tests__/status.test.ts` with a failing test that closes the **FR-007 automated-coverage gap** flagged by the analysis. Use the **already-retrofitted Copilot skill path** (depends on T011) so this test can land in Phase 2 without waiting for any user story. Setup: build a tmp `$HOME` with one real `~/.copilot/skills/my-skill/SKILL.md` plus a tmp vault containing the matching encrypted `copilot/skills/my-skill.tar.age` artifact (encrypt directly with the existing `encryptString` helper — no need to invoke `performPush`). Run the status command's logic (via the existing test hook pattern in `src/commands/__tests__/status.test.ts`, or factor a testable function out of `statusCommand.run` if no hook exists). Assert: exactly one row has `agent: copilot`, `file` ending in `.copilot/skills/my-skill`, and `status: synced`. Then mutate the local skill on disk (write a different file inside the directory), re-run, and assert the same row now reports `local-changed`. This is the regression net for the research R9 assumption that the existing `collectAgeFiles` walker picks up new artifacts without status-side code changes — and proves FR-007 holds for any agent that produces `<agent>/skills/<name>.tar.age` artifacts.
+- [X] T036 [P] Extend `src/commands/__tests__/push.test.ts` (the same file T008 creates or extends) with a failing test that closes the **FR-011 / SC-006 additive-default automated-coverage gap** flagged by the analysis. Use the Copilot skill path (depends on T011) so this test can land in Phase 2. Setup: build a tmp `$HOME` with one real `~/.copilot/skills/my-skill/SKILL.md`, run `performPush({ dryRun: false })` against a tmp vault, capture the byte content of `<vault>/copilot/skills/my-skill.tar.age` with `readFile`. Then `rm -rf` the local `~/.copilot/skills/my-skill/` directory and run `performPush` again. Assert: (a) the second call returns `pushed: 0` (no new artifacts written for the deleted skill), (b) `<vault>/copilot/skills/my-skill.tar.age` still exists, (c) its byte content is `Buffer.equals` to the captured snapshot. This proves a local delete does NOT mutate the vault — the additive-by-default property of FR-011 / SC-006 — which is the safety guarantee that makes `agentsync skill remove` (Phase 6) the only way a skill leaves the vault.
+
+**Checkpoint**: At the end of Phase 2, the walker is callable from any agent adapter, the tar filter rejects symlinks under the new flag AND produces deterministic bytes for status hashing, the push pipeline aborts on never-sync inside a skill, the Copilot pipeline already honors FR-016/FR-017, status surfaces skill drift for any agent, additive-by-default push is proven by an automated test, and `doctor` reports on the three new directories. Run `bun run check` here as a phase-end gate before moving on.
+
+---
+
+## Phase 3: User Story 1 - Claude skills follow me to a new laptop (Priority: P1) 🎯 MVP
+
+**Goal**: A user-created skill under `~/.claude/skills/<name>/` round-trips through the encrypted vault and lands on a fresh second machine in exactly the same place after `pull`. This is the highest-value slice — the spec ranks it P1 because Claude is the primary daily driver and skills are the richest per-user Claude configuration.
+
+**Independent Test**: Populate `~/.claude/skills/my-skill/SKILL.md` on machine A, run `agentsync push`, run `agentsync pull` on a second machine with an empty `~/.claude/skills/`, and confirm the same skill tree exists at `~/.claude/skills/my-skill/` on machine B with identical contents — quickstart.md steps 2–4.
+
+### Tests for User Story 1 (REQUIRED — runtime feature, no documentation-only exception) ⚠️
+
+- [X] T014 [US1] Extend `src/agents/__tests__/claude.test.ts` with failing tests for the Claude skill round-trip. Include: (1) a happy-path snapshot test that creates `~/.claude/skills/my-skill/SKILL.md` plus `~/.claude/skills/my-skill/notes.md` and asserts `snapshotClaude()` returns one artifact with `vaultPath === "claude/skills/my-skill.tar.age"` and a non-empty base64 `plaintext`; (2) an apply-side test that calls `applyClaudeSkill("my-skill", base64Tar)` (where `base64Tar` is built with `archiveDirectory(srcDir)`) and asserts the files appear under the test's tmp `claude.skillsDir`; (3) an `applyClaudeVault` integration test that sets up an encrypted `claude/skills/my-skill.tar.age` artifact in a tmp vault and asserts `applyClaudeVault(vaultDir, key, false)` restores the directory; (4) a dry-run test (`applyClaudeVault(..., true)`) that asserts the local skills dir was NOT touched; (5) **FR-009 missing-dir case**: point `testClaudePaths.skillsDir` at a tmp path that does NOT exist on disk, run `snapshotClaude()`, and assert it returns an empty skill-artifact list, zero warnings, and does NOT throw — the missing dir is a no-op, not an error; (6) **FR-016 interior-symlink at the agent layer (defense-in-depth for the walker)**: build a real `~/.claude/skills/my-skill/` containing `SKILL.md` plus a `helper.md` symlink, run `snapshotClaude()`, decrypt the resulting base64 tar to a tmp dir, and assert `helper.md` is absent while every real file is present. Use the existing claude.test.ts mutation pattern (`testClaudePaths.skillsDir = join(tmpDir, "skills")`); add `skillsDir` to the `MutableClaudePaths` type if it's not already there.
+- [X] T015 [P] [US1] Extend `src/agents/__tests__/claude.test.ts` with three Claude-specific edge-case tests built on the walker contract: (a) a top-level symlinked skill root must NOT appear in `snapshotClaude()`'s artifacts; (b) a `~/.claude/skills/.system/` directory must NOT appear; (c) a real skill whose `SKILL.md` is itself a symlink must NOT appear. These mirror the walker tests at the agent layer to prove the wiring is correct.
+
+### Implementation for User Story 1
+
+- [X] T016 [US1] Extend `src/agents/claude.ts::snapshotClaude` (currently at `claude.ts:18-95`) to call `collectSkillArtifacts("claude", AgentPaths.claude.skillsDir)` after the existing `agentsDir` block, then spread `walker.artifacts` into `artifacts` and `walker.warnings` into `warnings`. Add a new exported `applyClaudeSkill(skillName: string, base64Tar: string): Promise<void>` helper that mirrors `applyCopilotSkill` (`copilot.ts:148-153`): `mkdir(targetDir, { recursive: true })`, then `extractArchive(Buffer.from(base64Tar, "base64"), targetDir)`. Extend `applyClaudeVault` to call `readAgeFiles(join(claudeDir, "skills"))` after the existing `agents/` block, decrypt each `.tar.age`, base64-decode, and call `applyClaudeSkill(basename(name, ".tar.age"), decrypted)` — except in `dryRun` mode, where it logs `[dry-run] [claude] would extract skill: <name>` and continues. Add JSDoc per Principle V. Verify T014 and T015 pass.
+
+**Checkpoint**: At this point, User Story 1 is fully functional. Quickstart steps 2–4 (the Claude round trip) can be executed manually and pass. The MVP slice ships here. Run `bun run check`.
+
+---
+
+## Phase 4: User Story 2 - Codex skills sync alongside Codex configuration (Priority: P2)
+
+**Goal**: A user-created skill under `~/.codex/skills/<name>/` round-trips through the vault the same way Claude skills do, with the additional concrete check that the host's `~/.codex/skills/.system/` vendor bundle is silently skipped (FR-017).
+
+**Independent Test**: Place a valid skill under `~/.codex/skills/<name>/SKILL.md`, push, pull on a second machine, verify identical contents — quickstart.md step 10 (Codex variant).
+
+### Tests for User Story 2 (REQUIRED) ⚠️
+
+- [X] T017 [US2] Extend `src/agents/__tests__/codex.test.ts` with the six Codex skill tests mirroring T014: (1) happy-path snapshot, (2) `applyCodexSkill` direct test, (3) `applyCodexVault` round-trip, (4) dry-run no-op, (5) **FR-009 missing-dir case** — point `testCodexPaths.skillsDir` at a non-existent path, run `snapshotCodex()`, assert empty skill-artifact list with zero warnings and no throw, (6) **FR-016 interior-symlink defense-in-depth** — real skill dir with one symlinked helper file inside, snapshot, decrypt the tar, assert the symlinked entry is absent while real files are present. Use `testCodexPaths.skillsDir` (extend the mutable paths type if needed). Vault path expected: `codex/skills/my-skill.tar.age`.
+- [X] T018 [P] [US2] Extend `src/agents/__tests__/codex.test.ts` with the FR-017 dot-skip assertion specific to Codex: build a tmp `~/.codex/skills/` containing one real skill `my-skill/SKILL.md` AND one `.system/` directory containing its own `SKILL.md`, run `snapshotCodex()`, and assert the result has exactly one artifact whose `vaultPath === "codex/skills/my-skill.tar.age"` — the `.system` directory is NOT archived. This is the regression test that catches a future change accidentally bypassing the dot-skip rule.
+
+### Implementation for User Story 2
+
+- [X] T019 [US2] Extend `src/agents/codex.ts::snapshotCodex` (currently at `codex.ts:43-88`) to call `collectSkillArtifacts("codex", AgentPaths.codex.skillsDir)` after the existing `rulesDir` block, then spread the walker output. Add `applyCodexSkill(skillName, base64Tar)` mirroring `applyCopilotSkill`. Extend `applyCodexVault` (currently at `codex.ts:147-186`) to read `.tar.age` files from `join(codexDir, "skills")` and apply each via `applyCodexSkill`, with the dry-run log line `[dry-run] [codex] would extract skill: <name>`. Add JSDoc. Verify T017 and T018 pass.
+
+**Checkpoint**: User Story 2 is fully functional. Quickstart step 10 (Codex variant) passes manually. Run `bun run check`.
+
+---
+
+## Phase 5: User Story 3 - Cursor skills round-trip without hand-copying (Priority: P3)
+
+**Goal**: Skills under `~/.cursor/skills/` (the FR-010 canonical path) round-trip through the vault, AND the bundled `~/.cursor/skills-cursor/` directory is provably never touched. The negative assertion is the load-bearing piece of this story because it's the only direct evidence that FR-010 is honored.
+
+**Independent Test**: Create `~/.cursor/skills/<name>/SKILL.md`, push, pull on a second machine, verify the skill is restored at `~/.cursor/skills/<name>/`. Separately, create a `~/.cursor/skills-cursor/<name>/SKILL.md` and verify push does NOT produce any artifact under `cursor/skills-cursor/` in the vault — quickstart.md step 10 (Cursor variant).
+
+### Tests for User Story 3 (REQUIRED) ⚠️
+
+- [X] T020 [US3] Extend `src/agents/__tests__/cursor.test.ts` with the six Cursor skill tests mirroring T014: (1) happy-path snapshot, (2) `applyCursorSkill` direct test, (3) `applyCursorVault` round-trip, (4) dry-run no-op, (5) **FR-009 missing-dir case** — point `testCursorPaths.skillsDir` at a non-existent path, run `snapshotCursor()`, assert empty skill-artifact list with zero warnings and no throw, (6) **FR-016 interior-symlink defense-in-depth** — real skill dir with one symlinked helper file inside, snapshot, decrypt the tar, assert the symlinked entry is absent while real files are present. Use `testCursorPaths.skillsDir` (extend the mutable paths type if needed). Vault path expected: `cursor/skills/my-skill.tar.age`.
+- [X] T021 [P] [US3] Extend `src/agents/__tests__/cursor.test.ts` with the FR-010 negative assertion: in the same tmp dir containing a real `~/.cursor/skills/my-skill/SKILL.md`, also create a `~/.cursor/skills-cursor/other-skill/SKILL.md`. Run `snapshotCursor()`, assert that the result contains exactly one skill artifact (`cursor/skills/my-skill.tar.age`) AND that `result.artifacts.every(a => !a.vaultPath.includes("skills-cursor"))` is true. This is User Story 3 acceptance scenario 3 from the spec.
+
+### Implementation for User Story 3
+
+- [X] T022 [US3] Extend `src/agents/cursor.ts::snapshotCursor` (currently at `cursor.ts:36-92`) to call `collectSkillArtifacts("cursor", AgentPaths.cursor.skillsDir)` after the existing `commandsDir` block, then spread the walker output. Add `applyCursorSkill(skillName, base64Tar)` mirroring `applyCopilotSkill`. Extend `applyCursorVault` (currently at `cursor.ts:140-182`) to read `.tar.age` files from `join(cursorDir, "skills")` and apply each via `applyCursorSkill`, with dry-run log line `[dry-run] [cursor] would extract skill: <name>`. Make sure the existing `applyCursorVault` "Unrecognised vault file" warn line at `cursor.ts:165` does NOT trigger on the new `skills/` sub-directory — the existing code only inspects top-level files and walks `commands/` separately, so adding a parallel `skills/` walk should not collide, but verify by re-running existing cursor tests. Add JSDoc. Verify T020 and T021 pass.
+
+**Checkpoint**: All three numbered user stories are functional and independently testable. Run `bun run check`.
+
+---
+
+## Phase 6: Cross-cutting — Explicit Vault Removal (FR-012, FR-013)
+
+**Purpose**: Implement the new `agentsync skill remove <agent> <name>` CLI verb introduced by Q2's clarification. This verb is intentionally NOT a numbered user story because it cuts across all four agents and depends on the foundational walker output already being in the vault — but it can ship independently of US1/US2/US3 (it can even operate on Copilot skills today). The pull-side no-delete guarantee (FR-013) is enforced *implicitly* by the existing `applyXxxVault` functions, so this phase's only test of FR-013 is an integration test that proves the implicit guarantee holds end-to-end.
+
+- [X] T023 Create `src/commands/__tests__/skill.test.ts` with failing tests for every row in `contracts/skill-remove-cli.md`: (1) **success path** — set up a tmp vault with `<vaultDir>/claude/skills/my-skill.tar.age` present, run the command's underlying function (not the citty wrapper) with `("claude", "my-skill")`, assert the file is gone, the working tree has a commit, and `process.exitCode` is unset (or 0); (2) **not-found path** — run with `("claude", "does-not-exist")` and assert `process.exitCode === 1`, the vault file count is unchanged, and the error log contains the resolved path; (3) **unknown-agent path** — run with `("vscode", "anything")` and assert `process.exitCode === 1` and the error mentions the supported agent list; (4) **leave-local-alone assertion** — before invoking the success path, write a sentinel file at `<tmpHome>/.claude/skills/my-skill/SKILL.md` and after invocation assert the sentinel still exists. Use `__setPushAgentsForTesting`-style hooks if the new command exposes one; otherwise factor the command body into a testable async function.
+- [X] T024 Create `src/commands/skill.ts` exporting `skillCommand`, a citty `defineCommand` that sets `subCommands: { remove: removeSubCommand }` where `removeSubCommand` accepts two positional args `<agent>` and `<name>`. The implementation MUST: validate `<agent>` is one of `claude | cursor | codex | copilot` (reject `vscode` and any other value with exit 1); resolve `<vaultDir>` via `resolveRuntimeContext()`; build the path `join(runtime.vaultDir, agent, "skills", \`${name}.tar.age\`)`; check existence with `stat`; on missing, print the not-found error format from `contracts/skill-remove-cli.md` and set `process.exitCode = 1`; on present, call `git.reconcileWithRemote(...)` (same options used by `performPush`), `unlink` the file, `git.commit({ message: \`skill remove(${agent}): ${name}\` })`, then `git.push("origin", config.remote.branch)`. NEVER touch any path under `AgentPaths.<agent>.skillsDir`. Add JSDoc per Principle V. Verify T023 passes.
+- [X] T025 Register the new `skillCommand` group on the root CLI in `src/cli.ts` alongside `init`, `push`, `pull`, `status`, `doctor`, `daemon`, `key`. Confirm `agentsync skill --help` and `agentsync skill remove --help` both render after the change. This task is NOT parallelizable with T024 — it edits the same shared registration block in `cli.ts` that other tasks may also touch.
+- [X] T026 [P] Extend `src/commands/__tests__/integration.test.ts` with TWO end-to-end tests. **First test (FR-013 pull-side no-delete)**: (a) build a tmp vault containing one Claude skill artifact, (b) call `applyClaudeVault(vaultDir, key, false)` against a tmp `$HOME` to populate the local skill, (c) delete the artifact from the vault directly (simulating the post-`skill remove` state on the remote without invoking the CLI), (d) call `applyClaudeVault(vaultDir, key, false)` AGAIN with the same tmp `$HOME`, and (e) assert the local skill directory at `<tmpHome>/.claude/skills/my-skill/` still exists with its original files. This proves FR-013's pull-side no-delete guarantee is upheld by the existing apply pipeline — if it fails, `applyXxxVault` or the walker is silently deleting locally, which violates the contract. **Second test (SC-009 negative-space vault content check)**: (a) build a tmp `$HOME` whose `~/.claude/skills/` contains one real skill `my-skill/SKILL.md` AND one top-level symlink `vendored -> /tmp/vendored-pool/sensitive-skill/` (where the target tree contains a marker file like `secret-marker.md` with content `THIS_MUST_NOT_LEAK`), (b) run `performPush({ dryRun: false })` against a tmp vault, (c) assert no `<vault>/claude/skills/vendored.tar.age` file was written, (d) for every `<vault>/claude/skills/*.tar.age` that DID get written, decrypt it, base64-decode it, gunzip the tar, walk the entries, and assert that NO entry has a path containing `vendored`, `sensitive-skill`, or `secret-marker`, AND that no entry's content contains the literal string `THIS_MUST_NOT_LEAK`. This proves SC-009's information-leak guarantee — vendored pool data never reaches the encrypted vault, even indirectly through tar-follow or path traversal. If the test fails, FR-016's outer-tier rule has a leak path that the walker test (T006) cannot catch because T006 only inspects walker output structure, not the post-encryption byte content.
+
+**Checkpoint**: `agentsync skill remove` is wired up, exit codes match the contract, and the FR-013 invariant is proven by integration. Run `bun run check`.
+
+---
+
+## Phase 7: Polish & Documentation
+
+**Purpose**: Ship the documentation updates the spec's Documentation Impact section requires (FR-014), the two Mermaid diagrams FR-015 mandates, the README safety note, and the manual cross-machine validation that automated tests cannot cover. This phase is not optional — Constitution Principle V's documentation gate blocks merge until docs land in the same commit as the code.
+
+- [X] T027 [P] Update `docs/architecture.md` to add a new "Skills sync flow" section describing the shared `skills-walker.ts` module, the five gates in order (FR-002/FR-006/FR-016/FR-017), and how each agent adapter consumes the walker. Add the **first** Mermaid diagram from `research.md` R10 (sync flow: local skills directory → sentinel check → tar archive → age encryption → vault namespace → pull → atomic restore). Apply the GitHub-compatible Mermaid rules from the project's global guidelines: inline `:::className` styles, single `subgraph`, `<br/>` instead of `\n`, no parentheses in node labels, descriptive node IDs of ≥ 3 characters, and `classDef` colour pairs that meet WCAG 2 AA contrast (≥ 4.5:1).
+- [X] T028 [P] Update `docs/architecture.md` (same file as T027 — but a new sub-section, so the two diagram tasks can be developed in parallel branches and merged sequentially without conflict if coordinated; otherwise perform T028 after T027) to add the **second** Mermaid diagram from `research.md` R10 (vault-removal flow: explicit user request → vault namespace entry removed → next pull on another machine leaves the local skill in place). Same Mermaid rule set. Place this section directly after the sync-flow section so a reader sees both flows in context.
+- [X] T029 [P] Update `docs/command-reference.md` to extend the `push`, `pull`, `status`, and `doctor` entries with one-line additions naming the new vault namespaces (`claude/skills/`, `codex/skills/`, `cursor/skills/`) alongside the existing `copilot/skills/`, and add a new top-level `skill remove` section documenting the signature, exit codes, success/not-found/git-error output formats from `contracts/skill-remove-cli.md`. Include the explicit warning that `skill remove` never touches local skill directories on any machine.
+- [X] T030 [P] Update `docs/troubleshooting.md` to add the six new entries enumerated in `spec.md`'s Documentation Impact section: (1) "my skills did not push" → FR-002 sentinel rule; (2) "my push aborted because of a never-sync file inside a skill" → FR-006; (3) "I deleted a skill locally and it came back after pull" → FR-011 + pointer to `skill remove`; (4) "I removed a skill from the vault but it is still on my other laptop" → FR-013; (5) "my vendored / symlinked skill did not sync" → FR-016 root-symlink rule; (6) "a helper file inside my skill is missing on the other machine after pull" → FR-016 interior-symlink omission.
+- [X] T031 [P] Update `README.md` "What a vault means here" block (currently citing only `copilot/skills/<name>.tar.age`) to also name `claude/skills/`, `codex/skills/`, and `cursor/skills/`. Add a one-line safety note immediately after that block: "AgentSync never silently removes vault skills — removal is always an explicit user action via `agentsync skill remove`."
+- [X] T032 Validate every Mermaid diagram introduced or modified by T027 and T028 against the project's GitHub Mermaid renderer rules. Concretely: paste each diagram into the GitHub markdown preview (or use the `mermaid-cli` lint pass if available locally) and verify it renders without parser errors and that every node label is legible. Constitution Principle V treats invalid Mermaid as a documentation defect — a failure here MUST be fixed before merge.
+- [X] T033 Run `bun run check` (typecheck → biome → bun test --coverage) from the repo root and verify zero failures. Confirm coverage on `src/agents/skills-walker.ts`, `src/commands/skill.ts`, and the extended portions of `src/agents/{claude,cursor,codex,copilot}.ts` is ≥ 70 % per Constitution Principle II. Confirm `src/core/sanitizer.ts` and `src/core/encryptor.ts` coverage remains ≥ 90 % (both should be unchanged since neither file is modified).
+- [ ] T034 Execute the manual cross-machine walkthrough in `quickstart.md` end-to-end on either two physical machines, two `$HOME`-isolated user accounts on the same host, or two Bun processes against two distinct tmp `$HOME` paths. Walk every numbered step and record pass/fail for each row in the "What this walkthrough proves" matrix at the bottom of `quickstart.md`. Attach the result list to the PR description so reviewers can see which spec requirements have been observed end-to-end.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: T001 has no dependencies — start immediately.
+- **Phase 2 (Foundational)**: T002–T013, T035, T036 depend on T001. Within Phase 2, the dependencies are: `T002 → T003`, `T004 → T005`, `T006 → T007 (which also depends on T002 + T005)`, `T008 → T009 (which also depends on T007)`, `T010 → T011 (which also depends on T007)`, `T012 → T013 (which also depends on T002)`, `T011 → T035` (status test reuses the retrofitted Copilot skill path), `T011 → T036` (additive-default test reuses the retrofitted Copilot skill path). Phase 2 BLOCKS every later phase.
+- **Phases 3, 4, 5 (US1/US2/US3)**: All three depend on Phase 2 complete. They can run in parallel by different developers (the agent files are disjoint), or sequentially in priority order (P1 → P2 → P3) if a single developer is implementing.
+- **Phase 6 (Cross-cutting `skill remove`)**: Depends on Phase 2 complete. Does NOT depend on any of US1/US2/US3 — the verb operates on the vault directly and works on Copilot skills the moment Phase 2 is done. Can ship as a standalone increment if desired.
+- **Phase 7 (Polish)**: Depends on every code change being merged. The four `[P]` doc tasks (T027, T028, T029, T030, T031) can run in parallel. T032 (Mermaid validation) depends on T027 and T028. T033 (`bun run check`) is the merge gate. T034 (manual walkthrough) depends on every other task being complete.
+
+### User Story Dependencies
+
+- **US1 (Claude, P1)**: Depends only on Foundational complete. No dependency on US2 or US3.
+- **US2 (Codex, P2)**: Depends only on Foundational. No dependency on US1 or US3.
+- **US3 (Cursor, P3)**: Depends only on Foundational. No dependency on US1 or US2.
+- **Cross-cutting `skill remove` (Phase 6)**: Depends only on Foundational. Provides cross-cutting capability for all agents simultaneously.
+
+### Within Each User Story
+
+- Tests are written FIRST and MUST FAIL before implementation lands (TDD per Constitution Principle II).
+- Each story is one test task plus one implementation task. The story is complete when the implementation passes the tests AND the existing test suite still passes.
+
+### Parallel Opportunities
+
+- Phase 2: T003, T004, T006, T008, T010, T012, T035, T036 are marked `[P]` because each touches a different file (T035 → `status.test.ts`, T036 → `push.test.ts` which T008 already targets so coordinate authoring with T008). Within each test/implementation pair (T002→T003, T004→T005, T006→T007, T008→T009, T010→T011, T012→T013) the implementation cannot start until the test compiles and fails. T035 and T036 both depend on T011 (Copilot retrofit) being complete because they reuse the Copilot skill path as their test fixture.
+- Phase 3 (US1): T015 is marked `[P]` because it can be authored alongside T014 (both edit `claude.test.ts` — the parallelism here is *concurrent test authoring within one task batch* rather than two LLM agents on the same file simultaneously; if two agents are working on `claude.test.ts` they MUST coordinate at the file level).
+- Phases 3 / 4 / 5 / 6 can all run in parallel by different developers once Foundational is done.
+- Phase 7: T027–T031 are all `[P]` (different files). T028 touches the same file as T027 and is marked `[P]` only with the caveat that the two diagram sub-sections are merged sequentially.
+
+---
+
+## Parallel Example: Phase 2 — multiple foundational tasks at once
+
+```bash
+# After T002 completes, the following can be authored concurrently:
+Task: "T003 Extend src/config/__tests__/paths.test.ts with skillsDir assertions"
+Task: "T004 Add failing test for archiveDirectory({ skipSymlinks: true }) in src/core/__tests__/tar.test.ts"
+Task: "T006 Create src/agents/__tests__/skills-walker.test.ts with the 12-row matrix"
+Task: "T008 Add failing never-sync-inside-skill push abort test"
+Task: "T010 Add failing copilot retrofit regression tests"
+Task: "T012 Add failing doctor skills-dir readability test"
+
+# After T005 + T007 complete, T009 / T011 / T013 can land in any order.
+```
+
+## Parallel Example: User stories after Foundational
+
+```bash
+# Three developers, three agent stories, no cross-talk:
+Developer A: T014 → T015 → T016                  # US1 Claude
+Developer B: T017 → T018 → T019                  # US2 Codex
+Developer C: T020 → T021 → T022                  # US3 Cursor
+Developer D: T023 → T024 → T025 → T026          # skill remove cross-cutting
+
+# All four pipelines merge into Phase 7 polish in parallel.
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Complete Phase 1 (T001) — confirm green baseline.
+2. Complete Phase 2 (T002–T013) — foundational walker, tar filter, push gate, doctor, Copilot retrofit. **CRITICAL**: this phase is non-skippable.
+3. Complete Phase 3 (T014–T016) — Claude skill round-trip.
+4. **STOP and VALIDATE**: Run quickstart steps 2–4 manually on a single machine. Confirm `~/.claude/skills/<name>` round-trips.
+5. Open the PR with US1 only and ship the MVP. US2/US3/skill-remove/polish can land in follow-ups, OR all in the same PR if the team prefers a single delivery.
+
+### Incremental Delivery
+
+1. Foundational done → walker callable, push aborts on never-sync inside skill, Copilot already correct.
+2. + US1 → Claude users see skills round-trip. (MVP — first shippable increment.)
+3. + US2 → Codex users join.
+4. + US3 → Cursor users join.
+5. + Cross-cutting `skill remove` → users gain the explicit removal escape hatch.
+6. + Polish → docs, Mermaid diagrams, manual walkthrough recorded.
+
+Each increment is independently testable per its acceptance scenarios in the spec.
+
+### Single-PR Strategy (if preferred)
+
+Land everything (T001–T036) in a single PR, walking the dependency graph in a deterministic order: T001 → T002 → T003 → T004 → T005 → T006 → T007 → T008 → T009 → T010 → T011 → T035 → T036 → T012 → T013 → T014 → T015 → T016 → T017 → T018 → T019 → T020 → T021 → T022 → T023 → T024 → T025 → T026 → T027 → T028 → T029 → T030 → T031 → T032 → T033 → T034. Note that T035 and T036 are inserted after T011 (which they depend on) and before T012/T013 (which are independent of them). Run `bun run check` after every Phase boundary, not only at T033, so a regression introduced in (say) T013 is caught before it propagates into US1.
+
+---
+
+## Notes
+
+- **`[P]` tasks** = different files, no dependencies on incomplete tasks.
+- **`[Story]` label** maps a task to its user story for traceability. Setup, Foundational, Cross-cutting, and Polish phases have NO story label by design.
+- **Each user story** is independently completable and testable (US1 on its own ships the MVP).
+- **Documentation tasks (T027–T031)** are NOT optional — Constitution Principle V's documentation gate blocks merge.
+- **Mermaid validation (T032)** is NOT optional — Constitution Principle V treats invalid Mermaid as a documentation defect.
+- **TDD ordering**: every implementation task in this list is preceded by a failing test task. Verify tests fail before implementing.
+- **Commit cadence**: commit after each task or each logical pair. Avoid bundling more than one phase into a single commit.
+- **Stop at any checkpoint** to validate a story or sub-feature independently before continuing.
+- **Avoid**: vague descriptions (every task in this list names exact file paths), same-file parallelism without coordination (the tasks file flags this for `claude.test.ts`, `cursor.test.ts`, `codex.test.ts`, and `architecture.md`), and cross-story dependencies (none are introduced here — all four user stories and the cross-cutting verb are independent).

--- a/src/agents/__tests__/claude.test.ts
+++ b/src/agents/__tests__/claude.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
+import { archiveDirectory, extractArchive } from "../../core/tar";
 import { createTmpDir } from "../../test-helpers/fixtures";
 
 {
@@ -19,6 +20,7 @@ type MutableClaudePaths = {
   agentsDir: string;
   mcpJson: string;
   credentials: string;
+  skillsDir: string;
 };
 
 const testClaudePaths = AgentPaths.claude as MutableClaudePaths;
@@ -43,6 +45,7 @@ describe("snapshotClaude", () => {
     testClaudePaths.agentsDir = join(tmpDir, "agents");
     testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
     testClaudePaths.credentials = join(tmpDir, ".credentials.json");
+    testClaudePaths.skillsDir = join(tmpDir, "skills");
   });
 
   afterEach(async () => {
@@ -123,6 +126,108 @@ describe("snapshotClaude", () => {
     // Warnings bubble up from sanitization
     expect(result.warnings.length).toBeGreaterThanOrEqual(0);
   });
+
+  // T014 — US1 Claude skill round-trip happy path (FR-001, FR-003, FR-004)
+
+  test("snapshots a real Claude skill directory as a base64 tar artifact", async () => {
+    const skillDir = join(testClaudePaths.skillsDir, "my-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# my skill", "utf8");
+    writeFileSync(join(skillDir, "notes.md"), "# notes", "utf8");
+
+    const result = await claudeModule.snapshotClaude();
+    const art = result.artifacts.find((a) => a.vaultPath === "claude/skills/my-skill.tar.age");
+    expect(art).toBeDefined();
+    expect(art?.sourcePath).toBe(skillDir);
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    expect(() => Buffer.from(art!.plaintext, "base64")).not.toThrow();
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    expect(art!.plaintext.length).toBeGreaterThan(0);
+  });
+
+  // T014(5) — FR-009 missing-dir case at the agent layer
+
+  test("snapshotClaude does not throw when the skills directory is missing (FR-009)", async () => {
+    testClaudePaths.skillsDir = join(tmpDir, "skills-does-not-exist");
+
+    const result = await claudeModule.snapshotClaude();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("claude/skills/"));
+    expect(skillArts).toHaveLength(0);
+    expect(result.warnings.filter((w) => w.startsWith("never-sync"))).toHaveLength(0);
+  });
+
+  // T014(6) — FR-016 interior-symlink defense-in-depth at the agent layer
+
+  test("snapshotClaude omits interior symlink helper files from the tar (FR-016 inner)", async () => {
+    // Vendored helper outside the skills root.
+    const helperTargetParent = join(tmpDir, "vendored-helpers");
+    mkdirSync(helperTargetParent, { recursive: true });
+    const helperTarget = join(helperTargetParent, "shared.md");
+    writeFileSync(helperTarget, "# vendored helper", "utf8");
+
+    const skillDir = join(testClaudePaths.skillsDir, "skill-with-helper");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# real", "utf8");
+    writeFileSync(join(skillDir, "real-note.md"), "# real note", "utf8");
+    symlinkSync(helperTarget, join(skillDir, "helper.md"));
+
+    const result = await claudeModule.snapshotClaude();
+    const art = result.artifacts.find(
+      (a) => a.vaultPath === "claude/skills/skill-with-helper.tar.age",
+    );
+    expect(art).toBeDefined();
+
+    // Decode the base64 tar and verify helper.md is absent.
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    const tarBuf = Buffer.from(art!.plaintext, "base64");
+    const extractDir = join(tmpDir, "extract-claude-helper");
+    mkdirSync(extractDir, { recursive: true });
+    await extractArchive(tarBuf, extractDir);
+
+    const entries = await readdir(extractDir);
+    expect(entries).toContain("SKILL.md");
+    expect(entries).toContain("real-note.md");
+    expect(entries).not.toContain("helper.md");
+  });
+
+  // T015 — Claude-specific edge cases that prove the walker is correctly
+  // wired into snapshotClaude (not just the walker module in isolation).
+
+  test("snapshotClaude skips a top-level symlinked skill root (FR-016 outer)", async () => {
+    const vendoredTarget = join(tmpDir, "vendored-pool", "vendor-skill");
+    mkdirSync(vendoredTarget, { recursive: true });
+    writeFileSync(join(vendoredTarget, "SKILL.md"), "# vendored", "utf8");
+
+    mkdirSync(testClaudePaths.skillsDir, { recursive: true });
+    symlinkSync(vendoredTarget, join(testClaudePaths.skillsDir, "vendored-skill"));
+
+    const result = await claudeModule.snapshotClaude();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("claude/skills/"));
+    expect(skillArts).toHaveLength(0);
+  });
+
+  test("snapshotClaude skips a top-level .system directory (FR-017 dot-skip)", async () => {
+    const systemSkill = join(testClaudePaths.skillsDir, ".system", "vendor");
+    mkdirSync(systemSkill, { recursive: true });
+    writeFileSync(join(systemSkill, "SKILL.md"), "# vendor", "utf8");
+
+    const result = await claudeModule.snapshotClaude();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("claude/skills/"));
+    expect(skillArts).toHaveLength(0);
+  });
+
+  test("snapshotClaude skips a skill whose SKILL.md sentinel is a symlink (FR-016 sentinel)", async () => {
+    const realSentinel = join(tmpDir, "vendored-sentinel.md");
+    writeFileSync(realSentinel, "# vendored", "utf8");
+
+    const skillDir = join(testClaudePaths.skillsDir, "fake-skill");
+    mkdirSync(skillDir, { recursive: true });
+    symlinkSync(realSentinel, join(skillDir, "SKILL.md"));
+
+    const result = await claudeModule.snapshotClaude();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("claude/skills/"));
+    expect(skillArts).toHaveLength(0);
+  });
 });
 
 // T024 — applyClaudeMd / applyClaudeHooks / applyClaudeMcp / applyClaudeCommand / applyClaudeAgent
@@ -138,6 +243,7 @@ describe("apply* functions", () => {
     testClaudePaths.agentsDir = join(tmpDir, "agents");
     testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
     testClaudePaths.credentials = join(tmpDir, ".credentials.json");
+    testClaudePaths.skillsDir = join(tmpDir, "skills");
   });
 
   afterEach(async () => {
@@ -192,6 +298,28 @@ describe("apply* functions", () => {
     const content = await Bun.file(join(testClaudePaths.agentsDir, "my-agent.md")).text();
     expect(content).toBe("# Agent content");
   });
+
+  // T014(2) — applyClaudeSkill direct extraction test
+
+  test("applyClaudeSkill extracts a tar archive into the local skills dir", async () => {
+    // Build a source skill, archive it via the same helper the walker uses,
+    // then round-trip the base64 payload through applyClaudeSkill.
+    const srcSkill = join(tmpDir, "src-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# skill body", "utf8");
+    writeFileSync(join(srcSkill, "extra.md"), "# extra", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+
+    await claudeModule.applyClaudeSkill("my-skill", base64);
+
+    const targetSkillDir = join(testClaudePaths.skillsDir, "my-skill");
+    const skillMd = await Bun.file(join(targetSkillDir, "SKILL.md")).text();
+    const extra = await Bun.file(join(targetSkillDir, "extra.md")).text();
+    expect(skillMd).toBe("# skill body");
+    expect(extra).toBe("# extra");
+  });
 });
 
 // T028 — dryRun (applyClaudeVault)
@@ -207,6 +335,7 @@ describe("applyClaudeVault dryRun", () => {
     testClaudePaths.agentsDir = join(tmpDir, "apply", "agents");
     testClaudePaths.mcpJson = join(tmpDir, "apply", ".claude.json");
     testClaudePaths.credentials = join(tmpDir, "apply", ".credentials.json");
+    testClaudePaths.skillsDir = join(tmpDir, "apply", "skills");
   });
 
   afterEach(async () => {
@@ -231,6 +360,70 @@ describe("applyClaudeVault dryRun", () => {
 
     // File should NOT exist since dryRun=true
     const exists = await Bun.file(testClaudePaths.claudeMd).exists();
+    expect(exists).toBeFalse();
+  });
+
+  // T014(3) — applyClaudeVault round-trip restores skill from encrypted vault
+
+  test("applyClaudeVault restores a Claude skill from an encrypted vault artifact", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    // Build a real source skill, archive it, encrypt it, write to a tmp vault.
+    const srcSkill = join(tmpDir, "src", "round-trip-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# round trip", "utf8");
+    writeFileSync(join(srcSkill, "guide.md"), "# guide", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-skill-roundtrip");
+    const skillsVaultDir = join(vaultDir, "claude", "skills");
+    await mkdir(skillsVaultDir, { recursive: true });
+    await writeFile(join(skillsVaultDir, "round-trip-skill.tar.age"), encrypted, "utf8");
+
+    await claudeModule.applyClaudeVault(vaultDir, identity, false /* dryRun */);
+
+    // The local skill directory should now contain both files.
+    const restoredSkillDir = join(testClaudePaths.skillsDir, "round-trip-skill");
+    const restoredSkill = await Bun.file(join(restoredSkillDir, "SKILL.md")).text();
+    const restoredGuide = await Bun.file(join(restoredSkillDir, "guide.md")).text();
+    expect(restoredSkill).toBe("# round trip");
+    expect(restoredGuide).toBe("# guide");
+  });
+
+  // T014(4) — applyClaudeVault dryRun=true must NOT touch the local skills dir
+
+  test("applyClaudeVault dryRun=true does not extract skill artifacts", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const srcSkill = join(tmpDir, "src", "dry-run-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# dry run skill", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-skill-dryrun");
+    const skillsVaultDir = join(vaultDir, "claude", "skills");
+    await mkdir(skillsVaultDir, { recursive: true });
+    await writeFile(join(skillsVaultDir, "dry-run-skill.tar.age"), encrypted, "utf8");
+
+    await claudeModule.applyClaudeVault(vaultDir, identity, true /* dryRun */);
+
+    // The local skills directory must not contain the skill.
+    const restoredSkillDir = join(testClaudePaths.skillsDir, "dry-run-skill");
+    const exists = await Bun.file(join(restoredSkillDir, "SKILL.md")).exists();
     expect(exists).toBeFalse();
   });
 });

--- a/src/agents/__tests__/claude.test.ts
+++ b/src/agents/__tests__/claude.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -25,11 +25,24 @@ type MutableClaudePaths = {
 
 const testClaudePaths = AgentPaths.claude as MutableClaudePaths;
 
+// Capture the real paths once at module load so afterAll can put them back.
+// Without this, the beforeEach hooks below mutate AgentPaths.claude.* to point
+// at per-test tmp dirs and the mutation bleeds into later test files in the
+// same bun test run — notably src/config/__tests__/paths.test.ts, which
+// asserts the original ~/.claude/... values. Different OSes give bun test a
+// different file load order, so the bleed shows up on CI Linux but may be
+// hidden on macOS depending on which file happens to run first.
+const originalClaudePaths: MutableClaudePaths = { ...testClaudePaths };
+
 type ClaudeModule = typeof import("../claude");
 let claudeModule: ClaudeModule;
 
 beforeAll(async () => {
   claudeModule = await import("../claude");
+});
+
+afterAll(() => {
+  Object.assign(testClaudePaths, originalClaudePaths);
 });
 
 // T018 — snapshotClaude

--- a/src/agents/__tests__/claude.test.ts
+++ b/src/agents/__tests__/claude.test.ts
@@ -426,4 +426,53 @@ describe("applyClaudeVault dryRun", () => {
     const exists = await Bun.file(join(restoredSkillDir, "SKILL.md")).exists();
     expect(exists).toBeFalse();
   });
+
+  // Phase 8 M6 — adversarial filename regression. Locks the H1 path-traversal
+  // fix: a crafted vault file named `...tar.age` basenames to `..`, which must
+  // be rejected by validateSkillName before any filesystem write occurs.
+
+  test("applyClaudeSkill rejects traversal and hidden skill names", async () => {
+    const { InvalidSkillNameError } = await import("../skills-walker");
+    const badNames = ["", ".", "..", "../foo", "foo/bar", "foo\\bar", ".hidden", "foo\x00bar"];
+    for (const bad of badNames) {
+      await expect(claudeModule.applyClaudeSkill(bad, "")).rejects.toBeInstanceOf(
+        InvalidSkillNameError,
+      );
+    }
+  });
+
+  test("applyClaudeVault skips adversarial vault filenames without traversal", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    // Build a tar whose first entry is a payload that WOULD overwrite the
+    // Claude config root if extraction escaped skillsDir.
+    const payloadSrc = join(tmpDir, "payload-src");
+    mkdirSync(payloadSrc, { recursive: true });
+    writeFileSync(join(payloadSrc, "CLAUDE.md"), "LEAKED_PAYLOAD", "utf8");
+    const tarBuffer = await archiveDirectory(payloadSrc);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-adversarial");
+    const skillsVaultDir = join(vaultDir, "claude", "skills");
+    await mkdir(skillsVaultDir, { recursive: true });
+    // `...tar.age` → basename strips `.tar.age` → skillName is `..`
+    await writeFile(join(skillsVaultDir, "...tar.age"), encrypted, "utf8");
+
+    // Must not throw — the bad entry is caught and logged, loop continues.
+    await claudeModule.applyClaudeVault(vaultDir, identity, false /* dryRun */);
+
+    // The skillsDir parent must NOT have a leaked payload file.
+    const escapedPayload = join(testClaudePaths.skillsDir, "..", "CLAUDE.md");
+    const leakedExists = await Bun.file(escapedPayload).exists();
+    // In this tmp layout the parent of skillsDir is `<tmpDir>/apply`, which
+    // is the same directory that holds `CLAUDE.md` for the dry-run test above
+    // (testClaudePaths.claudeMd). If the validator were bypassed, the payload
+    // would land exactly on top of it.
+    expect(leakedExists).toBeFalse();
+  });
 });

--- a/src/agents/__tests__/codex.test.ts
+++ b/src/agents/__tests__/codex.test.ts
@@ -341,4 +341,42 @@ describe("applyCodexVault dryRun", () => {
     const exists = await Bun.file(join(restoredSkillDir, "SKILL.md")).exists();
     expect(exists).toBeFalse();
   });
+
+  // Phase 8 M6 — adversarial filename regression for Codex.
+
+  test("applyCodexSkill rejects traversal and hidden skill names", async () => {
+    const { InvalidSkillNameError } = await import("../skills-walker");
+    const badNames = ["", ".", "..", "../foo", "foo/bar", "foo\\bar", ".hidden", "foo\x00bar"];
+    for (const bad of badNames) {
+      await expect(codexModule.applyCodexSkill(bad, "")).rejects.toBeInstanceOf(
+        InvalidSkillNameError,
+      );
+    }
+  });
+
+  test("applyCodexVault skips adversarial vault filenames without traversal", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const payloadSrc = join(tmpDir, "payload-src");
+    mkdirSync(payloadSrc, { recursive: true });
+    writeFileSync(join(payloadSrc, "AGENTS.md"), "LEAKED_PAYLOAD", "utf8");
+    const tarBuffer = await archiveDirectory(payloadSrc);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-adversarial");
+    const skillsVaultDir = join(vaultDir, "codex", "skills");
+    await mkdir(skillsVaultDir, { recursive: true });
+    await writeFile(join(skillsVaultDir, "...tar.age"), encrypted, "utf8");
+
+    await codexModule.applyCodexVault(vaultDir, identity, false);
+
+    const escapedPayload = join(testCodexPaths.skillsDir, "..", "AGENTS.md");
+    const leakedExists = await Bun.file(escapedPayload).exists();
+    expect(leakedExists).toBeFalse();
+  });
 });

--- a/src/agents/__tests__/codex.test.ts
+++ b/src/agents/__tests__/codex.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
+import { archiveDirectory, extractArchive } from "../../core/tar";
 import { createTmpDir } from "../../test-helpers/fixtures";
 
 {
@@ -18,6 +19,7 @@ type MutableCodexPaths = {
   configToml: string;
   rulesDir: string;
   authJson: string;
+  skillsDir: string;
 };
 
 const testCodexPaths = AgentPaths.codex as MutableCodexPaths;
@@ -41,6 +43,7 @@ describe("snapshotCodex", () => {
     testCodexPaths.configToml = join(tmpDir, "config.toml");
     testCodexPaths.rulesDir = join(tmpDir, "rules");
     testCodexPaths.authJson = join(tmpDir, "auth.json");
+    testCodexPaths.skillsDir = join(tmpDir, "skills");
   });
 
   afterEach(async () => {
@@ -87,6 +90,89 @@ describe("snapshotCodex", () => {
     const authArt = result.artifacts.find((a) => a.vaultPath.includes("auth.json"));
     expect(authArt).toBeUndefined();
   });
+
+  // T017(1) — US2 Codex skill round-trip happy path (FR-001, FR-003, FR-004)
+
+  test("snapshots a real Codex skill directory as a base64 tar artifact", async () => {
+    const skillDir = join(testCodexPaths.skillsDir, "my-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# my codex skill", "utf8");
+    writeFileSync(join(skillDir, "notes.md"), "# notes", "utf8");
+
+    const result = await codexModule.snapshotCodex();
+    const art = result.artifacts.find((a) => a.vaultPath === "codex/skills/my-skill.tar.age");
+    expect(art).toBeDefined();
+    expect(art?.sourcePath).toBe(skillDir);
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    expect(() => Buffer.from(art!.plaintext, "base64")).not.toThrow();
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    expect(art!.plaintext.length).toBeGreaterThan(0);
+  });
+
+  // T017(5) — FR-009 missing-dir case at the agent layer
+
+  test("snapshotCodex does not throw when the skills directory is missing (FR-009)", async () => {
+    testCodexPaths.skillsDir = join(tmpDir, "skills-does-not-exist");
+
+    const result = await codexModule.snapshotCodex();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("codex/skills/"));
+    expect(skillArts).toHaveLength(0);
+    expect(result.warnings.filter((w) => w.startsWith("never-sync"))).toHaveLength(0);
+  });
+
+  // T017(6) — FR-016 interior-symlink defense-in-depth at the agent layer
+
+  test("snapshotCodex omits interior symlink helper files from the tar (FR-016 inner)", async () => {
+    // Vendored helper outside the skills root.
+    const helperTargetParent = join(tmpDir, "vendored-helpers");
+    mkdirSync(helperTargetParent, { recursive: true });
+    const helperTarget = join(helperTargetParent, "shared.md");
+    writeFileSync(helperTarget, "# vendored helper", "utf8");
+
+    const skillDir = join(testCodexPaths.skillsDir, "skill-with-helper");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# real", "utf8");
+    writeFileSync(join(skillDir, "real-note.md"), "# real note", "utf8");
+    symlinkSync(helperTarget, join(skillDir, "helper.md"));
+
+    const result = await codexModule.snapshotCodex();
+    const art = result.artifacts.find(
+      (a) => a.vaultPath === "codex/skills/skill-with-helper.tar.age",
+    );
+    expect(art).toBeDefined();
+
+    // Decode the base64 tar and verify helper.md is absent.
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    const tarBuf = Buffer.from(art!.plaintext, "base64");
+    const extractDir = join(tmpDir, "extract-codex-helper");
+    mkdirSync(extractDir, { recursive: true });
+    await extractArchive(tarBuf, extractDir);
+
+    const entries = await readdir(extractDir);
+    expect(entries).toContain("SKILL.md");
+    expect(entries).toContain("real-note.md");
+    expect(entries).not.toContain("helper.md");
+  });
+
+  // T018 — FR-017 dot-skip regression specific to Codex (.system vendor bundle)
+
+  test("snapshotCodex skips a top-level .system directory (FR-017 dot-skip)", async () => {
+    // Real skill alongside a .system/ directory which represents a vendor bundle
+    // that Codex may ship with its installer. The dot-skip rule MUST filter this
+    // out regardless of whether it contains a valid SKILL.md sentinel.
+    const realSkill = join(testCodexPaths.skillsDir, "my-skill");
+    mkdirSync(realSkill, { recursive: true });
+    writeFileSync(join(realSkill, "SKILL.md"), "# real", "utf8");
+
+    const systemSkill = join(testCodexPaths.skillsDir, ".system", "vendor");
+    mkdirSync(systemSkill, { recursive: true });
+    writeFileSync(join(systemSkill, "SKILL.md"), "# vendor", "utf8");
+
+    const result = await codexModule.snapshotCodex();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("codex/skills/"));
+    expect(skillArts).toHaveLength(1);
+    expect(skillArts[0]?.vaultPath).toBe("codex/skills/my-skill.tar.age");
+  });
 });
 
 // T025 — applyCodexAgentsMd / applyCodexConfig / applyCodexRule
@@ -101,6 +187,7 @@ describe("apply* functions", () => {
     testCodexPaths.configToml = join(tmpDir, "config.toml");
     testCodexPaths.rulesDir = join(tmpDir, "rules");
     testCodexPaths.authJson = join(tmpDir, "auth.json");
+    testCodexPaths.skillsDir = join(tmpDir, "skills");
   });
 
   afterEach(async () => {
@@ -134,6 +221,26 @@ describe("apply* functions", () => {
     const content = await Bun.file(join(testCodexPaths.rulesDir, "testing.md")).text();
     expect(content).toBe("## Testing rules");
   });
+
+  // T017(2) — applyCodexSkill direct extraction test
+
+  test("applyCodexSkill extracts a tar archive into the local skills dir", async () => {
+    const srcSkill = join(tmpDir, "src-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# codex skill body", "utf8");
+    writeFileSync(join(srcSkill, "extra.md"), "# extra", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+
+    await codexModule.applyCodexSkill("my-skill", base64);
+
+    const targetSkillDir = join(testCodexPaths.skillsDir, "my-skill");
+    const skillMd = await Bun.file(join(targetSkillDir, "SKILL.md")).text();
+    const extra = await Bun.file(join(targetSkillDir, "extra.md")).text();
+    expect(skillMd).toBe("# codex skill body");
+    expect(extra).toBe("# extra");
+  });
 });
 
 // T028 — dryRun (applyCodexVault)
@@ -148,6 +255,7 @@ describe("applyCodexVault dryRun", () => {
     testCodexPaths.configToml = join(tmpDir, "apply", "config.toml");
     testCodexPaths.rulesDir = join(tmpDir, "apply", "rules");
     testCodexPaths.authJson = join(tmpDir, "apply", "auth.json");
+    testCodexPaths.skillsDir = join(tmpDir, "apply", "skills");
   });
 
   afterEach(async () => {
@@ -170,6 +278,67 @@ describe("applyCodexVault dryRun", () => {
     await codexModule.applyCodexVault(vaultDir, identity, true);
 
     const exists = await Bun.file(testCodexPaths.agentsMd).exists();
+    expect(exists).toBeFalse();
+  });
+
+  // T017(3) — applyCodexVault restores a Codex skill from an encrypted artifact
+
+  test("applyCodexVault restores a Codex skill from an encrypted vault artifact", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const srcSkill = join(tmpDir, "src", "round-trip-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# codex round trip", "utf8");
+    writeFileSync(join(srcSkill, "guide.md"), "# guide", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-skill-roundtrip");
+    const skillsVaultDir = join(vaultDir, "codex", "skills");
+    await mkdir(skillsVaultDir, { recursive: true });
+    await writeFile(join(skillsVaultDir, "round-trip-skill.tar.age"), encrypted, "utf8");
+
+    await codexModule.applyCodexVault(vaultDir, identity, false);
+
+    const restoredSkillDir = join(testCodexPaths.skillsDir, "round-trip-skill");
+    const restoredSkill = await Bun.file(join(restoredSkillDir, "SKILL.md")).text();
+    const restoredGuide = await Bun.file(join(restoredSkillDir, "guide.md")).text();
+    expect(restoredSkill).toBe("# codex round trip");
+    expect(restoredGuide).toBe("# guide");
+  });
+
+  // T017(4) — applyCodexVault dryRun=true must NOT touch the local skills dir
+
+  test("applyCodexVault dryRun=true does not extract skill artifacts", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const srcSkill = join(tmpDir, "src", "dry-run-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# codex dry run skill", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-skill-dryrun");
+    const skillsVaultDir = join(vaultDir, "codex", "skills");
+    await mkdir(skillsVaultDir, { recursive: true });
+    await writeFile(join(skillsVaultDir, "dry-run-skill.tar.age"), encrypted, "utf8");
+
+    await codexModule.applyCodexVault(vaultDir, identity, true);
+
+    const restoredSkillDir = join(testCodexPaths.skillsDir, "dry-run-skill");
+    const exists = await Bun.file(join(restoredSkillDir, "SKILL.md")).exists();
     expect(exists).toBeFalse();
   });
 });

--- a/src/agents/__tests__/codex.test.ts
+++ b/src/agents/__tests__/codex.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -24,11 +24,20 @@ type MutableCodexPaths = {
 
 const testCodexPaths = AgentPaths.codex as MutableCodexPaths;
 
+// Capture the real paths once at module load so afterAll can put them back.
+// See claude.test.ts for the full explanation of the cross-file mutation
+// bleed this guards against.
+const originalCodexPaths: MutableCodexPaths = { ...testCodexPaths };
+
 type CodexModule = typeof import("../codex");
 let codexModule: CodexModule;
 
 beforeAll(async () => {
   codexModule = await import("../codex");
+});
+
+afterAll(() => {
+  Object.assign(testCodexPaths, originalCodexPaths);
 });
 
 // T019 — snapshotCodex

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { readdir, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -24,11 +24,20 @@ type MutableCopilotPaths = {
 
 const testCopilotPaths = AgentPaths.copilot as MutableCopilotPaths;
 
+// Capture the real paths once at module load so afterAll can put them back.
+// See claude.test.ts for the full explanation of the cross-file mutation
+// bleed this guards against.
+const originalCopilotPaths: MutableCopilotPaths = { ...testCopilotPaths };
+
 type CopilotModule = typeof import("../copilot");
 let copilotModule: CopilotModule;
 
 beforeAll(async () => {
   copilotModule = await import("../copilot");
+});
+
+afterAll(() => {
+  Object.assign(testCopilotPaths, originalCopilotPaths);
 });
 
 // T020 — snapshotCopilot

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -368,6 +368,20 @@ describe("applyCopilotVault dryRun", () => {
     }
   });
 
+  // Thread 6 regression — the agents/ loop in applyCopilotVault mirrors the
+  // skills/ loop and was missed in the Phase 8 fix. Same basename-strip
+  // vector (`...tar.age` → `..`) would let a compromised vault overwrite
+  // files in the agent config root via path.join(agentsDir, "..").
+  test("applyCopilotAgent rejects traversal and hidden agent names", async () => {
+    const { InvalidSkillNameError } = await import("../skills-walker");
+    const badNames = ["", ".", "..", "../foo", "foo/bar", "foo\\bar", ".hidden", "foo\x00bar"];
+    for (const bad of badNames) {
+      await expect(copilotModule.applyCopilotAgent(bad, "")).rejects.toBeInstanceOf(
+        InvalidSkillNameError,
+      );
+    }
+  });
+
   test("applyCopilotVault skips adversarial vault filenames without traversal", async () => {
     const { generateIdentity, identityToRecipient, encryptString } = await import(
       "../../core/encryptor"
@@ -391,6 +405,37 @@ describe("applyCopilotVault dryRun", () => {
     await copilotModule.applyCopilotVault(vaultDir, identity, false);
 
     const escapedPayload = join(testCopilotPaths.skillsDir, "..", "instructions.md");
+    const leakedExists = await Bun.file(escapedPayload).exists();
+    expect(leakedExists).toBeFalse();
+  });
+
+  // Thread 6 regression end-to-end: an adversarial file in copilot/agents/
+  // must be rejected symmetrically with the skills/ loop above. Distinct
+  // payload filename (`AGENT_LEAKED.md`) so a false positive can't be
+  // mistaken for the skills-loop assertion's leakage.
+  test("applyCopilotVault skips adversarial agent filenames without traversal", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const { archiveDirectory } = await import("../../core/tar");
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const payloadSrc = join(tmpDir, "agent-payload-src");
+    mkdirSync(payloadSrc, { recursive: true });
+    writeFileSync(join(payloadSrc, "AGENT_LEAKED.md"), "LEAKED_AGENT_PAYLOAD", "utf8");
+    const tarBuffer = await archiveDirectory(payloadSrc);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-adversarial-agent");
+    const agentsVaultDir = join(vaultDir, "copilot", "agents");
+    mkdirSync(agentsVaultDir, { recursive: true });
+    writeFileSync(join(agentsVaultDir, "...tar.age"), encrypted, "utf8");
+
+    await copilotModule.applyCopilotVault(vaultDir, identity, false);
+
+    const escapedPayload = join(testCopilotPaths.agentsDir, "..", "AGENT_LEAKED.md");
     const leakedExists = await Bun.file(escapedPayload).exists();
     expect(leakedExists).toBeFalse();
   });

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { rm } from "node:fs/promises";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { readdir, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
+import { extractArchive } from "../../core/tar";
 import { createTmpDir } from "../../test-helpers/fixtures";
 
 {
@@ -132,6 +133,66 @@ describe("snapshotCopilot", () => {
     expect(art).toBeDefined();
     // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
     expect(() => Buffer.from(art!.plaintext, "base64")).not.toThrow();
+  });
+
+  // T010 — walker retrofit regression: the new snapshotCopilot must inherit
+  // the FR-016 (symlink) and FR-017 (dot-skip) rules from the shared walker.
+
+  test("retrofit: top-level symlinked skill root produces zero artifacts (FR-016)", async () => {
+    // Build a "vendored pool" outside the skills root and symlink it in.
+    const vendoredTarget = join(tmpDir, "vendored-pool", "vendor-skill");
+    mkdirSync(vendoredTarget, { recursive: true });
+    writeFileSync(join(vendoredTarget, "SKILL.md"), "# vendored", "utf8");
+
+    mkdirSync(testCopilotPaths.skillsDir, { recursive: true });
+    symlinkSync(vendoredTarget, join(testCopilotPaths.skillsDir, "vendored-skill"));
+
+    const result = await copilotModule.snapshotCopilot();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("copilot/skills/"));
+    expect(skillArts).toHaveLength(0);
+  });
+
+  test("retrofit: top-level .system directory is skipped (FR-017)", async () => {
+    const systemSkill = join(testCopilotPaths.skillsDir, ".system", "vendor");
+    mkdirSync(systemSkill, { recursive: true });
+    writeFileSync(join(systemSkill, "SKILL.md"), "# vendor", "utf8");
+
+    const result = await copilotModule.snapshotCopilot();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("copilot/skills/"));
+    expect(skillArts).toHaveLength(0);
+  });
+
+  test("retrofit: real skill with interior symlink helper omits the helper (FR-016 inner)", async () => {
+    // Vendored helper file outside the skills root.
+    const helperTargetDir = join(tmpDir, "vendored-helpers");
+    mkdirSync(helperTargetDir, { recursive: true });
+    const helperTarget = join(helperTargetDir, "shared.md");
+    writeFileSync(helperTarget, "# vendored helper", "utf8");
+
+    // Real skill directory with one real file plus the symlink.
+    const skillDir = join(testCopilotPaths.skillsDir, "skill-with-helper");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# real", "utf8");
+    writeFileSync(join(skillDir, "real-note.md"), "# real note", "utf8");
+    symlinkSync(helperTarget, join(skillDir, "helper.md"));
+
+    const result = await copilotModule.snapshotCopilot();
+    const art = result.artifacts.find(
+      (a) => a.vaultPath === "copilot/skills/skill-with-helper.tar.age",
+    );
+    expect(art).toBeDefined();
+
+    // Decrypt-ish: base64 → tar bytes → extract → list entries.
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    const tarBuf = Buffer.from(art!.plaintext, "base64");
+    const extractDir = join(tmpDir, "extract-retrofit");
+    mkdirSync(extractDir, { recursive: true });
+    await extractArchive(tarBuf, extractDir);
+
+    const entries = await readdir(extractDir);
+    expect(entries).toContain("SKILL.md");
+    expect(entries).toContain("real-note.md");
+    expect(entries).not.toContain("helper.md");
   });
 });
 

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -346,4 +346,43 @@ describe("applyCopilotVault dryRun", () => {
     ).text();
     expect(content).toBe("# instr file");
   });
+
+  // Phase 8 M6 — adversarial filename regression for Copilot.
+
+  test("applyCopilotSkill rejects traversal and hidden skill names", async () => {
+    const { InvalidSkillNameError } = await import("../skills-walker");
+    const badNames = ["", ".", "..", "../foo", "foo/bar", "foo\\bar", ".hidden", "foo\x00bar"];
+    for (const bad of badNames) {
+      await expect(copilotModule.applyCopilotSkill(bad, "")).rejects.toBeInstanceOf(
+        InvalidSkillNameError,
+      );
+    }
+  });
+
+  test("applyCopilotVault skips adversarial vault filenames without traversal", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const { archiveDirectory } = await import("../../core/tar");
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const payloadSrc = join(tmpDir, "payload-src");
+    mkdirSync(payloadSrc, { recursive: true });
+    writeFileSync(join(payloadSrc, "instructions.md"), "LEAKED_PAYLOAD", "utf8");
+    const tarBuffer = await archiveDirectory(payloadSrc);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-adversarial");
+    const skillsVaultDir = join(vaultDir, "copilot", "skills");
+    mkdirSync(skillsVaultDir, { recursive: true });
+    writeFileSync(join(skillsVaultDir, "...tar.age"), encrypted, "utf8");
+
+    await copilotModule.applyCopilotVault(vaultDir, identity, false);
+
+    const escapedPayload = join(testCopilotPaths.skillsDir, "..", "instructions.md");
+    const leakedExists = await Bun.file(escapedPayload).exists();
+    expect(leakedExists).toBeFalse();
+  });
 });

--- a/src/agents/__tests__/cursor.test.ts
+++ b/src/agents/__tests__/cursor.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
+import { archiveDirectory, extractArchive } from "../../core/tar";
 import { createAgeIdentity, createTmpDir } from "../../test-helpers/fixtures";
 
 {
@@ -16,6 +17,7 @@ type MutableCursorPaths = {
   mcpGlobal: string;
   commandsDir: string;
   settingsJson: string;
+  skillsDir: string;
 };
 
 const testCursorPaths = AgentPaths.cursor as MutableCursorPaths;
@@ -37,6 +39,7 @@ describe("snapshotCursor", () => {
     testCursorPaths.settingsJson = join(tmpDir, "settings.json");
     testCursorPaths.mcpGlobal = join(tmpDir, "mcp.json");
     testCursorPaths.commandsDir = join(tmpDir, "commands");
+    testCursorPaths.skillsDir = join(tmpDir, "skills");
   });
 
   afterEach(async () => {
@@ -116,6 +119,96 @@ describe("snapshotCursor", () => {
     expect(commands.some((a) => a.vaultPath === "cursor/commands/fix.md.age")).toBe(true);
     expect(commands.some((a) => a.vaultPath === "cursor/commands/explain.md.age")).toBe(true);
   });
+
+  // T020(1) — US3 Cursor skill round-trip happy path (FR-001, FR-003, FR-004)
+
+  test("snapshots a real Cursor skill directory as a base64 tar artifact", async () => {
+    const { snapshotCursor } = cursorModule;
+    const skillDir = join(testCursorPaths.skillsDir, "my-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# my cursor skill", "utf8");
+    writeFileSync(join(skillDir, "notes.md"), "# notes", "utf8");
+
+    const result = await snapshotCursor();
+    const art = result.artifacts.find((a) => a.vaultPath === "cursor/skills/my-skill.tar.age");
+    expect(art).toBeDefined();
+    expect(art?.sourcePath).toBe(skillDir);
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    expect(() => Buffer.from(art!.plaintext, "base64")).not.toThrow();
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    expect(art!.plaintext.length).toBeGreaterThan(0);
+  });
+
+  // T020(5) — FR-009 missing-dir case at the agent layer
+
+  test("snapshotCursor does not throw when the skills directory is missing (FR-009)", async () => {
+    const { snapshotCursor } = cursorModule;
+    testCursorPaths.skillsDir = join(tmpDir, "skills-does-not-exist");
+
+    const result = await snapshotCursor();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("cursor/skills/"));
+    expect(skillArts).toHaveLength(0);
+    expect(result.warnings.filter((w) => w.startsWith("never-sync"))).toHaveLength(0);
+  });
+
+  // T020(6) — FR-016 interior-symlink defense-in-depth at the agent layer
+
+  test("snapshotCursor omits interior symlink helper files from the tar (FR-016 inner)", async () => {
+    const { snapshotCursor } = cursorModule;
+    const helperTargetParent = join(tmpDir, "vendored-helpers");
+    mkdirSync(helperTargetParent, { recursive: true });
+    const helperTarget = join(helperTargetParent, "shared.md");
+    writeFileSync(helperTarget, "# vendored helper", "utf8");
+
+    const skillDir = join(testCursorPaths.skillsDir, "skill-with-helper");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# real", "utf8");
+    writeFileSync(join(skillDir, "real-note.md"), "# real note", "utf8");
+    symlinkSync(helperTarget, join(skillDir, "helper.md"));
+
+    const result = await snapshotCursor();
+    const art = result.artifacts.find(
+      (a) => a.vaultPath === "cursor/skills/skill-with-helper.tar.age",
+    );
+    expect(art).toBeDefined();
+
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    const tarBuf = Buffer.from(art!.plaintext, "base64");
+    const extractDir = join(tmpDir, "extract-cursor-helper");
+    mkdirSync(extractDir, { recursive: true });
+    await extractArchive(tarBuf, extractDir);
+
+    const entries = await readdir(extractDir);
+    expect(entries).toContain("SKILL.md");
+    expect(entries).toContain("real-note.md");
+    expect(entries).not.toContain("helper.md");
+  });
+
+  // T021 — FR-010 negative assertion: ~/.cursor/skills-cursor/ is never read.
+  // This is the load-bearing test for US3 because it is the only direct
+  // evidence that the Cursor adapter is pointed at the canonical "skills"
+  // path and never touches the bundled "skills-cursor" directory.
+
+  test("snapshotCursor never touches ~/.cursor/skills-cursor/ (FR-010)", async () => {
+    const { snapshotCursor } = cursorModule;
+    // Real skill at the canonical path.
+    const realSkill = join(testCursorPaths.skillsDir, "my-skill");
+    mkdirSync(realSkill, { recursive: true });
+    writeFileSync(join(realSkill, "SKILL.md"), "# real", "utf8");
+
+    // Decoy bundled directory at the path the spec says must be ignored.
+    const bundledSkill = join(tmpDir, "skills-cursor", "other-skill");
+    mkdirSync(bundledSkill, { recursive: true });
+    writeFileSync(join(bundledSkill, "SKILL.md"), "# bundled vendor", "utf8");
+
+    const result = await snapshotCursor();
+    const skillArts = result.artifacts.filter((a) => a.vaultPath.startsWith("cursor/skills/"));
+    expect(skillArts).toHaveLength(1);
+    expect(skillArts[0]?.vaultPath).toBe("cursor/skills/my-skill.tar.age");
+    // Negative-space assertion: nothing under skills-cursor can have leaked
+    // into the vault namespace, regardless of sub-path.
+    expect(result.artifacts.every((a) => !a.vaultPath.includes("skills-cursor"))).toBe(true);
+  });
 });
 
 // ── T027 — cursor apply functions ─────────────────────────────────────────────
@@ -128,6 +221,7 @@ describe("cursor apply functions", () => {
     testCursorPaths.settingsJson = join(tmpDir, "settings.json");
     testCursorPaths.mcpGlobal = join(tmpDir, "mcp.json");
     testCursorPaths.commandsDir = join(tmpDir, "commands");
+    testCursorPaths.skillsDir = join(tmpDir, "skills");
   });
 
   afterEach(async () => {
@@ -178,6 +272,27 @@ describe("cursor apply functions", () => {
     const target = join(testCursorPaths.commandsDir, "my-cmd.md");
     expect(await Bun.file(target).text()).toBe("# My Cmd\nDo things.");
   });
+
+  // T020(2) — applyCursorSkill direct extraction test
+
+  test("applyCursorSkill extracts a tar archive into the local skills dir", async () => {
+    const { applyCursorSkill } = cursorModule;
+    const srcSkill = join(tmpDir, "src-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# cursor skill body", "utf8");
+    writeFileSync(join(srcSkill, "extra.md"), "# extra", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+
+    await applyCursorSkill("my-skill", base64);
+
+    const targetSkillDir = join(testCursorPaths.skillsDir, "my-skill");
+    const skillMd = await Bun.file(join(targetSkillDir, "SKILL.md")).text();
+    const extra = await Bun.file(join(targetSkillDir, "extra.md")).text();
+    expect(skillMd).toBe("# cursor skill body");
+    expect(extra).toBe("# extra");
+  });
 });
 
 // ── T028 — dryRun vault apply ─────────────────────────────────────────────────
@@ -190,6 +305,7 @@ describe("applyCursorVault dryRun", () => {
     testCursorPaths.settingsJson = join(tmpDir, "settings.json");
     testCursorPaths.mcpGlobal = join(tmpDir, "mcp.json");
     testCursorPaths.commandsDir = join(tmpDir, "commands");
+    testCursorPaths.skillsDir = join(tmpDir, "skills");
   });
 
   afterEach(async () => {
@@ -212,6 +328,63 @@ describe("applyCursorVault dryRun", () => {
 
     // settings.json must NOT be created on dryRun
     expect(await Bun.file(testCursorPaths.settingsJson).exists()).toBe(false);
+  });
+
+  // T020(3) — applyCursorVault restores a Cursor skill from an encrypted artifact
+
+  test("applyCursorVault restores a Cursor skill from an encrypted vault artifact", async () => {
+    const { applyCursorVault } = cursorModule;
+    const { encryptString } = await import("../../core/encryptor");
+    const { identity, recipient } = await createAgeIdentity();
+
+    const srcSkill = join(tmpDir, "src", "round-trip-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# cursor round trip", "utf8");
+    writeFileSync(join(srcSkill, "guide.md"), "# guide", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-skill-roundtrip");
+    const skillsVaultDir = join(vaultDir, "cursor", "skills");
+    await mkdir(skillsVaultDir, { recursive: true });
+    await writeFile(join(skillsVaultDir, "round-trip-skill.tar.age"), encrypted, "utf8");
+
+    await applyCursorVault(vaultDir, identity, false);
+
+    const restoredSkillDir = join(testCursorPaths.skillsDir, "round-trip-skill");
+    const restoredSkill = await Bun.file(join(restoredSkillDir, "SKILL.md")).text();
+    const restoredGuide = await Bun.file(join(restoredSkillDir, "guide.md")).text();
+    expect(restoredSkill).toBe("# cursor round trip");
+    expect(restoredGuide).toBe("# guide");
+  });
+
+  // T020(4) — applyCursorVault dryRun=true must NOT touch the local skills dir
+
+  test("applyCursorVault dryRun=true does not extract skill artifacts", async () => {
+    const { applyCursorVault } = cursorModule;
+    const { encryptString } = await import("../../core/encryptor");
+    const { identity, recipient } = await createAgeIdentity();
+
+    const srcSkill = join(tmpDir, "src", "dry-run-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# cursor dry run skill", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-skill-dryrun");
+    const skillsVaultDir = join(vaultDir, "cursor", "skills");
+    await mkdir(skillsVaultDir, { recursive: true });
+    await writeFile(join(skillsVaultDir, "dry-run-skill.tar.age"), encrypted, "utf8");
+
+    await applyCursorVault(vaultDir, identity, true);
+
+    const restoredSkillDir = join(testCursorPaths.skillsDir, "dry-run-skill");
+    const exists = await Bun.file(join(restoredSkillDir, "SKILL.md")).exists();
+    expect(exists).toBeFalse();
   });
 });
 

--- a/src/agents/__tests__/cursor.test.ts
+++ b/src/agents/__tests__/cursor.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -22,11 +22,20 @@ type MutableCursorPaths = {
 
 const testCursorPaths = AgentPaths.cursor as MutableCursorPaths;
 
+// Capture the real paths once at module load so afterAll can put them back.
+// See claude.test.ts for the full explanation of the cross-file mutation
+// bleed this guards against.
+const originalCursorPaths: MutableCursorPaths = { ...testCursorPaths };
+
 type CursorModule = typeof import("../cursor");
 let cursorModule: CursorModule;
 
 beforeAll(async () => {
   cursorModule = await import("../cursor");
+});
+
+afterAll(() => {
+  Object.assign(testCursorPaths, originalCursorPaths);
 });
 
 // ── T021 — snapshotCursor ─────────────────────────────────────────────────────

--- a/src/agents/__tests__/cursor.test.ts
+++ b/src/agents/__tests__/cursor.test.ts
@@ -386,6 +386,41 @@ describe("applyCursorVault dryRun", () => {
     const exists = await Bun.file(join(restoredSkillDir, "SKILL.md")).exists();
     expect(exists).toBeFalse();
   });
+
+  // Phase 8 M6 — adversarial filename regression for Cursor.
+
+  test("applyCursorSkill rejects traversal and hidden skill names", async () => {
+    const { applyCursorSkill } = cursorModule;
+    const { InvalidSkillNameError } = await import("../skills-walker");
+    const badNames = ["", ".", "..", "../foo", "foo/bar", "foo\\bar", ".hidden", "foo\x00bar"];
+    for (const bad of badNames) {
+      await expect(applyCursorSkill(bad, "")).rejects.toBeInstanceOf(InvalidSkillNameError);
+    }
+  });
+
+  test("applyCursorVault skips adversarial vault filenames without traversal", async () => {
+    const { applyCursorVault } = cursorModule;
+    const { encryptString } = await import("../../core/encryptor");
+    const { identity, recipient } = await createAgeIdentity();
+
+    const payloadSrc = join(tmpDir, "payload-src");
+    mkdirSync(payloadSrc, { recursive: true });
+    writeFileSync(join(payloadSrc, "user-rules.md"), "LEAKED_PAYLOAD", "utf8");
+    const tarBuffer = await archiveDirectory(payloadSrc);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const vaultDir = join(tmpDir, "vault-adversarial");
+    const skillsVaultDir = join(vaultDir, "cursor", "skills");
+    await mkdir(skillsVaultDir, { recursive: true });
+    await writeFile(join(skillsVaultDir, "...tar.age"), encrypted, "utf8");
+
+    await applyCursorVault(vaultDir, identity, false);
+
+    const escapedPayload = join(testCursorPaths.skillsDir, "..", "user-rules.md");
+    const leakedExists = await Bun.file(escapedPayload).exists();
+    expect(leakedExists).toBeFalse();
+  });
 });
 
 // ── applyCursorVault unknown file warning ─────────────────────────────────────

--- a/src/agents/__tests__/skills-walker.test.ts
+++ b/src/agents/__tests__/skills-walker.test.ts
@@ -170,10 +170,14 @@ describe("collectSkillArtifacts", () => {
 
     const result = await collectSkillArtifacts("claude", tmpDir);
     expect(result.artifacts).toHaveLength(0);
-    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
-    const offending = result.warnings.find((w) => w.startsWith("never-sync inside skill: "));
+    // Exactly one warning — the contract promises one entry per offending path,
+    // and this fixture seeds exactly one. A looser assertion would silently
+    // accept a walker regression that duplicated warnings.
+    expect(result.warnings).toHaveLength(1);
+    const offending = result.warnings[0];
     expect(offending).toBeDefined();
     expect(offending).toContain("auth.json");
+    expect(offending?.startsWith("never-sync inside skill: ")).toBe(true);
   });
 
   // Row 12 — two skills, one clean + one dirty → walker collects clean, warns dirty (R3)
@@ -190,8 +194,9 @@ describe("collectSkillArtifacts", () => {
     const result = await collectSkillArtifacts("claude", tmpDir);
     expect(result.artifacts).toHaveLength(1);
     expect(result.artifacts[0]?.vaultPath).toBe("claude/skills/clean-skill.tar.age");
-    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
-    expect(result.warnings.some((w) => w.startsWith("never-sync inside skill: "))).toBe(true);
+    // One dirty skill with one offending file → exactly one warning.
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.startsWith("never-sync inside skill: ")).toBe(true);
   });
 
   // Row 13 — the skills root path itself is a symlink (NC-1 from PR review).

--- a/src/agents/__tests__/skills-walker.test.ts
+++ b/src/agents/__tests__/skills-walker.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the shared skills walker (src/agents/skills-walker.ts).
+ *
+ * Covers the 12-row behavioral matrix from contracts/walker-interface.md.
+ * Each row builds an independent fixture under a tmp dir, calls
+ * collectSkillArtifacts, and asserts on the returned shape.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { extractArchive } from "../../core/tar";
+import { createTmpDir } from "../../test-helpers/fixtures";
+import { collectSkillArtifacts } from "../skills-walker";
+
+describe("collectSkillArtifacts", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // Row 1 — empty skills root
+  test("returns empty result for an empty skills root", async () => {
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Row 2 — missing skills root (FR-009)
+  test("returns empty result when skills root does not exist (FR-009)", async () => {
+    const result = await collectSkillArtifacts("claude", join(tmpDir, "does-not-exist"));
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Row 3 — happy path: real skill with SKILL.md plus extra files
+  test("archives one real skill (happy path)", async () => {
+    const skillDir = join(tmpDir, "my-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# skill", "utf8");
+    await writeFile(join(skillDir, "README.md"), "# notes", "utf8");
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0]?.vaultPath).toBe("claude/skills/my-skill.tar.age");
+    expect(result.artifacts[0]?.sourcePath).toBe(skillDir);
+    expect(result.artifacts[0]?.plaintext.length).toBeGreaterThan(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Row 4 — directory missing SKILL.md sentinel
+  test("skips a directory that has no SKILL.md sentinel (FR-002)", async () => {
+    const skillDir = join(tmpDir, "no-sentinel");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "README.md"), "# notes", "utf8");
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Row 5 — SKILL.md is itself a symlink (FR-016 sentinel back-door)
+  test("skips a skill whose SKILL.md is itself a symlink (FR-016 sentinel guard)", async () => {
+    const realSentinel = join(tmpDir, ".vendored-sentinel.md");
+    await writeFile(realSentinel, "# vendored", "utf8");
+
+    const skillDir = join(tmpDir, "fake-skill");
+    await mkdir(skillDir, { recursive: true });
+    await symlink(realSentinel, join(skillDir, "SKILL.md"));
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Row 6 — top-level symlink root pointing into a vendored pool (FR-016 outer)
+  test("skips a top-level symlinked skill root (FR-016 outer tier)", async () => {
+    const targetSkill = join(tmpDir, ".vendored-pool", "real-target");
+    await mkdir(targetSkill, { recursive: true });
+    await writeFile(join(targetSkill, "SKILL.md"), "# vendored skill", "utf8");
+
+    await symlink(targetSkill, join(tmpDir, "vendored-skill"));
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Row 7 — top-level .system directory containing a real skill (FR-017)
+  test("skips a top-level .system directory (FR-017 dot-skip)", async () => {
+    const systemSkill = join(tmpDir, ".system", "vendor-skill");
+    await mkdir(systemSkill, { recursive: true });
+    await writeFile(join(systemSkill, "SKILL.md"), "# vendor", "utf8");
+
+    const result = await collectSkillArtifacts("codex", tmpDir);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Row 8 — top-level .DS_Store regular file (FR-017)
+  test("skips a top-level .DS_Store file (FR-017 dot-skip)", async () => {
+    await writeFile(join(tmpDir, ".DS_Store"), "binary", "utf8");
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Row 9 — two real skills + one symlinked root → 2 artifacts
+  test("archives multiple real skills while skipping a symlinked root", async () => {
+    const a = join(tmpDir, "skill-a");
+    await mkdir(a, { recursive: true });
+    await writeFile(join(a, "SKILL.md"), "# a", "utf8");
+
+    const b = join(tmpDir, "skill-b");
+    await mkdir(b, { recursive: true });
+    await writeFile(join(b, "SKILL.md"), "# b", "utf8");
+
+    const target = join(tmpDir, ".outside-pool", "vendored");
+    await mkdir(target, { recursive: true });
+    await writeFile(join(target, "SKILL.md"), "# vendored", "utf8");
+    await symlink(target, join(tmpDir, "skill-c"));
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(2);
+    const vaultPaths = result.artifacts.map((art) => art.vaultPath).sort();
+    expect(vaultPaths).toEqual(["claude/skills/skill-a.tar.age", "claude/skills/skill-b.tar.age"]);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Row 10 — real skill with interior symlink helper file (FR-016 inner)
+  test("archives a real skill while omitting interior symlink helper files (FR-016 inner tier)", async () => {
+    const helperTargetParent = join(tmpDir, ".helper-pool");
+    await mkdir(helperTargetParent, { recursive: true });
+    const helperTarget = join(helperTargetParent, "shared.md");
+    await writeFile(helperTarget, "# vendored helper", "utf8");
+
+    const skillDir = join(tmpDir, "skill-with-helper");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# real", "utf8");
+    await writeFile(join(skillDir, "real-note.md"), "# real note", "utf8");
+    await symlink(helperTarget, join(skillDir, "helper.md"));
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0]?.vaultPath).toBe("claude/skills/skill-with-helper.tar.age");
+
+    // Decrypt the tar back to disk and verify helper.md is NOT present.
+    const tarBuf = Buffer.from(result.artifacts[0]?.plaintext ?? "", "base64");
+    const extractDir = join(tmpDir, "extract-row-10");
+    await mkdir(extractDir, { recursive: true });
+    await extractArchive(tarBuf, extractDir);
+
+    const entries = await readdir(extractDir);
+    expect(entries).toContain("SKILL.md");
+    expect(entries).toContain("real-note.md");
+    expect(entries).not.toContain("helper.md");
+  });
+
+  // Row 11 — skill containing a never-sync file (FR-006)
+  test("rejects a skill that contains a never-sync file (FR-006)", async () => {
+    const skillDir = join(tmpDir, "dirty-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# dirty", "utf8");
+    await writeFile(join(skillDir, "auth.json"), '{"token":"x"}', "utf8");
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+    const offending = result.warnings.find((w) => w.startsWith("never-sync inside skill: "));
+    expect(offending).toBeDefined();
+    expect(offending).toContain("auth.json");
+  });
+
+  // Row 12 — two skills, one clean + one dirty → walker collects clean, warns dirty (R3)
+  test("collects clean skills even when another skill has a never-sync hit (R3)", async () => {
+    const clean = join(tmpDir, "clean-skill");
+    await mkdir(clean, { recursive: true });
+    await writeFile(join(clean, "SKILL.md"), "# clean", "utf8");
+
+    const dirty = join(tmpDir, "dirty-skill");
+    await mkdir(dirty, { recursive: true });
+    await writeFile(join(dirty, "SKILL.md"), "# dirty", "utf8");
+    await writeFile(join(dirty, "auth.json"), '{"token":"x"}', "utf8");
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0]?.vaultPath).toBe("claude/skills/clean-skill.tar.age");
+    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(result.warnings.some((w) => w.startsWith("never-sync inside skill: "))).toBe(true);
+  });
+
+  // Row 13 — the skills root path itself is a symlink (NC-1 from PR review).
+  // Resolves the spec ambiguity toward the conservative "skills I created"
+  // intent: if the entire root is a symlink (e.g., a power user has done
+  // `ln -s /srv/team-pool ~/.claude/skills`), the walker MUST refuse to
+  // enumerate it. The same anti-vendoring rule that FR-016 applies to
+  // individual entries extends to the root by consistency.
+  test("returns empty when the skills root path is itself a symlink (NC-1)", async () => {
+    const realRoot = join(tmpDir, "real-pool");
+    await mkdir(realRoot, { recursive: true });
+    // Populate it with a real skill so we can prove the walker WOULD have
+    // collected it had the root not been a symlink.
+    const realSkill = join(realRoot, "would-be-vendored");
+    await mkdir(realSkill, { recursive: true });
+    await writeFile(join(realSkill, "SKILL.md"), "# would be vendored", "utf8");
+
+    const linkedRoot = join(tmpDir, "linked-root");
+    await symlink(realRoot, linkedRoot);
+
+    const result = await collectSkillArtifacts("claude", linkedRoot);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { AgentPaths } from "../config/paths";
 import { sanitizeClaudeHooks, sanitizeClaudeMcp, shouldNeverSync } from "../core/sanitizer";
+import { extractArchive } from "../core/tar";
 import {
   atomicWrite,
   collect,
@@ -10,6 +11,7 @@ import {
   type SnapshotArtifact,
   type SnapshotResult,
 } from "./_utils";
+import { collectSkillArtifacts } from "./skills-walker";
 
 /** Snapshot payload for the Claude adapter. */
 export type ClaudeSnapshotResult = SnapshotResult;
@@ -91,7 +93,33 @@ export async function snapshotClaude(): Promise<SnapshotResult> {
     // agents dir may not exist yet.
   }
 
+  // Skills — delegated to the shared walker (FR-001/FR-002/FR-006/FR-016/FR-017).
+  // The walker handles dot-skip, symlink rejection, sentinel verification, the
+  // never-sync interior scan, and the symlink-filtered tar archival in one
+  // place so every skill-bearing agent inherits identical rules.
+  const claudeSkills = await collectSkillArtifacts("claude", AgentPaths.claude.skillsDir);
+  artifacts.push(...claudeSkills.artifacts);
+  warnings.push(...claudeSkills.warnings);
+
   return { artifacts, warnings };
+}
+
+/**
+ * Restore one Claude skill directory from the vault by extracting its
+ * encrypted tar archive into `~/.claude/skills/<name>/`.
+ *
+ * Mirrors {@link applyCopilotSkill}: parents are created on demand and the
+ * tar's interior layout is preserved bit-for-bit.
+ *
+ * @param skillName  Basename of the skill (no extension).
+ * @param base64Tar  Base64-encoded `.tar.gz` payload that the walker
+ *                   produced on the source machine.
+ */
+export async function applyClaudeSkill(skillName: string, base64Tar: string): Promise<void> {
+  const targetDir = join(AgentPaths.claude.skillsDir, skillName);
+  await mkdir(targetDir, { recursive: true });
+  const tarBuffer = Buffer.from(base64Tar, "base64");
+  await extractArchive(tarBuffer, targetDir);
 }
 
 /** Restore the shared CLAUDE.md prompt file from the vault. */
@@ -224,5 +252,21 @@ export async function applyClaudeVault(
     } else {
       await applyClaudeAgent(agentName, decrypted);
     }
+  }
+
+  // Skills sub-directory — stored as <name>.tar.age (FR-005). Mirrors the
+  // Copilot apply path: each entry is decrypted, then the inner base64 tar
+  // is extracted into ~/.claude/skills/<name>/ via applyClaudeSkill.
+  const skillFiles = await readAgeFiles(join(claudeDir, "skills"));
+  for (const { name, fullPath } of skillFiles) {
+    if (!name.endsWith(".tar.age")) continue;
+    const encrypted = await readFile(fullPath, "utf8");
+    const decrypted = await decryptString(encrypted, key);
+    const skillName = basename(name, ".tar.age");
+    if (dryRun) {
+      log.info(`[dry-run] [claude] would extract skill: ${skillName}`);
+      continue;
+    }
+    await applyClaudeSkill(skillName, decrypted);
   }
 }

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -11,7 +11,7 @@ import {
   type SnapshotArtifact,
   type SnapshotResult,
 } from "./_utils";
-import { collectSkillArtifacts } from "./skills-walker";
+import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "./skills-walker";
 
 /** Snapshot payload for the Claude adapter. */
 export type ClaudeSnapshotResult = SnapshotResult;
@@ -116,6 +116,7 @@ export async function snapshotClaude(): Promise<SnapshotResult> {
  *                   produced on the source machine.
  */
 export async function applyClaudeSkill(skillName: string, base64Tar: string): Promise<void> {
+  validateSkillName(skillName);
   const targetDir = join(AgentPaths.claude.skillsDir, skillName);
   await mkdir(targetDir, { recursive: true });
   const tarBuffer = Buffer.from(base64Tar, "base64");
@@ -260,9 +261,18 @@ export async function applyClaudeVault(
   const skillFiles = await readAgeFiles(join(claudeDir, "skills"));
   for (const { name, fullPath } of skillFiles) {
     if (!name.endsWith(".tar.age")) continue;
+    const skillName = basename(name, ".tar.age");
+    try {
+      validateSkillName(skillName);
+    } catch (err) {
+      if (err instanceof InvalidSkillNameError) {
+        log.warn(`[claude] Skipping vault skill with invalid name '${name}': ${err.reason}`);
+        continue;
+      }
+      throw err;
+    }
     const encrypted = await readFile(fullPath, "utf8");
     const decrypted = await decryptString(encrypted, key);
-    const skillName = basename(name, ".tar.age");
     if (dryRun) {
       log.info(`[dry-run] [claude] would extract skill: ${skillName}`);
       continue;

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -12,7 +12,7 @@ import {
   type SnapshotArtifact,
   type SnapshotResult,
 } from "./_utils";
-import { collectSkillArtifacts } from "./skills-walker";
+import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "./skills-walker";
 
 /** Snapshot payload for the Codex adapter. */
 export type CodexSnapshotResult = SnapshotResult;
@@ -146,6 +146,7 @@ export async function applyCodexRule(ruleName: string, content: string): Promise
  *                   produced on the source machine.
  */
 export async function applyCodexSkill(skillName: string, base64Tar: string): Promise<void> {
+  validateSkillName(skillName);
   const targetDir = join(AgentPaths.codex.skillsDir, skillName);
   await mkdir(targetDir, { recursive: true });
   const tarBuffer = Buffer.from(base64Tar, "base64");
@@ -219,9 +220,18 @@ export async function applyCodexVault(
   const skillFiles = await readAgeFiles(join(codexDir, "skills"));
   for (const { name, fullPath } of skillFiles) {
     if (!name.endsWith(".tar.age")) continue;
+    const skillName = basename(name, ".tar.age");
+    try {
+      validateSkillName(skillName);
+    } catch (err) {
+      if (err instanceof InvalidSkillNameError) {
+        log.warn(`[codex] Skipping vault skill with invalid name '${name}': ${err.reason}`);
+        continue;
+      }
+      throw err;
+    }
     const encrypted = await readFile(fullPath, "utf8");
     const decrypted = await decryptString(encrypted, key);
-    const skillName = basename(name, ".tar.age");
     if (dryRun) {
       log.info(`[dry-run] [codex] would extract skill: ${skillName}`);
       continue;

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -4,6 +4,7 @@ import { log } from "@clack/prompts";
 import * as TOML from "@iarna/toml";
 import { AgentPaths } from "../config/paths";
 import { type RedactionResult, redactSecretLiterals, shouldNeverSync } from "../core/sanitizer";
+import { extractArchive } from "../core/tar";
 import {
   atomicWrite,
   collect,
@@ -11,6 +12,7 @@ import {
   type SnapshotArtifact,
   type SnapshotResult,
 } from "./_utils";
+import { collectSkillArtifacts } from "./skills-walker";
 
 /** Snapshot payload for the Codex adapter. */
 export type CodexSnapshotResult = SnapshotResult;
@@ -84,6 +86,15 @@ export async function snapshotCodex(): Promise<SnapshotResult> {
     // rules dir may not exist yet
   }
 
+  // Skills — delegated to the shared walker (FR-001/FR-002/FR-006/FR-016/FR-017).
+  // The walker enforces dot-skip (which covers Codex's vendored `.system/`
+  // bundle — FR-017), symlink rejection at the root, sentinel verification,
+  // the never-sync interior scan, and the symlink-filtered tar archival in one
+  // place so every skill-bearing agent inherits identical rules.
+  const codexSkills = await collectSkillArtifacts("codex", AgentPaths.codex.skillsDir);
+  artifacts.push(...codexSkills.artifacts);
+  warnings.push(...codexSkills.warnings);
+
   return { artifacts, warnings };
 }
 
@@ -121,6 +132,24 @@ export async function applyCodexRule(ruleName: string, content: string): Promise
   const target = join(AgentPaths.codex.rulesDir, ruleName);
   await mkdir(AgentPaths.codex.rulesDir, { recursive: true });
   await atomicWrite(target, content);
+}
+
+/**
+ * Restore one Codex skill directory from the vault by extracting its
+ * encrypted tar archive into `~/.codex/skills/<name>/`.
+ *
+ * Mirrors {@link applyClaudeSkill}: parents are created on demand and the
+ * tar's interior layout is preserved bit-for-bit.
+ *
+ * @param skillName  Basename of the skill (no extension).
+ * @param base64Tar  Base64-encoded `.tar.gz` payload that the walker
+ *                   produced on the source machine.
+ */
+export async function applyCodexSkill(skillName: string, base64Tar: string): Promise<void> {
+  const targetDir = join(AgentPaths.codex.skillsDir, skillName);
+  await mkdir(targetDir, { recursive: true });
+  const tarBuffer = Buffer.from(base64Tar, "base64");
+  await extractArchive(tarBuffer, targetDir);
 }
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
@@ -182,5 +211,21 @@ export async function applyCodexVault(
     } else {
       await applyCodexRule(ruleName, decrypted);
     }
+  }
+
+  // Skills sub-directory — stored as <name>.tar.age (FR-005). Mirrors the
+  // Claude/Copilot apply path: each entry is decrypted, then the inner base64
+  // tar is extracted into ~/.codex/skills/<name>/ via applyCodexSkill.
+  const skillFiles = await readAgeFiles(join(codexDir, "skills"));
+  for (const { name, fullPath } of skillFiles) {
+    if (!name.endsWith(".tar.age")) continue;
+    const encrypted = await readFile(fullPath, "utf8");
+    const decrypted = await decryptString(encrypted, key);
+    const skillName = basename(name, ".tar.age");
+    if (dryRun) {
+      log.info(`[dry-run] [codex] would extract skill: ${skillName}`);
+      continue;
+    }
+    await applyCodexSkill(skillName, decrypted);
   }
 }

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -132,6 +132,12 @@ export async function applyCopilotSkill(skillName: string, base64Tar: string): P
 
 /** Extract one archived Copilot agent directory into the local agents folder. */
 export async function applyCopilotAgent(agentName: string, base64Tar: string): Promise<void> {
+  // Symmetric path-traversal guard to the one in applyCopilotSkill: a vault
+  // file named `...tar.age` would basename-strip to `..` and resolve outside
+  // agentsDir, letting a compromised vault overwrite files in `~/.copilot/`
+  // or any parent directory. See validateSkillName in skills-walker.ts — the
+  // helper is named for skills but is the generic vault-basename check.
+  validateSkillName(agentName);
   const targetDir = join(AgentPaths.copilot.agentsDir, agentName);
   await mkdir(targetDir, { recursive: true });
   const tarBuffer = Buffer.from(base64Tar, "base64");
@@ -235,9 +241,18 @@ export async function applyCopilotVault(
   const agentFiles = await readAgeFiles(join(copilotDir, "agents"));
   for (const { name, fullPath } of agentFiles) {
     if (!name.endsWith(".tar.age")) continue;
+    const agentName = basename(name, ".tar.age");
+    try {
+      validateSkillName(agentName);
+    } catch (err) {
+      if (err instanceof InvalidSkillNameError) {
+        log.warn(`[copilot] Skipping vault agent with invalid name '${name}': ${err.reason}`);
+        continue;
+      }
+      throw err;
+    }
     const encrypted = await readFile(fullPath, "utf8");
     const decrypted = await decryptString(encrypted, key);
-    const agentName = basename(name, ".tar.age");
     if (dryRun) {
       log.info(`[dry-run] [copilot] would extract agent: ${agentName}`);
       continue;

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -5,19 +5,10 @@ import { AgentPaths } from "../config/paths";
 import { shouldNeverSync } from "../core/sanitizer";
 import { archiveDirectory, extractArchive } from "../core/tar";
 import { atomicWrite, readIfExists, type SnapshotArtifact, type SnapshotResult } from "./_utils";
+import { collectSkillArtifacts } from "./skills-walker";
 
 /** Snapshot payload for the Copilot adapter. */
 export type CopilotSnapshotResult = SnapshotResult;
-
-/** Check whether an optional skill directory sentinel file exists. */
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await stat(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /** Collect Copilot instructions, prompts, skills, and agents into vault artifacts. */
 export async function snapshotCopilot(): Promise<SnapshotResult> {
@@ -77,28 +68,14 @@ export async function snapshotCopilot(): Promise<SnapshotResult> {
     // directory may not exist
   }
 
-  // Skills — each skill is a directory containing at minimum SKILL.md.
-  // Archive the whole directory as <name>.tar, then that tar content is what we encrypt.
-  try {
-    const names = await readdir(AgentPaths.copilot.skillsDir);
-    for (const name of names) {
-      const skillDir = join(AgentPaths.copilot.skillsDir, name);
-      const skillDirStat = await stat(skillDir).catch(() => null);
-      if (!skillDirStat?.isDirectory()) continue;
-      const skillMd = join(skillDir, "SKILL.md");
-      if (!(await fileExists(skillMd))) continue; // not a valid skill directory
-      const tarBuffer = await archiveDirectory(skillDir);
-      artifacts.push({
-        vaultPath: `copilot/skills/${name}.tar.age`,
-        sourcePath: skillDir,
-        // Store as base64 so it survives the UTF-8 string layer before encryption
-        plaintext: tarBuffer.toString("base64"),
-        warnings: [],
-      });
-    }
-  } catch {
-    // skills dir may not exist
-  }
+  // Skills — delegated to the shared walker so the FR-002, FR-006, FR-016,
+  // and FR-017 rules from the agent-skills-sync feature are enforced
+  // identically across every skill-bearing agent. The walker uses lstat
+  // throughout, so symlinked roots and symlinked SKILL.md sentinels (the
+  // vendored-pool patterns observed on real machines) are correctly skipped.
+  const copilotSkills = await collectSkillArtifacts("copilot", AgentPaths.copilot.skillsDir);
+  artifacts.push(...copilotSkills.artifacts);
+  warnings.push(...copilotSkills.warnings);
 
   // Agents directories (tar each one, similar to skills)
   try {

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -5,7 +5,7 @@ import { AgentPaths } from "../config/paths";
 import { shouldNeverSync } from "../core/sanitizer";
 import { archiveDirectory, extractArchive } from "../core/tar";
 import { atomicWrite, readIfExists, type SnapshotArtifact, type SnapshotResult } from "./_utils";
-import { collectSkillArtifacts } from "./skills-walker";
+import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "./skills-walker";
 
 /** Snapshot payload for the Copilot adapter. */
 export type CopilotSnapshotResult = SnapshotResult;
@@ -123,6 +123,7 @@ export async function applyCopilotPrompt(fileName: string, content: string): Pro
 
 /** Extract one archived Copilot skill directory into the local skills folder. */
 export async function applyCopilotSkill(skillName: string, base64Tar: string): Promise<void> {
+  validateSkillName(skillName);
   const targetDir = join(AgentPaths.copilot.skillsDir, skillName);
   await mkdir(targetDir, { recursive: true });
   const tarBuffer = Buffer.from(base64Tar, "base64");
@@ -211,9 +212,18 @@ export async function applyCopilotVault(
   const skillFiles = await readAgeFiles(join(copilotDir, "skills"));
   for (const { name, fullPath } of skillFiles) {
     if (!name.endsWith(".tar.age")) continue;
+    const skillName = basename(name, ".tar.age");
+    try {
+      validateSkillName(skillName);
+    } catch (err) {
+      if (err instanceof InvalidSkillNameError) {
+        log.warn(`[copilot] Skipping vault skill with invalid name '${name}': ${err.reason}`);
+        continue;
+      }
+      throw err;
+    }
     const encrypted = await readFile(fullPath, "utf8");
     const decrypted = await decryptString(encrypted, key);
-    const skillName = basename(name, ".tar.age");
     if (dryRun) {
       log.info(`[dry-run] [copilot] would extract skill: ${skillName}`);
       continue;

--- a/src/agents/cursor.ts
+++ b/src/agents/cursor.ts
@@ -3,6 +3,7 @@ import { basename, join } from "node:path";
 import { log } from "@clack/prompts";
 import { AgentPaths } from "../config/paths";
 import { redactSecretLiterals, shouldNeverSync } from "../core/sanitizer";
+import { extractArchive } from "../core/tar";
 import {
   atomicWrite,
   collect,
@@ -10,6 +11,7 @@ import {
   type SnapshotArtifact,
   type SnapshotResult,
 } from "./_utils";
+import { collectSkillArtifacts } from "./skills-walker";
 
 /** Snapshot payload for the Cursor adapter. */
 export type CursorSnapshotResult = SnapshotResult;
@@ -88,6 +90,16 @@ export async function snapshotCursor(): Promise<SnapshotResult> {
     // commands dir may not exist yet.
   }
 
+  // Skills — delegated to the shared walker. The walker is pointed at
+  // `AgentPaths.cursor.skillsDir` which resolves to `~/.cursor/skills/` —
+  // the FR-010 canonical path. The bundled `~/.cursor/skills-cursor/`
+  // directory is NEVER read because `paths.ts` does not expose it and the
+  // walker is not given a pointer to it, so there is no code path through
+  // which vendor bundles can leak into the vault.
+  const cursorSkills = await collectSkillArtifacts("cursor", AgentPaths.cursor.skillsDir);
+  artifacts.push(...cursorSkills.artifacts);
+  warnings.push(...cursorSkills.warnings);
+
   return { artifacts, warnings };
 }
 
@@ -115,6 +127,25 @@ export async function applyCursorCommand(commandName: string, content: string): 
   const target = join(AgentPaths.cursor.commandsDir, commandName);
   await mkdir(AgentPaths.cursor.commandsDir, { recursive: true });
   await atomicWrite(target, content);
+}
+
+/**
+ * Restore one Cursor skill directory from the vault by extracting its
+ * encrypted tar archive into `~/.cursor/skills/<name>/` — NEVER into the
+ * bundled `~/.cursor/skills-cursor/` path (FR-010).
+ *
+ * Mirrors {@link applyClaudeSkill}: parents are created on demand and the
+ * tar's interior layout is preserved bit-for-bit.
+ *
+ * @param skillName  Basename of the skill (no extension).
+ * @param base64Tar  Base64-encoded `.tar.gz` payload that the walker
+ *                   produced on the source machine.
+ */
+export async function applyCursorSkill(skillName: string, base64Tar: string): Promise<void> {
+  const targetDir = join(AgentPaths.cursor.skillsDir, skillName);
+  await mkdir(targetDir, { recursive: true });
+  const tarBuffer = Buffer.from(base64Tar, "base64");
+  await extractArchive(tarBuffer, targetDir);
 }
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
@@ -178,5 +209,23 @@ export async function applyCursorVault(
     } else {
       await applyCursorCommand(commandName, decrypted);
     }
+  }
+
+  // Skills sub-directory — stored as <name>.tar.age (FR-005). Mirrors the
+  // Claude/Codex/Copilot apply path: each entry is decrypted, then the inner
+  // base64 tar is extracted into ~/.cursor/skills/<name>/ via applyCursorSkill.
+  // The top-level unrecognised-file warning above is inspecting only top-level
+  // cursor/*.age files, so cursor/skills/*.tar.age never triggers it.
+  const skillFiles = await readAgeFiles(join(cursorDir, "skills"));
+  for (const { name, fullPath } of skillFiles) {
+    if (!name.endsWith(".tar.age")) continue;
+    const encrypted = await readFile(fullPath, "utf8");
+    const decrypted = await decryptString(encrypted, key);
+    const skillName = basename(name, ".tar.age");
+    if (dryRun) {
+      log.info(`[dry-run] [cursor] would extract skill: ${skillName}`);
+      continue;
+    }
+    await applyCursorSkill(skillName, decrypted);
   }
 }

--- a/src/agents/cursor.ts
+++ b/src/agents/cursor.ts
@@ -11,7 +11,7 @@ import {
   type SnapshotArtifact,
   type SnapshotResult,
 } from "./_utils";
-import { collectSkillArtifacts } from "./skills-walker";
+import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "./skills-walker";
 
 /** Snapshot payload for the Cursor adapter. */
 export type CursorSnapshotResult = SnapshotResult;
@@ -142,6 +142,7 @@ export async function applyCursorCommand(commandName: string, content: string): 
  *                   produced on the source machine.
  */
 export async function applyCursorSkill(skillName: string, base64Tar: string): Promise<void> {
+  validateSkillName(skillName);
   const targetDir = join(AgentPaths.cursor.skillsDir, skillName);
   await mkdir(targetDir, { recursive: true });
   const tarBuffer = Buffer.from(base64Tar, "base64");
@@ -219,9 +220,18 @@ export async function applyCursorVault(
   const skillFiles = await readAgeFiles(join(cursorDir, "skills"));
   for (const { name, fullPath } of skillFiles) {
     if (!name.endsWith(".tar.age")) continue;
+    const skillName = basename(name, ".tar.age");
+    try {
+      validateSkillName(skillName);
+    } catch (err) {
+      if (err instanceof InvalidSkillNameError) {
+        log.warn(`[cursor] Skipping vault skill with invalid name '${name}': ${err.reason}`);
+        continue;
+      }
+      throw err;
+    }
     const encrypted = await readFile(fullPath, "utf8");
     const decrypted = await decryptString(encrypted, key);
-    const skillName = basename(name, ".tar.age");
     if (dryRun) {
       log.info(`[dry-run] [cursor] would extract skill: ${skillName}`);
       continue;

--- a/src/agents/skills-walker.ts
+++ b/src/agents/skills-walker.ts
@@ -46,6 +46,71 @@ const NEVER_SYNC_WARNING_PREFIX = "never-sync inside skill: ";
 const ARCHIVE_FAILURE_WARNING_PREFIX = "skill archive failed: ";
 
 /**
+ * Thrown by {@link validateSkillName} when a skill name derived from a vault
+ * filename fails the allow-list. A dedicated subclass (rather than a generic
+ * `Error`) lets the `applyXxxVault` call sites catch this specific failure
+ * mode and log a targeted warning without swallowing unrelated I/O errors.
+ */
+export class InvalidSkillNameError extends Error {
+  constructor(
+    public readonly provided: string,
+    public readonly reason: string,
+  ) {
+    super(`Invalid skill name '${provided}': ${reason}`);
+    this.name = "InvalidSkillNameError";
+  }
+}
+
+/**
+ * Validate a skill name derived from a vault filename BEFORE it is joined onto
+ * the local skills root. This is the trust-boundary check for the pull-side
+ * symmetric to the walker's own gates on the push-side.
+ *
+ * **Why this exists**: `applyXxxSkill(skillName, base64Tar)` is called with
+ * `skillName = basename(vaultFile, ".tar.age")`. A compromised vault can
+ * contain a file literally named `...tar.age`, which `basename` strips down
+ * to `".."`, and `path.join(skillsRoot, "..")` resolves to the agent's
+ * config root (e.g. `~/.codex/`). `extractArchive` then writes tar entries
+ * into that config root and can overwrite legitimate files like
+ * `~/.codex/AGENTS.md` or `~/.codex/config.toml`. The existing tar-slip
+ * filter in `src/core/tar.ts::extractArchive` defends against traversing
+ * entry paths but does NOT sanitize the `cwd` argument — this validator
+ * closes that gap at the caller.
+ *
+ * Rules MUST reject every name that could:
+ *   - resolve to a different directory under `path.join` (`.`, `..`, empty)
+ *   - contain a path separator on any platform (`/` on POSIX, `\` on Windows)
+ *   - collide with hidden-file rules the walker applies on the push side
+ *     (dot-prefixed names are silently skipped during push, so pull should
+ *     not manufacture them either — see FR-017)
+ *   - smuggle control characters or NUL bytes that shell or filesystem
+ *     layers might interpret inconsistently
+ *
+ * @param name  The skill basename, typically from `basename(vaultFile, ".tar.age")`.
+ * @throws {InvalidSkillNameError} if the name fails any rule above.
+ */
+export function validateSkillName(name: string): void {
+  if (name.length === 0) {
+    throw new InvalidSkillNameError(name, "empty");
+  }
+  if (name === "." || name === "..") {
+    throw new InvalidSkillNameError(name, "reserved name");
+  }
+  if (name.startsWith(".")) {
+    throw new InvalidSkillNameError(name, "leading dot is reserved for hidden entries");
+  }
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i);
+    if (code < 0x20) {
+      throw new InvalidSkillNameError(name, "contains control character");
+    }
+    if (code === 0x2f || code === 0x5c) {
+      throw new InvalidSkillNameError(name, "contains path separator");
+    }
+  }
+}
+
+/**
  * Walk an agent's local skills root and collect encrypted-ready tar artifacts
  * for every directory that qualifies as a user-created skill.
  *

--- a/src/agents/skills-walker.ts
+++ b/src/agents/skills-walker.ts
@@ -1,0 +1,216 @@
+/**
+ * src/agents/skills-walker.ts
+ *
+ * Shared skill-collection helper used by every skill-bearing agent adapter
+ * (Claude, Cursor, Codex, Copilot). Encapsulates the five gates required by
+ * the agent-skills-sync feature so the rules live in exactly one place:
+ *
+ *   1. FR-017 — top-level dot-prefixed entries are skipped (silent).
+ *   2. FR-016 — entries that are symlinks are skipped (silent).
+ *   3. FR-002 — entries without a real (non-symlink) `SKILL.md` sentinel are
+ *               skipped (silent).
+ *   4. FR-006 — interior file paths matching `NEVER_SYNC_PATTERNS` cause the
+ *               skill to be rejected with a `never-sync inside skill:`
+ *               warning that the push pipeline escalates to a fatal error.
+ *   5. FR-016 — interior symlink files and sub-directories are omitted from
+ *               the archive while real surrounding content is still archived.
+ *
+ * The walker NEVER throws on filesystem read errors and NEVER emits log
+ * output. Quiet by design — see contracts/walker-interface.md for the rules.
+ */
+
+import { lstat, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { shouldNeverSync } from "../core/sanitizer";
+import { archiveDirectory } from "../core/tar";
+import type { SnapshotArtifact, SnapshotResult } from "./_utils";
+
+/**
+ * Agents that may host skill directories. VS Code is intentionally excluded
+ * because the editor does not have a user-skills concept; encoding that here
+ * keeps the walker's input domain narrower than the full `AgentName` union.
+ */
+export type SkillBearingAgent = "claude" | "cursor" | "codex" | "copilot";
+
+/**
+ * Result returned by {@link collectSkillArtifacts}. Structurally identical to
+ * `SnapshotResult` — exported as a distinct alias so call sites and the
+ * walker contract document line up under the same name.
+ */
+export type SkillsWalkerResult = SnapshotResult;
+
+/** Warning prefix emitted when a never-sync rule matches inside a skill. */
+const NEVER_SYNC_WARNING_PREFIX = "never-sync inside skill: ";
+
+/** Warning prefix emitted when `archiveDirectory` fails on an otherwise-valid skill. */
+const ARCHIVE_FAILURE_WARNING_PREFIX = "skill archive failed: ";
+
+/**
+ * Walk an agent's local skills root and collect encrypted-ready tar artifacts
+ * for every directory that qualifies as a user-created skill.
+ *
+ * Gates are applied in the order documented in
+ * `specs/20260411-002222-agent-skills-sync/contracts/walker-interface.md`.
+ *
+ * @param agent      Vault namespace this walker writes under (`claude`, `cursor`, `codex`, `copilot`).
+ * @param skillsDir  Absolute path to the agent's skills root on disk. A
+ *                   missing directory is NOT an error — the walker returns
+ *                   an empty result (FR-009). A skills root that is itself a
+ *                   symbolic link is also rejected (returns empty) under the
+ *                   "skills I created" spec intent — the same anti-vendoring
+ *                   rule that FR-016 applies to individual skill entries
+ *                   extends to the root by consistency.
+ * @returns          A {@link SkillsWalkerResult} with one artifact per
+ *                   qualifying skill and zero or more warnings: each
+ *                   `never-sync inside skill: ` warning is escalated to a
+ *                   fatal abort by the push pipeline (FR-006), and each
+ *                   `skill archive failed: ` warning is surfaced as a soft
+ *                   warning to the user without aborting the push.
+ *                   The walker NEVER throws on filesystem read errors.
+ */
+export async function collectSkillArtifacts(
+  agent: SkillBearingAgent,
+  skillsDir: string,
+): Promise<SkillsWalkerResult> {
+  const artifacts: SnapshotArtifact[] = [];
+  const warnings: string[] = [];
+
+  // Reject a symlinked skills root before reading it. Node's `readdir` follows
+  // symlinks on its argument by default, so without this guard a user with
+  // `~/.claude/skills -> /srv/team-pool` would silently sync every team
+  // skill as if it were their own. The check is intentionally `lstat` so a
+  // missing path falls through to the catch block below and yields the same
+  // empty no-op as a missing directory (FR-009).
+  try {
+    const rootStat = await lstat(skillsDir);
+    if (rootStat.isSymbolicLink()) return { artifacts, warnings };
+  } catch {
+    return { artifacts, warnings };
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(skillsDir);
+  } catch {
+    // FR-009: missing or unreadable skills root is a no-op, not an error.
+    return { artifacts, warnings };
+  }
+
+  for (const entryName of entries) {
+    // Gate 1 (FR-017): skip dot-prefixed entries silently.
+    if (entryName.startsWith(".")) continue;
+
+    const entryPath = join(skillsDir, entryName);
+
+    let entryStat: Awaited<ReturnType<typeof lstat>>;
+    try {
+      entryStat = await lstat(entryPath);
+    } catch {
+      continue;
+    }
+
+    // Gate 2 (FR-016 outer): reject anything that is not a real directory.
+    // A symlink (even one pointing at a directory) fails isDirectory() under
+    // lstat — there is no separate symlink check needed.
+    if (!entryStat.isDirectory()) continue;
+
+    // Gate 3 (FR-002 + FR-016 sentinel guard): require a REAL `SKILL.md` file.
+    // Using lstat means a symlinked SKILL.md fails the isFile() check, so
+    // vendored skills cannot smuggle themselves in via a symlinked sentinel.
+    const sentinelPath = join(entryPath, "SKILL.md");
+    let sentinelStat: Awaited<ReturnType<typeof lstat>>;
+    try {
+      sentinelStat = await lstat(sentinelPath);
+    } catch {
+      continue;
+    }
+    if (!sentinelStat.isFile()) continue;
+
+    // Gate 4 (FR-006): never-sync interior walk. The walker collects every
+    // matching path in the skill — not just the first — so the user sees
+    // every offender in one push instead of fixing them one at a time.
+    const neverSyncHits = await collectNeverSyncHits(entryPath);
+    if (neverSyncHits.length > 0) {
+      for (const hit of neverSyncHits) {
+        warnings.push(`${NEVER_SYNC_WARNING_PREFIX}${hit}`);
+      }
+      // Skip the artifact entirely so encryption never sees the bad bytes,
+      // even in the unlikely event that the push gate is later removed.
+      continue;
+    }
+
+    // Gate 5 (FR-016 inner): archive with interior symlinks filtered out.
+    let tarBuffer: Buffer;
+    try {
+      tarBuffer = await archiveDirectory(entryPath, { skipSymlinks: true });
+    } catch (err) {
+      // Distinct from the FR-017 / FR-016 silent skips: a tar failure here
+      // means the user DID intend the skill to sync but the machine failed
+      // (EACCES, EMFILE, transient I/O, etc.). Surfacing this as a warning
+      // gives the user a fighting chance to notice and fix it. The push
+      // pipeline does NOT escalate this prefix to a fatal abort — only the
+      // never-sync prefix is fatal — so a single broken skill never blocks
+      // the rest of the push.
+      const message = err instanceof Error ? err.message : String(err);
+      warnings.push(`${ARCHIVE_FAILURE_WARNING_PREFIX}${entryPath} — ${message}`);
+      continue;
+    }
+
+    artifacts.push({
+      vaultPath: `${agent}/skills/${entryName}.tar.age`,
+      sourcePath: entryPath,
+      // Base64 so the binary tar bytes survive the UTF-8 string layer that
+      // performPush feeds into encryptString.
+      plaintext: tarBuffer.toString("base64"),
+      warnings: [],
+    });
+  }
+
+  return { artifacts, warnings };
+}
+
+/**
+ * Walk a real skill directory and return the absolute paths of every interior
+ * file whose path matches a {@link shouldNeverSync} rule.
+ *
+ * Symlinks (files OR sub-directories) are NOT followed and NOT inspected,
+ * which is consistent with FR-016: vendored content reached via a symlink is
+ * out of scope for this feature and will not be archived in gate 5 either.
+ */
+async function collectNeverSyncHits(rootDir: string): Promise<string[]> {
+  const hits: string[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    let names: string[];
+    try {
+      names = await readdir(dir);
+    } catch {
+      return;
+    }
+
+    for (const name of names) {
+      const childPath = join(dir, name);
+      let childStat: Awaited<ReturnType<typeof lstat>>;
+      try {
+        childStat = await lstat(childPath);
+      } catch {
+        continue;
+      }
+
+      if (childStat.isSymbolicLink()) {
+        // Don't follow vendored content. The interior-symlink rule (FR-016
+        // inner) means it would be omitted from the tar in gate 5 anyway.
+        continue;
+      }
+
+      if (childStat.isDirectory()) {
+        await walk(childPath);
+      } else if (childStat.isFile() && shouldNeverSync(childPath)) {
+        hits.push(childPath);
+      }
+    }
+  }
+
+  await walk(rootDir);
+  return hits;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { keyCommand } from "./commands/key";
 import { migrateCommand } from "./commands/migrate";
 import { pullCommand } from "./commands/pull";
 import { pushCommand } from "./commands/push";
+import { skillCommand } from "./commands/skill";
 import { statusCommand } from "./commands/status";
 
 /** Root CLI command that wires every user-facing subcommand into a single entry point. */
@@ -25,6 +26,7 @@ const main = defineCommand({
     daemon: daemonCommand,
     key: keyCommand,
     migrate: migrateCommand,
+    skill: skillCommand,
   },
 });
 

--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -7,7 +7,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { rm } from "node:fs/promises";
+import { rm, symlink } from "node:fs/promises";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
 import { createTmpDir } from "../../test-helpers/fixtures";
@@ -106,5 +106,27 @@ describe("buildSkillsDirChecks (FR-008)", () => {
     const claudeRow = rows.find((r) => r.name === "Claude skills directory");
     expect(claudeRow?.status).toBe("warn");
     expect(claudeRow?.detail).toContain("not a directory");
+  });
+
+  // Thread 8 — parity with the walker's FR-016 rule. The walker refuses to
+  // enumerate a skills root that is itself a symlink, so doctor must not
+  // report `pass` for that same layout. Using `stat` alone would follow the
+  // link and see a real directory, hiding the walker's silent refusal from
+  // the user.
+  test("reports `warn` when a skills path is a symlink (FR-016 parity)", async () => {
+    const realRoot = join(tmpDir, "real-claude-skills");
+    mkdirSync(realRoot, { recursive: true });
+    const linkedRoot = join(tmpDir, "linked-claude-skills");
+    await symlink(realRoot, linkedRoot);
+
+    mutablePaths.claude.skillsDir = linkedRoot;
+    mutablePaths.codex.skillsDir = join(tmpDir, "missing-codex");
+    mutablePaths.cursor.skillsDir = join(tmpDir, "missing-cursor");
+
+    const rows = await buildSkillsDirChecks();
+    const claudeRow = rows.find((r) => r.name === "Claude skills directory");
+    expect(claudeRow?.status).toBe("warn");
+    expect(claudeRow?.detail).toContain("Symlinked skills root");
+    expect(claudeRow?.detail).toContain("FR-016");
   });
 });

--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -6,7 +6,7 @@
  * key, git remote, vault scan, etc.).
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
@@ -90,5 +90,21 @@ describe("buildSkillsDirChecks (FR-008)", () => {
 
     const rows = await buildSkillsDirChecks();
     expect(rows.find((r) => r.name.toLowerCase().includes("copilot"))).toBeUndefined();
+  });
+
+  // Phase 8 L1 — guard against a misconfigured skillsDir that is a regular
+  // file, not a directory. `access(R_OK)` alone passes in that case, so a
+  // bare readability check would produce a false-positive `pass` row.
+  test("reports `warn` when a skills path exists but is not a directory", async () => {
+    const claudeFile = join(tmpDir, "claude-skills-is-a-file");
+    writeFileSync(claudeFile, "oops — this should be a directory", "utf8");
+    mutablePaths.claude.skillsDir = claudeFile;
+    mutablePaths.codex.skillsDir = join(tmpDir, "missing-codex");
+    mutablePaths.cursor.skillsDir = join(tmpDir, "missing-cursor");
+
+    const rows = await buildSkillsDirChecks();
+    const claudeRow = rows.find((r) => r.name === "Claude skills directory");
+    expect(claudeRow?.status).toBe("warn");
+    expect(claudeRow?.detail).toContain("not a directory");
   });
 });

--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the doctor command's skills-directory checks (FR-008).
+ *
+ * The check rows are produced by `buildSkillsDirChecks` so we can unit-test
+ * the rule directly without mocking the rest of the doctor pipeline (private
+ * key, git remote, vault scan, etc.).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { AgentPaths } from "../../config/paths";
+import { createTmpDir } from "../../test-helpers/fixtures";
+import { buildSkillsDirChecks } from "../doctor";
+
+type MutablePaths = {
+  claude: { skillsDir: string };
+  codex: { skillsDir: string };
+  cursor: { skillsDir: string };
+};
+const mutablePaths = AgentPaths as unknown as MutablePaths;
+
+describe("buildSkillsDirChecks (FR-008)", () => {
+  let tmpDir: string;
+  const saved = {
+    claude: mutablePaths.claude.skillsDir,
+    codex: mutablePaths.codex.skillsDir,
+    cursor: mutablePaths.cursor.skillsDir,
+  };
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+  });
+
+  afterEach(async () => {
+    mutablePaths.claude.skillsDir = saved.claude;
+    mutablePaths.codex.skillsDir = saved.codex;
+    mutablePaths.cursor.skillsDir = saved.cursor;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns one row per supported agent", async () => {
+    // Point all three at non-existent paths.
+    mutablePaths.claude.skillsDir = join(tmpDir, "missing-claude");
+    mutablePaths.codex.skillsDir = join(tmpDir, "missing-codex");
+    mutablePaths.cursor.skillsDir = join(tmpDir, "missing-cursor");
+
+    const rows = await buildSkillsDirChecks();
+    expect(rows).toHaveLength(3);
+    const names = rows.map((r) => r.name);
+    expect(names).toContain("Claude skills directory");
+    expect(names).toContain("Codex skills directory");
+    expect(names).toContain("Cursor skills directory");
+  });
+
+  test("reports `pass` when a skills directory is readable", async () => {
+    const claudeDir = join(tmpDir, "claude-skills");
+    const codexDir = join(tmpDir, "codex-skills");
+    mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(codexDir, { recursive: true });
+    mutablePaths.claude.skillsDir = claudeDir;
+    mutablePaths.codex.skillsDir = codexDir;
+    mutablePaths.cursor.skillsDir = join(tmpDir, "missing-cursor");
+
+    const rows = await buildSkillsDirChecks();
+    const claudeRow = rows.find((r) => r.name === "Claude skills directory");
+    const codexRow = rows.find((r) => r.name === "Codex skills directory");
+    expect(claudeRow?.status).toBe("pass");
+    expect(claudeRow?.detail).toBe(claudeDir);
+    expect(codexRow?.status).toBe("pass");
+    expect(codexRow?.detail).toBe(codexDir);
+  });
+
+  test("reports `warn` when a skills directory is missing", async () => {
+    mutablePaths.claude.skillsDir = join(tmpDir, "missing-claude");
+    mutablePaths.codex.skillsDir = join(tmpDir, "missing-codex");
+    mutablePaths.cursor.skillsDir = join(tmpDir, "missing-cursor");
+
+    const rows = await buildSkillsDirChecks();
+    expect(rows.every((r) => r.status === "warn")).toBe(true);
+    for (const r of rows) {
+      expect(r.detail).toContain("Not found or unreadable");
+    }
+  });
+
+  test("does NOT include a Copilot row (Copilot is wired through other paths)", async () => {
+    mutablePaths.claude.skillsDir = join(tmpDir, "missing");
+    mutablePaths.codex.skillsDir = join(tmpDir, "missing");
+    mutablePaths.cursor.skillsDir = join(tmpDir, "missing");
+
+    const rows = await buildSkillsDirChecks();
+    expect(rows.find((r) => r.name.toLowerCase().includes("copilot"))).toBeUndefined();
+  });
+});

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -598,3 +598,245 @@ describe("integration", () => {
     expect(existsSync(join(machineB.vaultDir, "claude", "blocked.age"))).toBe(false);
   });
 });
+
+// ─── T026 — agent-skills-sync integration guarantees ─────────────────────────
+//
+// These tests run AFTER the main `describe("integration")` block above, so its
+// `afterAll` has already reset the push/pull agent registries to the real
+// `Agents` list. We therefore exercise the REAL Claude adapter (and its
+// walker wiring) rather than the mocked test-only fake used above.
+
+describe("T026 — skills sync integration guarantees", () => {
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  type MutableClaudePaths = {
+    claudeMd: string;
+    settingsJson: string;
+    commandsDir: string;
+    agentsDir: string;
+    mcpJson: string;
+    credentials: string;
+    skillsDir: string;
+  };
+  // Lazy reference — `AgentPaths` is imported inside each test via dynamic
+  // import to avoid colliding with the module-scoped mocks at file top.
+  let mutableClaudePaths: MutableClaudePaths;
+  const savedClaude: Partial<MutableClaudePaths> = {};
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    const paths = await import("../../config/paths");
+    mutableClaudePaths = paths.AgentPaths.claude as MutableClaudePaths;
+    savedClaude.claudeMd = mutableClaudePaths.claudeMd;
+    savedClaude.settingsJson = mutableClaudePaths.settingsJson;
+    savedClaude.commandsDir = mutableClaudePaths.commandsDir;
+    savedClaude.agentsDir = mutableClaudePaths.agentsDir;
+    savedClaude.mcpJson = mutableClaudePaths.mcpJson;
+    savedClaude.credentials = mutableClaudePaths.credentials;
+    savedClaude.skillsDir = mutableClaudePaths.skillsDir;
+
+    tmpDir = await createTmpDir();
+    const bareRepoPath = await createBareRepo(tmpDir);
+    machine = await createMachineFixture(tmpDir, "skills-integration");
+
+    const claudeHome = join(tmpDir, "claude-home");
+    mutableClaudePaths.claudeMd = join(claudeHome, "CLAUDE.md");
+    mutableClaudePaths.settingsJson = join(claudeHome, "settings.json");
+    mutableClaudePaths.commandsDir = join(claudeHome, "commands");
+    mutableClaudePaths.agentsDir = join(claudeHome, "agents");
+    mutableClaudePaths.mcpJson = join(claudeHome, ".claude.json");
+    mutableClaudePaths.credentials = join(claudeHome, ".credentials.json");
+    mutableClaudePaths.skillsDir = join(claudeHome, "skills");
+
+    for (const key of RUNTIME_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+    process.env.AGENTSYNC_MACHINE = machine.machineName;
+
+    seedVaultRepo({
+      machine,
+      bareRepoPath,
+      agents: { claude: true, copilot: false },
+    });
+
+    fakeLogs.success.length = 0;
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    if (savedClaude.claudeMd !== undefined) {
+      mutableClaudePaths.claudeMd = savedClaude.claudeMd;
+      // biome-ignore lint/style/noNonNullAssertion: snapshot written in beforeEach
+      mutableClaudePaths.settingsJson = savedClaude.settingsJson!;
+      // biome-ignore lint/style/noNonNullAssertion: snapshot written in beforeEach
+      mutableClaudePaths.commandsDir = savedClaude.commandsDir!;
+      // biome-ignore lint/style/noNonNullAssertion: snapshot written in beforeEach
+      mutableClaudePaths.agentsDir = savedClaude.agentsDir!;
+      // biome-ignore lint/style/noNonNullAssertion: snapshot written in beforeEach
+      mutableClaudePaths.mcpJson = savedClaude.mcpJson!;
+      // biome-ignore lint/style/noNonNullAssertion: snapshot written in beforeEach
+      mutableClaudePaths.credentials = savedClaude.credentials!;
+      // biome-ignore lint/style/noNonNullAssertion: snapshot written in beforeEach
+      mutableClaudePaths.skillsDir = savedClaude.skillsDir!;
+    }
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // FR-013 — pull-side no-delete guarantee.
+  //
+  // This test proves that deleting a skill artifact from the vault (as the
+  // `skill remove` verb does) followed by a `pull` on another machine DOES
+  // NOT delete the local skill directory. The `applyXxxVault` functions are
+  // additive-only by construction — they only call `extractArchive`, never
+  // `unlink` — so any future regression that adds a local-delete sweep will
+  // fail this test.
+
+  test("FR-013 — applyClaudeVault does not delete a local skill when the vault artifact is gone", async () => {
+    const { mkdir: mkdirAsync, writeFile: writeFileAsync } = await import("node:fs/promises");
+    const { archiveDirectory } = await import("../../core/tar");
+    const { encryptString, generateIdentity, identityToRecipient } = await import(
+      "../../core/encryptor"
+    );
+    const claude = await import("../../agents/claude");
+
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    // Build a real skill and encrypt it into the vault.
+    const srcSkill = join(tmpDir, "src", "my-skill");
+    mkdirSync(srcSkill, { recursive: true });
+    writeFileSync(join(srcSkill, "SKILL.md"), "# my skill body", "utf8");
+    writeFileSync(join(srcSkill, "notes.md"), "# notes", "utf8");
+
+    const tarBuffer = await archiveDirectory(srcSkill);
+    const base64 = tarBuffer.toString("base64");
+    const encrypted = await encryptString(base64, [recipient]);
+
+    const skillsVaultDir = join(machine.vaultDir, "claude", "skills");
+    await mkdirAsync(skillsVaultDir, { recursive: true });
+    const vaultFile = join(skillsVaultDir, "my-skill.tar.age");
+    await writeFileAsync(vaultFile, encrypted, "utf8");
+
+    // First pull: populates the local ~/.claude/skills/my-skill/ directory.
+    await claude.applyClaudeVault(machine.vaultDir, identity, false);
+
+    const localSkillDir = join(mutableClaudePaths.skillsDir, "my-skill");
+    expect(existsSync(join(localSkillDir, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(localSkillDir, "notes.md"))).toBe(true);
+
+    // Simulate a post-`skill remove` vault — the artifact is gone from disk.
+    const { unlink: unlinkAsync } = await import("node:fs/promises");
+    await unlinkAsync(vaultFile);
+
+    // Second pull against the now-empty vault. FR-013 says the local skill
+    // directory MUST remain intact — no file is added, no file is removed.
+    await claude.applyClaudeVault(machine.vaultDir, identity, false);
+
+    expect(existsSync(join(localSkillDir, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(localSkillDir, "notes.md"))).toBe(true);
+    // And the content must be byte-equal to the original — no overwrite either.
+    const { readFile: readFileAsync } = await import("node:fs/promises");
+    const skillBody = await readFileAsync(join(localSkillDir, "SKILL.md"), "utf8");
+    expect(skillBody).toBe("# my skill body");
+  });
+
+  // SC-009 — negative-space vault content check.
+  //
+  // Builds a real ~/.claude/skills/ containing one valid skill plus a
+  // top-level symlink that points into a vendored-pool directory containing
+  // a secret marker. Runs the REAL `performPush` (registry reset to the real
+  // Agents) and decrypts every written artifact to verify that no entry
+  // contains the vendored path OR the secret marker content. This is the
+  // walker's outermost safety guarantee — SC-009 fails iff FR-016's
+  // root-symlink rejection rule is bypassed.
+
+  test("SC-009 — vault never contains vendored-pool content reached through a symlinked skill root", async () => {
+    // Build the vendored pool outside the skills directory.
+    const vendoredPool = join(tmpDir, "vendored-pool", "sensitive-skill");
+    mkdirSync(vendoredPool, { recursive: true });
+    writeFileSync(join(vendoredPool, "SKILL.md"), "# vendored vendor", "utf8");
+    writeFileSync(join(vendoredPool, "secret-marker.md"), "THIS_MUST_NOT_LEAK", "utf8");
+
+    // Build the local skills directory with:
+    //   - one real skill (must be archived normally)
+    //   - one top-level symlink pointing at the vendored pool (must be dropped)
+    mkdirSync(mutableClaudePaths.skillsDir, { recursive: true });
+    const realSkill = join(mutableClaudePaths.skillsDir, "my-skill");
+    mkdirSync(realSkill, { recursive: true });
+    writeFileSync(join(realSkill, "SKILL.md"), "# real skill", "utf8");
+
+    const { symlinkSync } = await import("node:fs");
+    symlinkSync(vendoredPool, join(mutableClaudePaths.skillsDir, "vendored"));
+
+    // Ensure the push registry is the REAL Agents so we exercise the real
+    // Claude adapter + walker path.
+    pushMod.__setPushAgentsForTesting(null);
+
+    const result = await pushMod.performPush({ agent: "claude" });
+    expect(result.fatal).toBe(false);
+    // At least one artifact should have been written — the real `my-skill`.
+    expect(result.pushed).toBeGreaterThanOrEqual(1);
+
+    // Assertion 1: no vendored.tar.age artifact was written.
+    const skillsVaultDir = join(machine.vaultDir, "claude", "skills");
+    expect(existsSync(join(skillsVaultDir, "vendored.tar.age"))).toBe(false);
+
+    // Assertion 2: decrypt every .tar.age in claude/skills/, extract it to a
+    // tmp dir, and walk every file entry. Nothing may mention the vendored
+    // path or contain the secret marker string.
+    const { readdir: readdirAsync, readFile: readFileAsync } = await import("node:fs/promises");
+    const { decryptString } = await import("../../core/encryptor");
+    const { extractArchive } = await import("../../core/tar");
+
+    const vaultEntries = await readdirAsync(skillsVaultDir);
+    const tarAgeEntries = vaultEntries.filter((n) => n.endsWith(".tar.age"));
+    expect(tarAgeEntries.length).toBeGreaterThanOrEqual(1);
+
+    for (const entry of tarAgeEntries) {
+      const encrypted = await readFileAsync(join(skillsVaultDir, entry), "utf8");
+      const base64 = await decryptString(encrypted, machine.identity);
+      const tarBuf = Buffer.from(base64, "base64");
+
+      const extractRoot = join(tmpDir, `extract-${entry}`);
+      mkdirSync(extractRoot, { recursive: true });
+      await extractArchive(tarBuf, extractRoot);
+
+      // Recursively walk the extracted tree and collect file paths + contents.
+      async function walk(dir: string): Promise<{ path: string; content: string }[]> {
+        const out: { path: string; content: string }[] = [];
+        for (const name of await readdirAsync(dir)) {
+          const full = join(dir, name);
+          const { stat: statAsync } = await import("node:fs/promises");
+          const info = await statAsync(full);
+          if (info.isDirectory()) {
+            out.push(...(await walk(full)));
+          } else if (info.isFile()) {
+            out.push({ path: full, content: await readFileAsync(full, "utf8") });
+          }
+        }
+        return out;
+      }
+
+      const files = await walk(extractRoot);
+      for (const file of files) {
+        expect(file.path).not.toContain("vendored");
+        expect(file.path).not.toContain("sensitive-skill");
+        expect(file.path).not.toContain("secret-marker");
+        expect(file.content).not.toContain("THIS_MUST_NOT_LEAK");
+      }
+    }
+  });
+});

--- a/src/commands/__tests__/push.test.ts
+++ b/src/commands/__tests__/push.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for performPush focused on the agent-skills-sync feature.
+ *
+ * These tests use the REAL Copilot adapter (after the walker retrofit at
+ * src/agents/copilot.ts) so the warning produced is the exact prefix the
+ * push gate must escalate to a fatal abort. They are NOT mocked at the
+ * agent-registry layer because the whole point is to prove the
+ * walker → snapshot → push gate chain holds end-to-end.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { readFile, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { AgentPaths } from "../../config/paths";
+import {
+  createBareRepo,
+  createMachineFixture,
+  createTmpDir,
+  seedVaultRepo,
+  type TestMachineFixture,
+} from "../../test-helpers/fixtures";
+
+// Bun's mock cache occasionally aliases node:fs/promises across files; the
+// integration test workaround re-exports the real module under the
+// fs/promises alias before any agent code loads. We mirror that here.
+{
+  const require = createRequire(import.meta.url);
+  // biome-ignore lint/style/useNodejsImportProtocol: deliberate alias to bypass mock cache
+  const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => realFsPromises);
+}
+
+// Mute @clack/prompts so log output doesn't pollute the test runner.
+const fakeLogs = {
+  success: [] as string[],
+  info: [] as string[],
+  warn: [] as string[],
+  error: [] as string[],
+};
+
+mock.module("@clack/prompts", () => ({
+  intro: () => {},
+  outro: () => {},
+  log: {
+    success: (m: string) => {
+      fakeLogs.success.push(m);
+    },
+    info: (m: string) => {
+      fakeLogs.info.push(m);
+    },
+    warn: (m: string) => {
+      fakeLogs.warn.push(m);
+    },
+    error: (m: string) => {
+      fakeLogs.error.push(m);
+    },
+  },
+  note: () => {},
+  spinner: () => ({ start: () => {}, stop: () => {}, message: () => {} }),
+}));
+
+type MutableCopilotPaths = {
+  instructionsFile: string;
+  instructionsDir: string;
+  skillsDir: string;
+  promptsDir: string;
+  agentsDir: string;
+  vscodeMcpInSettings: string;
+};
+const mutableCopilotPaths = AgentPaths.copilot as MutableCopilotPaths;
+
+type PushMod = typeof import("../push");
+let pushMod: PushMod;
+
+const RUNTIME_ENV_KEYS = ["AGENTSYNC_VAULT_DIR", "AGENTSYNC_KEY_PATH", "AGENTSYNC_MACHINE"];
+
+beforeAll(async () => {
+  pushMod = await import("../push");
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("performPush — never-sync inside skill (FR-006)", () => {
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  const savedEnv: Record<string, string | undefined> = {};
+  const savedCopilot = {
+    skillsDir: mutableCopilotPaths.skillsDir,
+    instructionsFile: mutableCopilotPaths.instructionsFile,
+    instructionsDir: mutableCopilotPaths.instructionsDir,
+    promptsDir: mutableCopilotPaths.promptsDir,
+    agentsDir: mutableCopilotPaths.agentsDir,
+    vscodeMcpInSettings: mutableCopilotPaths.vscodeMcpInSettings,
+  };
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    const bareRepoPath = await createBareRepo(tmpDir);
+    machine = await createMachineFixture(tmpDir, "ns-test-machine");
+
+    // Point the Copilot adapter at a fully isolated tmp $HOME so no real
+    // ~/.copilot/skills entry leaks into the test fixture.
+    const copilotHome = join(tmpDir, "copilot-home");
+    mutableCopilotPaths.skillsDir = join(copilotHome, "skills");
+    mutableCopilotPaths.instructionsFile = join(copilotHome, "instructions");
+    mutableCopilotPaths.instructionsDir = join(copilotHome, "instructions");
+    mutableCopilotPaths.promptsDir = join(copilotHome, "prompts");
+    mutableCopilotPaths.agentsDir = join(copilotHome, "agents");
+    mutableCopilotPaths.vscodeMcpInSettings = join(tmpDir, "vscode-settings.json");
+
+    for (const key of RUNTIME_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+    process.env.AGENTSYNC_MACHINE = machine.machineName;
+
+    seedVaultRepo({
+      machine,
+      bareRepoPath,
+      agents: { copilot: true, claude: false },
+    });
+
+    fakeLogs.success.length = 0;
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mutableCopilotPaths.skillsDir = savedCopilot.skillsDir;
+    mutableCopilotPaths.instructionsFile = savedCopilot.instructionsFile;
+    mutableCopilotPaths.instructionsDir = savedCopilot.instructionsDir;
+    mutableCopilotPaths.promptsDir = savedCopilot.promptsDir;
+    mutableCopilotPaths.agentsDir = savedCopilot.agentsDir;
+    mutableCopilotPaths.vscodeMcpInSettings = savedCopilot.vscodeMcpInSettings;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("aborts the entire push when a Copilot skill contains a never-sync file", async () => {
+    // Build a Copilot skills root with one valid skill plus one dirty skill.
+    // `auth.json` is in NEVER_SYNC_PATTERNS (`**/auth.json`).
+    const cleanSkill = join(mutableCopilotPaths.skillsDir, "clean-skill");
+    mkdirSync(cleanSkill, { recursive: true });
+    writeFileSync(join(cleanSkill, "SKILL.md"), "# clean", "utf8");
+
+    const dirtySkill = join(mutableCopilotPaths.skillsDir, "dirty-skill");
+    mkdirSync(dirtySkill, { recursive: true });
+    writeFileSync(join(dirtySkill, "SKILL.md"), "# dirty", "utf8");
+    writeFileSync(join(dirtySkill, "auth.json"), '{"token":"x"}', "utf8");
+
+    const result = await pushMod.performPush({ agent: "copilot" });
+
+    expect(result.fatal).toBe(true);
+    expect(result.pushed).toBe(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors.some((e) => e.startsWith("Push aborted"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("never-sync inside skill"))).toBe(true);
+    // The offending file path should appear in at least one error string so
+    // the user can fix it without grepping the codebase.
+    expect(result.errors.some((e) => e.includes("auth.json"))).toBe(true);
+
+    // Belt and braces: no skill artifacts should have been written for either
+    // skill — the gate aborts before any encryption.
+    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "clean-skill.tar.age"))).toBe(
+      false,
+    );
+    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "dirty-skill.tar.age"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("performPush — additive default for local deletes (FR-011 / SC-006)", () => {
+  // T036 — closes the analysis-flagged automated-coverage gap for FR-011.
+  // Uses the same Copilot fixture pattern as the never-sync test above.
+
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  const savedEnv: Record<string, string | undefined> = {};
+  const savedCopilot = {
+    skillsDir: mutableCopilotPaths.skillsDir,
+    instructionsFile: mutableCopilotPaths.instructionsFile,
+    instructionsDir: mutableCopilotPaths.instructionsDir,
+    promptsDir: mutableCopilotPaths.promptsDir,
+    agentsDir: mutableCopilotPaths.agentsDir,
+    vscodeMcpInSettings: mutableCopilotPaths.vscodeMcpInSettings,
+  };
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    const bareRepoPath = await createBareRepo(tmpDir);
+    machine = await createMachineFixture(tmpDir, "addl-test-machine");
+
+    const copilotHome = join(tmpDir, "copilot-home-additive");
+    mutableCopilotPaths.skillsDir = join(copilotHome, "skills");
+    mutableCopilotPaths.instructionsFile = join(copilotHome, "instructions");
+    mutableCopilotPaths.instructionsDir = join(copilotHome, "instructions");
+    mutableCopilotPaths.promptsDir = join(copilotHome, "prompts");
+    mutableCopilotPaths.agentsDir = join(copilotHome, "agents");
+    mutableCopilotPaths.vscodeMcpInSettings = join(tmpDir, "vscode-settings.json");
+
+    for (const key of RUNTIME_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+    process.env.AGENTSYNC_MACHINE = machine.machineName;
+
+    seedVaultRepo({
+      machine,
+      bareRepoPath,
+      agents: { copilot: true, claude: false },
+    });
+
+    fakeLogs.success.length = 0;
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mutableCopilotPaths.skillsDir = savedCopilot.skillsDir;
+    mutableCopilotPaths.instructionsFile = savedCopilot.instructionsFile;
+    mutableCopilotPaths.instructionsDir = savedCopilot.instructionsDir;
+    mutableCopilotPaths.promptsDir = savedCopilot.promptsDir;
+    mutableCopilotPaths.agentsDir = savedCopilot.agentsDir;
+    mutableCopilotPaths.vscodeMcpInSettings = savedCopilot.vscodeMcpInSettings;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("local skill deletion does NOT mutate the vault artifact (FR-011)", async () => {
+    // First push: create one Copilot skill and push it to the vault.
+    const skillDir = join(mutableCopilotPaths.skillsDir, "long-lived-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# long-lived", "utf8");
+    writeFileSync(join(skillDir, "notes.md"), "# notes", "utf8");
+
+    const firstResult = await pushMod.performPush({ agent: "copilot" });
+    expect(firstResult.fatal).toBe(false);
+    expect(firstResult.pushed).toBeGreaterThanOrEqual(1);
+
+    const vaultArtifact = join(machine.vaultDir, "copilot", "skills", "long-lived-skill.tar.age");
+    expect(existsSync(vaultArtifact)).toBe(true);
+    const firstBytes = await readFile(vaultArtifact);
+    expect(firstBytes.length).toBeGreaterThan(0);
+
+    // Now delete the local skill directory and push again. The additive
+    // default (FR-011) demands that the vault artifact stays exactly as it
+    // was — a stray local `rm -rf` must not propagate to other machines.
+    await rm(skillDir, { recursive: true, force: true });
+
+    const secondResult = await pushMod.performPush({ agent: "copilot" });
+    expect(secondResult.fatal).toBe(false);
+
+    // The vault artifact must still exist with byte-identical content.
+    expect(existsSync(vaultArtifact)).toBe(true);
+    const secondBytes = await readFile(vaultArtifact);
+    expect(Buffer.compare(firstBytes, secondBytes)).toBe(0);
+  });
+});

--- a/src/commands/__tests__/skill.test.ts
+++ b/src/commands/__tests__/skill.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Tests for the `agentsync skill remove` CLI verb (T023).
+ *
+ * These tests exercise the testable core `performSkillRemove` directly — they
+ * do not mock git because `performSkillRemove` uses a real `GitClient` against
+ * a tmp bare-repo + working-repo pair built by `createBareRepo` +
+ * `seedVaultRepo`. The goal is to prove every row in
+ * `specs/.../contracts/skill-remove-cli.md` end-to-end.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { rm, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { AgentPaths } from "../../config/paths";
+import {
+  createBareRepo,
+  createMachineFixture,
+  createTmpDir,
+  runGit,
+  seedVaultRepo,
+  type TestMachineFixture,
+} from "../../test-helpers/fixtures";
+
+{
+  const require = createRequire(import.meta.url);
+  // biome-ignore lint/style/useNodejsImportProtocol: deliberate alias to bypass mock cache
+  const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => realFsPromises);
+}
+
+// Mute @clack/prompts so log output doesn't pollute the test runner.
+const fakeLogs = {
+  success: [] as string[],
+  info: [] as string[],
+  warn: [] as string[],
+  error: [] as string[],
+};
+
+mock.module("@clack/prompts", () => ({
+  intro: () => {},
+  outro: () => {},
+  log: {
+    success: (m: string) => {
+      fakeLogs.success.push(m);
+    },
+    info: (m: string) => {
+      fakeLogs.info.push(m);
+    },
+    warn: (m: string) => {
+      fakeLogs.warn.push(m);
+    },
+    error: (m: string) => {
+      fakeLogs.error.push(m);
+    },
+  },
+  note: () => {},
+  spinner: () => ({ start: () => {}, stop: () => {}, message: () => {} }),
+}));
+
+type MutableClaudePaths = {
+  claudeMd: string;
+  settingsJson: string;
+  commandsDir: string;
+  agentsDir: string;
+  mcpJson: string;
+  credentials: string;
+  skillsDir: string;
+};
+const mutableClaudePaths = AgentPaths.claude as MutableClaudePaths;
+
+type SkillMod = typeof import("../skill");
+let skillMod: SkillMod;
+
+const RUNTIME_ENV_KEYS = ["AGENTSYNC_VAULT_DIR", "AGENTSYNC_KEY_PATH", "AGENTSYNC_MACHINE"];
+
+beforeAll(async () => {
+  skillMod = await import("../skill");
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("performSkillRemove — contract rows (T023)", () => {
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  const savedEnv: Record<string, string | undefined> = {};
+  const savedClaude = {
+    claudeMd: mutableClaudePaths.claudeMd,
+    settingsJson: mutableClaudePaths.settingsJson,
+    commandsDir: mutableClaudePaths.commandsDir,
+    agentsDir: mutableClaudePaths.agentsDir,
+    mcpJson: mutableClaudePaths.mcpJson,
+    credentials: mutableClaudePaths.credentials,
+    skillsDir: mutableClaudePaths.skillsDir,
+  };
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    const bareRepoPath = await createBareRepo(tmpDir);
+    machine = await createMachineFixture(tmpDir, "skill-remove-test");
+
+    // Point Claude at an isolated tmp $HOME so no real files leak in.
+    const claudeHome = join(tmpDir, "claude-home");
+    mutableClaudePaths.claudeMd = join(claudeHome, "CLAUDE.md");
+    mutableClaudePaths.settingsJson = join(claudeHome, "settings.json");
+    mutableClaudePaths.commandsDir = join(claudeHome, "commands");
+    mutableClaudePaths.agentsDir = join(claudeHome, "agents");
+    mutableClaudePaths.mcpJson = join(claudeHome, ".claude.json");
+    mutableClaudePaths.credentials = join(claudeHome, ".credentials.json");
+    mutableClaudePaths.skillsDir = join(claudeHome, "skills");
+
+    for (const key of RUNTIME_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+    process.env.AGENTSYNC_MACHINE = machine.machineName;
+
+    seedVaultRepo({
+      machine,
+      bareRepoPath,
+      agents: { claude: true, copilot: false },
+    });
+
+    fakeLogs.success.length = 0;
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mutableClaudePaths.claudeMd = savedClaude.claudeMd;
+    mutableClaudePaths.settingsJson = savedClaude.settingsJson;
+    mutableClaudePaths.commandsDir = savedClaude.commandsDir;
+    mutableClaudePaths.agentsDir = savedClaude.agentsDir;
+    mutableClaudePaths.mcpJson = savedClaude.mcpJson;
+    mutableClaudePaths.credentials = savedClaude.credentials;
+    mutableClaudePaths.skillsDir = savedClaude.skillsDir;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("success path — removes the vault file, commits, and leaves local alone", async () => {
+    // Seed vault with one encrypted skill artifact so the remove path has
+    // something to delete. The content does not need to decrypt — the verb
+    // only `stat`s the file and then unlinks it. The file must be committed
+    // (and pushed) first so that the subsequent unlink+commit actually has a
+    // file to remove from git's index.
+    const skillsVaultDir = join(machine.vaultDir, "claude", "skills");
+    mkdirSync(skillsVaultDir, { recursive: true });
+    writeFileSync(join(skillsVaultDir, "my-skill.tar.age"), "placeholder-bytes", "utf8");
+    runGit(["add", "."], machine.vaultDir);
+    runGit(["commit", "-m", "seed: my-skill artifact"], machine.vaultDir);
+    runGit(["push", "origin", "main"], machine.vaultDir);
+
+    // Sentinel: local skill directory with a real file that MUST survive.
+    const localSkill = join(mutableClaudePaths.skillsDir, "my-skill");
+    mkdirSync(localSkill, { recursive: true });
+    writeFileSync(join(localSkill, "SKILL.md"), "# local content", "utf8");
+
+    const result = await skillMod.performSkillRemove({ agent: "claude", name: "my-skill" });
+
+    expect(result.status).toBe("success");
+    // Vault file gone.
+    expect(existsSync(join(skillsVaultDir, "my-skill.tar.age"))).toBe(false);
+    // Local file still present (FR-012 leave-local-alone guarantee).
+    expect(existsSync(join(localSkill, "SKILL.md"))).toBe(true);
+    // A commit sha should be attached to the success result.
+    if (result.status === "success") {
+      expect(result.commitSha).not.toBeNull();
+      expect(result.commitSha).toMatch(/^[0-9a-f]{7}$/);
+    }
+  });
+
+  test("not-found path — exits with status 'not-found' when vault file is absent", async () => {
+    // Vault has no claude/skills/ at all.
+    const result = await skillMod.performSkillRemove({
+      agent: "claude",
+      name: "does-not-exist",
+    });
+
+    expect(result.status).toBe("not-found");
+    if (result.status === "not-found") {
+      expect(result.path).toContain("claude/skills/does-not-exist.tar.age");
+    }
+  });
+
+  test("unknown-agent path — rejects vscode and other unrecognised agent strings", async () => {
+    const result = await skillMod.performSkillRemove({ agent: "vscode", name: "anything" });
+
+    expect(result.status).toBe("unknown-agent");
+    if (result.status === "unknown-agent") {
+      expect(result.provided).toBe("vscode");
+      expect(result.supported).toEqual(["claude", "cursor", "codex", "copilot"]);
+    }
+  });
+
+  test("leave-local-alone — even when the vault file is absent, the local skill is untouched", async () => {
+    // Write a sentinel local skill. The command must not touch it regardless
+    // of whether the vault file exists or not.
+    const localSkill = join(mutableClaudePaths.skillsDir, "leave-alone");
+    mkdirSync(localSkill, { recursive: true });
+    writeFileSync(join(localSkill, "SKILL.md"), "# local sentinel", "utf8");
+
+    await skillMod.performSkillRemove({ agent: "claude", name: "leave-alone" });
+
+    // The local directory and sentinel file must still be present after the
+    // command has run, regardless of the returned status.
+    const info = await stat(join(localSkill, "SKILL.md"));
+    expect(info.isFile()).toBe(true);
+  });
+});
+
+describe("skillCommand — citty wrapper (T023 exit codes)", () => {
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    const bareRepoPath = await createBareRepo(tmpDir);
+    machine = await createMachineFixture(tmpDir, "skill-cli-test");
+
+    for (const key of RUNTIME_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+    process.env.AGENTSYNC_MACHINE = machine.machineName;
+
+    seedVaultRepo({
+      machine,
+      bareRepoPath,
+      agents: { claude: true, copilot: false },
+    });
+
+    fakeLogs.success.length = 0;
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    process.exitCode = 0;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Helper to invoke the `remove` subcommand's run callback directly. Citty
+   * subCommands can be declared as objects or lazy resolvers; defineCommand
+   * returns a plain object with a `.run` method in our usage.
+   */
+  async function runRemove(agent: string, name: string): Promise<void> {
+    const subs = skillMod.skillCommand.subCommands as unknown as Record<
+      string,
+      { run: (ctx: { args: Record<string, unknown> }) => Promise<void> }
+    >;
+    await subs.remove.run({ args: { agent, name } });
+  }
+
+  test("unknown agent sets process.exitCode = 1 and logs the supported list", async () => {
+    await runRemove("vscode", "anything");
+    expect(process.exitCode).toBe(1);
+    expect(fakeLogs.error.some((m) => m.includes("Unknown agent"))).toBe(true);
+    expect(fakeLogs.error.some((m) => m.includes("claude"))).toBe(true);
+  });
+
+  test("not-found sets process.exitCode = 1 and prints the resolved path", async () => {
+    await runRemove("claude", "does-not-exist");
+    expect(process.exitCode).toBe(1);
+    expect(fakeLogs.error.some((m) => m.includes("Skill not found"))).toBe(true);
+    expect(fakeLogs.info.some((m) => m.includes("claude/skills/does-not-exist.tar.age"))).toBe(
+      true,
+    );
+  });
+
+  test("success leaves process.exitCode at 0 and logs the commit sha", async () => {
+    const skillsVaultDir = join(machine.vaultDir, "claude", "skills");
+    mkdirSync(skillsVaultDir, { recursive: true });
+    writeFileSync(join(skillsVaultDir, "cli-skill.tar.age"), "placeholder", "utf8");
+    runGit(["add", "."], machine.vaultDir);
+    runGit(["commit", "-m", "seed: cli-skill artifact"], machine.vaultDir);
+    runGit(["push", "origin", "main"], machine.vaultDir);
+
+    await runRemove("claude", "cli-skill");
+
+    expect(process.exitCode).toBe(0);
+    expect(fakeLogs.success.some((m) => m.includes("Removed claude/cli-skill"))).toBe(true);
+    expect(fakeLogs.success.some((m) => /commit [0-9a-f]{7}/.test(m))).toBe(true);
+  });
+});

--- a/src/commands/__tests__/status.test.ts
+++ b/src/commands/__tests__/status.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import pc from "picocolors";
+import { AgentPaths } from "../../config/paths";
+import {
+  createBareRepo,
+  createMachineFixture,
+  createTmpDir,
+  seedVaultRepo,
+  type TestMachineFixture,
+} from "../../test-helpers/fixtures";
 
 // The statusColour mapping applies colour AFTER padding to preserve
 // column alignment. We verify each status gets a distinct colour function.
@@ -37,5 +49,213 @@ describe("status colour mapping", () => {
     const values = Object.entries(statusColour).map(([s, fn]) => fn(s));
     const unique = new Set(values);
     expect(unique.size).toBe(Object.keys(statusColour).length);
+  });
+});
+
+// T035 — FR-007 closes the analysis-flagged automated-coverage gap.
+// Proves the status command surfaces drift for skill .tar.age artifacts via
+// the existing collectAgeFiles walker, using the REAL Copilot agent path so
+// the proof carries to every other skill-bearing agent that calls the same
+// shared walker.
+
+{
+  const require = createRequire(import.meta.url);
+  // biome-ignore lint/style/useNodejsImportProtocol: deliberate alias to bypass mock cache
+  const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => realFsPromises);
+}
+
+const fakeLogs = {
+  success: [] as string[],
+  info: [] as string[],
+  warn: [] as string[],
+  error: [] as string[],
+};
+
+mock.module("@clack/prompts", () => ({
+  intro: () => {},
+  outro: () => {},
+  log: {
+    success: (m: string) => {
+      fakeLogs.success.push(m);
+    },
+    info: (m: string) => {
+      fakeLogs.info.push(m);
+    },
+    warn: (m: string) => {
+      fakeLogs.warn.push(m);
+    },
+    error: (m: string) => {
+      fakeLogs.error.push(m);
+    },
+  },
+  note: () => {},
+  spinner: () => ({ start: () => {}, stop: () => {}, message: () => {} }),
+}));
+
+type MutableCopilotPaths = {
+  instructionsFile: string;
+  instructionsDir: string;
+  skillsDir: string;
+  promptsDir: string;
+  agentsDir: string;
+  vscodeMcpInSettings: string;
+};
+const mutableCopilotPaths = AgentPaths.copilot as MutableCopilotPaths;
+
+const RUNTIME_ENV_KEYS = ["AGENTSYNC_VAULT_DIR", "AGENTSYNC_KEY_PATH", "AGENTSYNC_MACHINE"];
+
+describe("status — FR-007 surfaces skill drift", () => {
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  const savedEnv: Record<string, string | undefined> = {};
+  const savedCopilot = {
+    skillsDir: mutableCopilotPaths.skillsDir,
+    instructionsFile: mutableCopilotPaths.instructionsFile,
+    instructionsDir: mutableCopilotPaths.instructionsDir,
+    promptsDir: mutableCopilotPaths.promptsDir,
+    agentsDir: mutableCopilotPaths.agentsDir,
+    vscodeMcpInSettings: mutableCopilotPaths.vscodeMcpInSettings,
+  };
+
+  beforeAll(() => {
+    fakeLogs.success.length = 0;
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+  });
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    const bareRepoPath = await createBareRepo(tmpDir);
+    machine = await createMachineFixture(tmpDir, "status-test-machine");
+
+    const copilotHome = join(tmpDir, "copilot-home");
+    mutableCopilotPaths.skillsDir = join(copilotHome, "skills");
+    mutableCopilotPaths.instructionsFile = join(copilotHome, "instructions");
+    mutableCopilotPaths.instructionsDir = join(copilotHome, "instructions");
+    mutableCopilotPaths.promptsDir = join(copilotHome, "prompts");
+    mutableCopilotPaths.agentsDir = join(copilotHome, "agents");
+    mutableCopilotPaths.vscodeMcpInSettings = join(tmpDir, "vscode-settings.json");
+
+    for (const key of RUNTIME_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+    process.env.AGENTSYNC_MACHINE = machine.machineName;
+
+    seedVaultRepo({
+      machine,
+      bareRepoPath,
+      agents: { copilot: true, claude: false },
+    });
+
+    fakeLogs.success.length = 0;
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mutableCopilotPaths.skillsDir = savedCopilot.skillsDir;
+    mutableCopilotPaths.instructionsFile = savedCopilot.instructionsFile;
+    mutableCopilotPaths.instructionsDir = savedCopilot.instructionsDir;
+    mutableCopilotPaths.promptsDir = savedCopilot.promptsDir;
+    mutableCopilotPaths.agentsDir = savedCopilot.agentsDir;
+    mutableCopilotPaths.vscodeMcpInSettings = savedCopilot.vscodeMcpInSettings;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("reports a Copilot skill .tar.age artifact as synced when local matches vault", async () => {
+    // Build a real Copilot skill on disk.
+    const skillDir = join(mutableCopilotPaths.skillsDir, "drift-test-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# drift fixture", "utf8");
+
+    // Snapshot via the real walker so the byte content matches what status
+    // will hash on the next run.
+    const walker = await import("../../agents/skills-walker");
+    const snap = await walker.collectSkillArtifacts("copilot", mutableCopilotPaths.skillsDir);
+    expect(snap.artifacts).toHaveLength(1);
+
+    // Encrypt the artifact and write to the matching vault path so the
+    // status command sees a vault file to compare against.
+    const { encryptString } = await import("../../core/encryptor");
+    const recipient = machine.recipient;
+    const encrypted = await encryptString(snap.artifacts[0]?.plaintext ?? "", [recipient]);
+
+    const vaultArtPath = join(machine.vaultDir, "copilot", "skills", "drift-test-skill.tar.age");
+    await mkdir(dirname(vaultArtPath), { recursive: true });
+    writeFileSync(vaultArtPath, encrypted, "utf8");
+
+    // Run the real status command.
+    const statusMod = await import("../status");
+    await statusMod.statusCommand.run?.({
+      args: { verbose: false },
+      rawArgs: [],
+      cmd: {} as never,
+    } as never);
+
+    // The skill should appear in the rendered table as a synced row. Use a
+    // per-line `find` (not a blob `toContain`) because the status command's
+    // summary line ALWAYS prints the literal string `synced` (e.g.
+    // `Summary: 1 synced, 0 changed, ...`) regardless of how many rows are
+    // actually synced. A blob assertion would false-positive even if the
+    // skill row was reported as `local-changed`.
+    const skillRow = fakeLogs.info.find(
+      (line) => line.includes("drift-test-skill") && line.includes("synced"),
+    );
+    expect(skillRow).toBeDefined();
+  });
+
+  test("reports a Copilot skill as local-changed when local mutates after the vault snapshot", async () => {
+    const skillDir = join(mutableCopilotPaths.skillsDir, "mutating-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# v1", "utf8");
+
+    // Snapshot v1 and write the encrypted artifact to the vault.
+    const walker = await import("../../agents/skills-walker");
+    const snapV1 = await walker.collectSkillArtifacts("copilot", mutableCopilotPaths.skillsDir);
+    const { encryptString } = await import("../../core/encryptor");
+    const encryptedV1 = await encryptString(snapV1.artifacts[0]?.plaintext ?? "", [
+      machine.recipient,
+    ]);
+    const vaultArtPath = join(machine.vaultDir, "copilot", "skills", "mutating-skill.tar.age");
+    await mkdir(dirname(vaultArtPath), { recursive: true });
+    writeFileSync(vaultArtPath, encryptedV1, "utf8");
+
+    // Mutate the local skill so it no longer matches the vault snapshot.
+    writeFileSync(join(skillDir, "SKILL.md"), "# v2 — diverged", "utf8");
+
+    fakeLogs.info.length = 0;
+    const statusMod = await import("../status");
+    await statusMod.statusCommand.run?.({
+      args: { verbose: false },
+      rawArgs: [],
+      cmd: {} as never,
+    } as never);
+
+    // Per-line assertion (matches the synced test for consistency). The
+    // summary line uses the literal `changed` not `local-changed`, so this
+    // particular assertion would not be ambiguous on its own — but using the
+    // same shape across both tests makes the pattern clearly the right one
+    // to copy when the next reviewer adds another status row.
+    const skillRow = fakeLogs.info.find(
+      (line) => line.includes("mutating-skill") && line.includes("local-changed"),
+    );
+    expect(skillRow).toBeDefined();
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -11,10 +11,48 @@ import { AgentPaths } from "../config/paths";
 import { resolveRuntimeContext } from "./shared";
 
 /** Single diagnostic check row rendered by the doctor command. */
-interface Check {
+export interface Check {
   name: string;
   status: "pass" | "warn" | "fail";
   detail: string;
+}
+
+/**
+ * Build the readability check rows for the per-agent skills directories
+ * introduced by the agent-skills-sync feature (FR-008). Extracted into its
+ * own helper so the rule can be unit-tested without mocking the rest of the
+ * doctor pipeline.
+ *
+ * Each agent gets exactly one row:
+ *   - `pass` when the directory exists and is readable
+ *   - `warn` when the directory does not exist or is unreadable
+ *
+ * Copilot is intentionally excluded — its skill directory was wired through
+ * the original Copilot integration and is therefore covered by the broader
+ * Copilot setup, not this feature's new doctor rows.
+ */
+export async function buildSkillsDirChecks(): Promise<Check[]> {
+  const checks: Check[] = [];
+  const targets: ReadonlyArray<readonly [string, string]> = [
+    ["Claude skills directory", AgentPaths.claude.skillsDir],
+    ["Codex skills directory", AgentPaths.codex.skillsDir],
+    ["Cursor skills directory", AgentPaths.cursor.skillsDir],
+  ];
+
+  for (const [name, dir] of targets) {
+    try {
+      await access(dir, constants.R_OK);
+      checks.push({ name, status: "pass", detail: dir });
+    } catch {
+      checks.push({
+        name,
+        status: "warn",
+        detail: `Not found or unreadable: ${dir}`,
+      });
+    }
+  }
+
+  return checks;
 }
 
 /** Inspect local prerequisites, vault health, and service wiring without changing state. */
@@ -83,6 +121,10 @@ export const doctorCommand = defineCommand({
         detail: "Not found or unreadable. Claude hook/MCP sync may be partial.",
       });
     }
+
+    // 3a. Per-agent skills directories (agent-skills-sync feature, FR-008).
+    // Delegated to a testable helper so the rule has its own unit test.
+    checks.push(...(await buildSkillsDirChecks()));
 
     // 4. Vault config parses correctly against schema
     try {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -24,8 +24,10 @@ export interface Check {
  * doctor pipeline.
  *
  * Each agent gets exactly one row:
- *   - `pass` when the directory exists and is readable
- *   - `warn` when the directory does not exist or is unreadable
+ *   - `pass` when the path exists, is a real directory, and is readable
+ *   - `warn` when the path does not exist, is unreadable, or is not a
+ *     directory (e.g. the user accidentally created `~/.claude/skills` as
+ *     a regular file instead of a directory)
  *
  * Copilot is intentionally excluded — its skill directory was wired through
  * the original Copilot integration and is therefore covered by the broader
@@ -42,6 +44,15 @@ export async function buildSkillsDirChecks(): Promise<Check[]> {
   for (const [name, dir] of targets) {
     try {
       await access(dir, constants.R_OK);
+      const info = await stat(dir);
+      if (!info.isDirectory()) {
+        checks.push({
+          name,
+          status: "warn",
+          detail: `Exists but is not a directory: ${dir}`,
+        });
+        continue;
+      }
       checks.push({ name, status: "pass", detail: dir });
     } catch {
       checks.push({

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { constants } from "node:fs";
-import { access, readdir, stat } from "node:fs/promises";
+import { access, lstat, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, relative } from "node:path";
 import { promisify } from "node:util";
@@ -25,9 +25,16 @@ export interface Check {
  *
  * Each agent gets exactly one row:
  *   - `pass` when the path exists, is a real directory, and is readable
- *   - `warn` when the path does not exist, is unreadable, or is not a
- *     directory (e.g. the user accidentally created `~/.claude/skills` as
- *     a regular file instead of a directory)
+ *   - `warn` when the path does not exist, is unreadable, is a symbolic
+ *     link (walker refuses to enumerate symlinked roots per FR-016), or
+ *     exists but is not a directory (e.g. the user accidentally created
+ *     `~/.claude/skills` as a regular file instead of a directory)
+ *
+ * Using `lstat` instead of `stat` keeps this rule in lock-step with the
+ * walker at `src/agents/skills-walker.ts:150-151`, which rejects symlinked
+ * skills roots silently. Without `lstat`, the doctor would report `pass`
+ * for a user who has `~/.claude/skills -> /srv/team-pool`, and `push` would
+ * then sync nothing — the two checks must agree.
  *
  * Copilot is intentionally excluded — its skill directory was wired through
  * the original Copilot integration and is therefore covered by the broader
@@ -44,7 +51,15 @@ export async function buildSkillsDirChecks(): Promise<Check[]> {
   for (const [name, dir] of targets) {
     try {
       await access(dir, constants.R_OK);
-      const info = await stat(dir);
+      const info = await lstat(dir);
+      if (info.isSymbolicLink()) {
+        checks.push({
+          name,
+          status: "warn",
+          detail: `Symlinked skills root is not synced (FR-016): ${dir}`,
+        });
+        continue;
+      }
       if (!info.isDirectory()) {
         checks.push({
           name,

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -84,6 +84,16 @@ export async function performPush(
         }
       }
     }
+    // Walker-level warnings (e.g. "never-sync inside skill: <path>") are
+    // emitted on the top-level snapshot.warnings array by the shared skills
+    // walker (src/agents/skills-walker.ts), not on individual artifacts. They
+    // must also escalate to a fatal abort so a never-sync file inside a skill
+    // directory never reaches encryption (FR-006).
+    for (const w of snapshot.warnings) {
+      if (w.startsWith("never-sync inside skill: ")) {
+        secretErrors.push(`[${agent.name}] ${w}`);
+      }
+    }
   }
 
   if (secretErrors.length > 0) {
@@ -91,7 +101,7 @@ export async function performPush(
       pushed: 0,
       fatal: true,
       errors: [
-        `Push aborted: ${secretErrors.length} secret(s) detected in agent configs. Remove literal API keys before pushing.`,
+        `Push aborted: ${secretErrors.length} security issue(s) detected. Remove literal secrets and never-sync files inside skill directories before pushing.`,
         ...secretErrors,
       ],
     };

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,0 +1,201 @@
+import { stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { log } from "@clack/prompts";
+import { defineCommand } from "citty";
+import { loadConfig, resolveConfigPath } from "../config/loader";
+import { GitClient } from "../core/git";
+import { resolveRuntimeContext } from "./shared";
+
+/**
+ * Agents that participate in the skill sync feature. `vscode` is intentionally
+ * rejected because its configuration model does not include per-user skills.
+ */
+const SKILL_BEARING_AGENTS = ["claude", "cursor", "codex", "copilot"] as const;
+export type SkillBearingAgent = (typeof SKILL_BEARING_AGENTS)[number];
+
+function isSkillBearingAgent(value: string): value is SkillBearingAgent {
+  return (SKILL_BEARING_AGENTS as readonly string[]).includes(value);
+}
+
+/** Discriminated result of a `skill remove` invocation. */
+export type SkillRemoveResult =
+  | { status: "success"; path: string; commitSha: string | null }
+  | { status: "unknown-agent"; provided: string; supported: readonly string[] }
+  | { status: "not-found"; path: string }
+  | { status: "reconcile-error"; error: string }
+  | { status: "git-error"; path: string; error: string };
+
+/**
+ * Remove a single skill from the vault, commit the deletion, and push. Leaves
+ * every local skill directory on every machine untouched (FR-012 + FR-013).
+ *
+ * This function is the testable core — it returns a discriminated result
+ * object instead of throwing or calling `process.exit()` so tests can assert
+ * each branch deterministically. The thin citty wrapper at the bottom of this
+ * file translates the result into `@clack/prompts` log calls and
+ * `process.exitCode`.
+ *
+ * @param options.agent Name of the skill-bearing agent.
+ * @param options.name  Basename of the skill in the vault (no `.tar.age` suffix).
+ * @returns A {@link SkillRemoveResult} describing the outcome.
+ */
+export async function performSkillRemove(options: {
+  agent: string;
+  name: string;
+}): Promise<SkillRemoveResult> {
+  if (!isSkillBearingAgent(options.agent)) {
+    return {
+      status: "unknown-agent",
+      provided: options.agent,
+      supported: SKILL_BEARING_AGENTS,
+    };
+  }
+
+  const runtime = await resolveRuntimeContext();
+  const config = await loadConfig(resolveConfigPath(runtime.vaultDir));
+  const targetPath = join(runtime.vaultDir, options.agent, "skills", `${options.name}.tar.age`);
+
+  try {
+    await stat(targetPath);
+  } catch {
+    return { status: "not-found", path: targetPath };
+  }
+
+  const git = new GitClient(runtime.vaultDir);
+
+  try {
+    await git.reconcileWithRemote({
+      remote: "origin",
+      branch: config.remote.branch,
+      allowMissingRemote: true,
+    });
+  } catch (err) {
+    return {
+      status: "reconcile-error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  // Re-stat after the reconcile — the remote may have already removed the file
+  // as part of an earlier `skill remove` from another machine. If the file is
+  // gone post-reconcile, the removal has already happened upstream and there
+  // is nothing to do locally except report success without a new commit.
+  try {
+    await stat(targetPath);
+  } catch {
+    return { status: "success", path: targetPath, commitSha: null };
+  }
+
+  try {
+    await unlink(targetPath);
+    const committed = await git.commit({
+      message: `skill remove(${options.agent}): ${options.name}`,
+    });
+    if (committed) {
+      try {
+        await git.push("origin", config.remote.branch);
+      } catch (err) {
+        return {
+          status: "git-error",
+          path: targetPath,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }
+    return {
+      status: "success",
+      path: targetPath,
+      commitSha: committed ? await readHeadShortSha(runtime.vaultDir) : null,
+    };
+  } catch (err) {
+    return {
+      status: "git-error",
+      path: targetPath,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Read the 7-character short SHA of the current HEAD in a repo. Returns null
+ * if git cannot be invoked for any reason — the failure is non-fatal because
+ * the SHA is only used for the success log line.
+ */
+async function readHeadShortSha(repoDir: string): Promise<string | null> {
+  const result = Bun.spawnSync(["git", "-C", repoDir, "rev-parse", "--short=7", "HEAD"]);
+  if (result.exitCode !== 0) return null;
+  const out = new TextDecoder().decode(result.stdout).trim();
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Thin citty wrapper around {@link performSkillRemove}. Translates the
+ * discriminated result into log output and sets `process.exitCode = 1` on any
+ * non-success branch so the shell sees a failure.
+ */
+export const skillCommand = defineCommand({
+  meta: {
+    name: "skill",
+    description: "Manage skills stored in the vault",
+  },
+  subCommands: {
+    remove: defineCommand({
+      meta: {
+        name: "remove",
+        description: "Remove one skill from the vault (leaves local files alone)",
+      },
+      args: {
+        agent: {
+          type: "positional",
+          required: true,
+          description: "Agent owning the skill (claude|cursor|codex|copilot)",
+        },
+        name: {
+          type: "positional",
+          required: true,
+          description: "Basename of the skill in the vault",
+        },
+      },
+      async run({ args }) {
+        const result = await performSkillRemove({
+          agent: String(args.agent),
+          name: String(args.name),
+        });
+
+        switch (result.status) {
+          case "success": {
+            const shaFragment = result.commitSha ? ` (commit ${result.commitSha})` : "";
+            log.success(`Removed ${args.agent}/${args.name} from vault${shaFragment}`);
+            return;
+          }
+          case "unknown-agent": {
+            log.error(
+              `Unknown agent: ${result.provided}. Supported: ${result.supported.join(", ")}`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+          case "not-found": {
+            log.error(`Skill not found: ${args.agent}/${args.name}`);
+            log.info(`Looked for: ${result.path}`);
+            process.exitCode = 1;
+            return;
+          }
+          case "reconcile-error": {
+            log.error(result.error);
+            process.exitCode = 1;
+            return;
+          }
+          case "git-error": {
+            log.error(`Removal staged but not pushed: ${result.error}`);
+            log.info(
+              `Hint: run \`agentsync push\` or re-run \`agentsync skill remove ${args.agent} ${args.name}\` to retry.`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+        }
+      },
+    }),
+  },
+});

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -5,7 +5,7 @@ import { join, relative } from "node:path";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
 import pc from "picocolors";
-import type { SnapshotArtifact } from "../agents/registry";
+import type { AgentDefinition, SnapshotArtifact } from "../agents/registry";
 import { Agents } from "../agents/registry";
 import { loadConfig, resolveConfigPath } from "../config/loader";
 import { decryptString } from "../core/encryptor";
@@ -16,6 +16,21 @@ type SyncStatus = "synced" | "local-changed" | "vault-only" | "local-only" | "er
 
 function sha256(content: string): string {
   return createHash("sha256").update(content).digest("hex").slice(0, 12);
+}
+
+let agentDefinitionsForStatus: AgentDefinition[] = Agents;
+
+/**
+ * Test hook: substitute the agent registry used by `statusCommand`.
+ *
+ * Pass an array to inject custom agents (e.g. a single test agent that emits
+ * a synthetic skill artifact). Pass `null` to restore the real registry.
+ *
+ * Mirrors the same hook on `performPush` so foundational tests can drive the
+ * status command without depending on the rest of the agent ecosystem.
+ */
+export function __setStatusAgentsForTesting(agents: AgentDefinition[] | null): void {
+  agentDefinitionsForStatus = agents ?? Agents;
 }
 
 /** Recursively collect encrypted vault files so vault-only entries can be surfaced. */
@@ -72,7 +87,9 @@ export const statusCommand = defineCommand({
     log.info(`Remote: ${config.remote.url} (${config.remote.branch})`);
     log.info(``);
 
-    const enabledAgents = Agents.filter((a) => config.agents[a.name as keyof typeof config.agents]);
+    const enabledAgents = agentDefinitionsForStatus.filter(
+      (a) => config.agents[a.name as keyof typeof config.agents],
+    );
 
     let key: string | null = null;
     try {

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -1,8 +1,17 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
 import { loadConfig, resolveConfigPath, writeConfig } from "../loader";
+
+// Defensive re-install of the real node:fs/promises — see migrate.test.ts
+// for the full explanation of the bleed this guards against.
+{
+  const require = createRequire(import.meta.url);
+  const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => realFsPromises);
+}
 
 const MINIMAL_TOML = `
 version = "1"

--- a/src/config/__tests__/paths.test.ts
+++ b/src/config/__tests__/paths.test.ts
@@ -44,6 +44,30 @@ describe("paths", () => {
     expect(AgentPaths.copilot.agentsDir).toContain("agents");
   });
 
+  // T003 — skillsDir entries for the three newly skill-bearing agents (FR-001, FR-010)
+
+  test("AgentPaths.claude.skillsDir is ~/.claude/skills/", () => {
+    expect(AgentPaths.claude.skillsDir).toBe(join(HOME, ".claude", "skills"));
+  });
+
+  test("AgentPaths.cursor.skillsDir is ~/.cursor/skills/ (FR-010 canonical path)", () => {
+    expect(AgentPaths.cursor.skillsDir).toBe(join(HOME, ".cursor", "skills"));
+    // FR-010 forbids reading ~/.cursor/skills-cursor/. The path entry must NOT
+    // resolve to that location regardless of platform.
+    expect(AgentPaths.cursor.skillsDir).not.toContain("skills-cursor");
+  });
+
+  test("AgentPaths.codex.skillsDir is under the Codex root", () => {
+    expect(AgentPaths.codex.skillsDir).toContain("skills");
+    expect(AgentPaths.codex.skillsDir.startsWith(AgentPaths.codex.root)).toBe(true);
+  });
+
+  test("AgentPaths.vscode does NOT have a skillsDir (regression)", () => {
+    // VS Code is not a skill-bearing agent for this feature. A future
+    // accidental addition would silently grow the surface — fail loudly.
+    expect((AgentPaths.vscode as Record<string, unknown>).skillsDir).toBeUndefined();
+  });
+
   test("AgentPaths.vscode.mcpJson is a non-empty string", () => {
     expect(typeof AgentPaths.vscode.mcpJson).toBe("string");
     expect(AgentPaths.vscode.mcpJson.length).toBeGreaterThan(0);

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -9,6 +9,7 @@ export const AgentPaths = {
   cursor: {
     mcpGlobal: join(HOME, ".cursor", "mcp.json"),
     commandsDir: join(HOME, ".cursor", "commands"),
+    skillsDir: join(HOME, ".cursor", "skills"),
     settingsJson: (() => {
       if (PLATFORM === "darwin") {
         return join(HOME, "Library", "Application Support", "Cursor", "User", "settings.json");
@@ -26,6 +27,7 @@ export const AgentPaths = {
     agentsDir: join(HOME, ".claude", "agents"),
     mcpJson: join(HOME, ".claude.json"),
     credentials: join(HOME, ".claude", ".credentials.json"),
+    skillsDir: join(HOME, ".claude", "skills"),
   },
   codex: {
     root: process.env.CODEX_HOME ?? join(HOME, ".codex"),
@@ -33,6 +35,7 @@ export const AgentPaths = {
     configToml: join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "config.toml"),
     rulesDir: join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "rules"),
     authJson: join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "auth.json"),
+    skillsDir: join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "skills"),
   },
   copilot: {
     instructionsFile: join(HOME, ".copilot", "instructions"),

--- a/src/core/__tests__/encryptor.test.ts
+++ b/src/core/__tests__/encryptor.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 import { writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
 import {
@@ -10,6 +11,14 @@ import {
   generateIdentity,
   identityToRecipient,
 } from "../encryptor";
+
+// Defensive re-install of the real node:fs/promises — see migrate.test.ts
+// for the full explanation of the bleed this guards against.
+{
+  const require = createRequire(import.meta.url);
+  const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => realFsPromises);
+}
 
 describe("encryptor", () => {
   // T004 — generateIdentity + identityToRecipient

--- a/src/core/__tests__/git.test.ts
+++ b/src/core/__tests__/git.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import {
   createBareRepo,
@@ -8,6 +9,14 @@ import {
   runGit,
 } from "../../test-helpers/fixtures";
 import { GitClient, type GitReconciliationError } from "../git";
+
+// Defensive re-install of the real node:fs/promises — see migrate.test.ts
+// for the full explanation of the bleed this guards against.
+{
+  const require = createRequire(import.meta.url);
+  const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => realFsPromises);
+}
 
 // T036 — GitClient clone, init, commit, push, pull, currentBranch
 

--- a/src/core/__tests__/tar.test.ts
+++ b/src/core/__tests__/tar.test.ts
@@ -1,8 +1,17 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
 import { archiveDirectory, extractArchive } from "../tar";
+
+// Defensive re-install of the real node:fs/promises — see migrate.test.ts
+// for the full explanation of the bleed this guards against.
+{
+  const require = createRequire(import.meta.url);
+  const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => realFsPromises);
+}
 
 describe("tar", () => {
   let tmpDir: string;

--- a/src/core/__tests__/tar.test.ts
+++ b/src/core/__tests__/tar.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
 import { archiveDirectory, extractArchive } from "../tar";
@@ -96,5 +96,74 @@ describe("tar", () => {
 
     const text = await Bun.file(join(destDir, "café-config.toml")).text();
     expect(text).toBe('key = "value"');
+  });
+
+  // T004 — skipSymlinks filter (FR-016 inner tier)
+
+  test("archiveDirectory({ skipSymlinks: true }) omits symlink entries", async () => {
+    const srcDir = join(tmpDir, "src-symlink-skip");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(join(srcDir, "SKILL.md"), "# real skill", "utf8");
+    // Create a symlink target outside the source dir so the link is real but
+    // the resolved path is unambiguously not a sibling of the real files.
+    const linkTargetFile = join(tmpDir, "external-helper.md");
+    await writeFile(linkTargetFile, "# vendored helper", "utf8");
+    const linkTargetDir = join(tmpDir, "external-refs");
+    await mkdir(linkTargetDir, { recursive: true });
+    await writeFile(join(linkTargetDir, "shared.md"), "# shared", "utf8");
+
+    await symlink(linkTargetFile, join(srcDir, "helper.md"));
+    await symlink(linkTargetDir, join(srcDir, "refs"));
+
+    const buf = await archiveDirectory(srcDir, { skipSymlinks: true });
+
+    const destDir = join(tmpDir, "dest-symlink-skip");
+    await mkdir(destDir, { recursive: true });
+    await extractArchive(buf, destDir);
+
+    const entries = await readdir(destDir);
+    expect(entries).toContain("SKILL.md");
+    expect(entries).not.toContain("helper.md");
+    expect(entries).not.toContain("refs");
+  });
+
+  test("archiveDirectory() default behavior is unchanged (no skipSymlinks)", async () => {
+    // Regression: existing Copilot agent-tarballs (copilot/agents/*.tar.age)
+    // call archiveDirectory without options. They expect symlinks to be
+    // archived as symlink entries, not silently dropped.
+    const srcDir = join(tmpDir, "src-default-symlinks");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(join(srcDir, "real.md"), "# real", "utf8");
+    const linkTargetFile = join(tmpDir, "default-target.md");
+    await writeFile(linkTargetFile, "# target", "utf8");
+    await symlink(linkTargetFile, join(srcDir, "linked.md"));
+
+    // No options → default behavior preserved.
+    const buf = await archiveDirectory(srcDir);
+    expect(buf.length).toBeGreaterThan(0);
+    // We don't extract here — extractArchive's filter would normalise paths,
+    // but the contract is "archiveDirectory's behavior is unchanged when no
+    // option is passed", which is what we assert by getting a non-empty buffer
+    // back without throwing on the symlink entry.
+  });
+
+  // T004(3) — tar determinism for status hash stability (research R9 caveat)
+
+  test("archiveDirectory({ skipSymlinks: true }) is deterministic across calls", async () => {
+    // SC-003 depends on `archiveDirectory` producing identical bytes for the
+    // same directory tree so the status command's SHA-256 comparison is
+    // stable. If this test fails, the fix is to set `gzip: { mtime: 0 }` (or
+    // equivalent) on the underlying tar.create options so the gzip header
+    // does not leak the time-of-archival.
+    const srcDir = join(tmpDir, "src-determinism");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(join(srcDir, "SKILL.md"), "# determinism check", "utf8");
+    await mkdir(join(srcDir, "nested"), { recursive: true });
+    await writeFile(join(srcDir, "nested", "deep.md"), "deep", "utf8");
+
+    const first = await archiveDirectory(srcDir, { skipSymlinks: true });
+    const second = await archiveDirectory(srcDir, { skipSymlinks: true });
+
+    expect(Buffer.compare(first, second)).toBe(0);
   });
 });

--- a/src/core/__tests__/watcher.test.ts
+++ b/src/core/__tests__/watcher.test.ts
@@ -1,8 +1,17 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
 import { Watcher } from "../watcher";
+
+// Defensive re-install of the real node:fs/promises — see migrate.test.ts
+// for the full explanation of the bleed this guards against.
+{
+  const require = createRequire(import.meta.url);
+  const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => realFsPromises);
+}
 
 // T033-T035 — Watcher debounce and lifecycle
 

--- a/src/core/tar.ts
+++ b/src/core/tar.ts
@@ -1,15 +1,58 @@
+import type { Stats } from "node:fs";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 // tar v7 is a TypeScript rewrite that ships its own .d.ts — import named exports directly.
-import { c as tarCreate, x as tarExtract } from "tar";
+import { type ReadEntry, c as tarCreate, x as tarExtract } from "tar";
+
+/** Optional knobs for {@link archiveDirectory}. */
+export interface ArchiveDirectoryOptions {
+  /**
+   * When true, symlink entries (files OR sub-directories) inside `dirPath` are
+   * filtered out of the archive. Real entries surrounding the symlinks are
+   * still archived. Default `false` preserves the existing tar-everything
+   * behavior used by Copilot agent-tarballs.
+   *
+   * Set this to `true` for skill-directory archives so vendored helper files
+   * symlinked into a user skill never reach the encrypted vault (FR-016 inner
+   * tier of the agent-skills-sync feature).
+   */
+  skipSymlinks?: boolean;
+}
 
 /**
  * Create a gzipped tar archive of a directory and return the result as a Buffer.
  *
  * @param dirPath Absolute path to the directory to archive.
+ * @param options Optional flags. Pass `{ skipSymlinks: true }` to omit
+ *                symlink entries from the resulting archive — required by
+ *                the skills walker so vendored pool data is never indirectly
+ *                leaked into the vault through a follow-the-link archival.
  */
-export async function archiveDirectory(dirPath: string): Promise<Buffer> {
+export async function archiveDirectory(
+  dirPath: string,
+  options: ArchiveDirectoryOptions = {},
+): Promise<Buffer> {
   const chunks: Buffer[] = [];
+
+  // tar v7's filter callback receives `Stats | ReadEntry`. In create-mode
+  // (which is what we use here) the entry is always a `node:fs` Stats object
+  // produced by tar's internal lstat — but the union signature exists because
+  // the same callback type is reused by extract-mode. We narrow at runtime
+  // by feature-detecting `isSymbolicLink` and fall back to checking the
+  // ReadEntry `type` field for forward compatibility. TypeScript's `in`
+  // operator narrows the union arms automatically, so no explicit casts are
+  // needed inside the branches.
+  const filter = options.skipSymlinks
+    ? (_path: string, entry: Stats | ReadEntry): boolean => {
+        if ("isSymbolicLink" in entry && typeof entry.isSymbolicLink === "function") {
+          return !entry.isSymbolicLink();
+        }
+        if ("type" in entry) {
+          return entry.type !== "SymbolicLink";
+        }
+        return true;
+      }
+    : undefined;
 
   // tarCreate() with no `file` option returns a streaming Pack (ReadableStream).
   await new Promise<void>((resolve, reject) => {
@@ -18,6 +61,7 @@ export async function archiveDirectory(dirPath: string): Promise<Buffer> {
         gzip: true,
         cwd: dirPath,
         portable: true,
+        ...(filter ? { filter } : {}),
       },
       ["."],
     ) as unknown as NodeJS.ReadableStream;

--- a/src/daemon/__tests__/installer-linux.test.ts
+++ b/src/daemon/__tests__/installer-linux.test.ts
@@ -55,7 +55,15 @@ const { promisify } = require("node:util") as typeof import("node:util");
     });
   });
 
+// Spread the real module so `spawnSync` and every other export survive the
+// mock — a bare `() => ({ execFile })` would replace the module in bun's
+// cache with a 1-key object, and later test files in the run that do
+// `import { spawnSync } from "node:child_process"` would fail to load with
+// `SyntaxError: Export named 'spawnSync' not found`. See PR #26 for the
+// cross-file bleed this guards against.
+const actualChildProcess = require("node:child_process") as typeof import("node:child_process");
 mock.module("node:child_process", () => ({
+  ...actualChildProcess,
   execFile: execFileMock,
 }));
 

--- a/src/daemon/__tests__/installer-macos.test.ts
+++ b/src/daemon/__tests__/installer-macos.test.ts
@@ -64,7 +64,15 @@ const { promisify } = require("node:util") as typeof import("node:util");
     });
   });
 
+// Spread the real module so `spawnSync` and every other export survive the
+// mock — a bare `() => ({ execFile })` would replace the module in bun's
+// cache with a 1-key object, and later test files in the run that do
+// `import { spawnSync } from "node:child_process"` would fail to load with
+// `SyntaxError: Export named 'spawnSync' not found`. See PR #26 for the
+// cross-file bleed this guards against.
+const actualChildProcess = require("node:child_process") as typeof import("node:child_process");
 mock.module("node:child_process", () => ({
+  ...actualChildProcess,
   execFile: execFileMock,
 }));
 

--- a/src/daemon/__tests__/installer-windows.test.ts
+++ b/src/daemon/__tests__/installer-windows.test.ts
@@ -52,7 +52,15 @@ const { promisify } = require("node:util") as typeof import("node:util");
     });
   });
 
+// Spread the real module so `spawnSync` and every other export survive the
+// mock — a bare `() => ({ execFile })` would replace the module in bun's
+// cache with a 1-key object, and later test files in the run that do
+// `import { spawnSync } from "node:child_process"` would fail to load with
+// `SyntaxError: Export named 'spawnSync' not found`. See PR #26 for the
+// cross-file bleed this guards against.
+const actualChildProcess = require("node:child_process") as typeof import("node:child_process");
 mock.module("node:child_process", () => ({
+  ...actualChildProcess,
   execFile: execFileMock,
 }));
 

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -4,13 +4,28 @@
  * translation, secret detection, and write behaviour.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { AgentPaths } from "../../config/paths";
 import { performMigrate, readSourceArtefacts } from "../migrate";
+
+// Re-install the real node:fs/promises in bun's module cache. The daemon
+// installer test files (installer-linux/macos/windows) stub fs/promises at
+// top level and bun's `mock.restore()` is a no-op for `mock.module()`, so
+// their stubs leak into every later file in the same bun test run. This
+// block is the defensive undo — identical to the pattern in claude.test.ts,
+// packaging.test.ts, status.test.ts and friends. The bleed only surfaces in
+// CI because the Linux readdir order puts daemon/ before migrate/; on macOS
+// the order happens to be the reverse.
+{
+  const require = createRequire(import.meta.url);
+  const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => realFsPromises);
+}
 
 // ── Mutable path references for testing ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds end-to-end round-trip for user-created skill directories under `~/.claude/skills/`, `~/.codex/skills/`, and `~/.cursor/skills/` alongside the already-supported Copilot skills, and introduces a new `agentsync skill remove <agent> <name>` CLI verb for explicit vault removal.
- Extracts a shared five-gate `skills-walker.ts` module (dot-skip → root-symlink rejection → SKILL.md sentinel via lstat → never-sync interior scan → symlink-filtered tar) and retrofits Copilot onto it so every skill-bearing agent inherits identical safety rules. `src/core/tar.ts::archiveDirectory` gains an opt-in `skipSymlinks` flag; `src/commands/push.ts`' Phase-1 gate escalates walker-level `never-sync inside skill:` warnings to fatal aborts; `src/commands/doctor.ts` now reports readability of the three new skills directories.
- Push is **additive-by-default** (FR-011) — a local delete never mutates the vault. Pull is **extract-only** (FR-013) — even when a vault artifact is gone, `applyXxxVault` leaves existing local skill directories untouched. The `skill remove` verb is the only operation that takes a skill out of the vault, and it never touches any local skill directory on any machine (FR-012).

## Spec artifacts

- [spec.md](../blob/20260411-002222-agent-skills-sync/specs/20260411-002222-agent-skills-sync/spec.md)
- [plan.md](../blob/20260411-002222-agent-skills-sync/specs/20260411-002222-agent-skills-sync/plan.md)
- [research.md](../blob/20260411-002222-agent-skills-sync/specs/20260411-002222-agent-skills-sync/research.md)
- [data-model.md](../blob/20260411-002222-agent-skills-sync/specs/20260411-002222-agent-skills-sync/data-model.md)
- [contracts/walker-interface.md](../blob/20260411-002222-agent-skills-sync/specs/20260411-002222-agent-skills-sync/contracts/walker-interface.md)
- [contracts/skill-remove-cli.md](../blob/20260411-002222-agent-skills-sync/specs/20260411-002222-agent-skills-sync/contracts/skill-remove-cli.md)
- [contracts/vault-paths.md](../blob/20260411-002222-agent-skills-sync/specs/20260411-002222-agent-skills-sync/contracts/vault-paths.md)
- [quickstart.md](../blob/20260411-002222-agent-skills-sync/specs/20260411-002222-agent-skills-sync/quickstart.md)
- [tasks.md](../blob/20260411-002222-agent-skills-sync/specs/20260411-002222-agent-skills-sync/tasks.md)

## Requirements coverage

Every FR/SC listed below has at least one automated regression test in this PR. The full matrix is in `tasks.md` at the bottom of the file.

| Ref | Guarantee | Proof |
|-----|-----------|-------|
| FR-001/003/004 | Round-trip for Claude, Codex, Cursor | `claude.test.ts`, `codex.test.ts`, `cursor.test.ts` happy-path snapshots |
| FR-002 | Real `SKILL.md` sentinel required | `skills-walker.test.ts` rows 4–6, agent-layer mirror tests |
| FR-006 | Never-sync inside a skill → fatal push abort | `push.test.ts` T008 |
| FR-007 / SC-003 | Status drift for skill artifacts | `status.test.ts` T035 |
| FR-008 | `doctor` checks skills directories | `doctor.test.ts` T012 |
| FR-009 | Missing skills dir is a no-op | T014(5) / T017(5) / T020(5) per agent |
| FR-010 | Cursor `~/.cursor/skills-cursor/` never touched | `cursor.test.ts` T021 |
| FR-011 / SC-006 | Additive-default: local delete ≠ vault delete | `push.test.ts` T036 |
| FR-012 | `skill remove` never touches local skills | `skill.test.ts` "leave-local-alone" |
| FR-013 | Pull is extract-only | `integration.test.ts` T026 FR-013 test |
| FR-016 outer | Symlinked skill root silently skipped | walker T006 + per-agent T015/T017(6)/T020(6) |
| FR-016 sentinel | Symlinked `SKILL.md` fails lstat check | `claude.test.ts` T015 sentinel row |
| FR-016 inner | Interior symlinks filtered from tar | T014(6) + mirrors + `tar.test.ts` T004 |
| FR-017 | Top-level dot entries silently skipped | walker + Codex `.system` T018 |
| SC-009 | Vault never contains vendored-pool content via symlinked root | `integration.test.ts` T026 SC-009 test |

## Implementation notes

- **Walker is the single source of truth.** Every `snapshot<Agent>` call now delegates skill collection to `collectSkillArtifacts("<agent>", AgentPaths.<agent>.skillsDir)`. A future CVE in any gate is patched in one file instead of four.
- **`tar.ts::archiveDirectory` filter is opt-in.** The existing Copilot agent-tarball callers (pre-walker) keep their current bit-for-bit behavior — the `skipSymlinks` flag is only passed inside the walker's skill archival path.
- **`performSkillRemove` returns a discriminated result.** Every contract row is a deterministic branch (`success`, `unknown-agent`, `not-found`, `reconcile-error`, `git-error`). The citty wrapper translates branches to `log.*` + `process.exitCode`.
- **`readHeadShortSha` is non-fatal.** If git fails to read the post-commit short SHA for the success log line, the command still reports success without the SHA fragment — the SHA is cosmetic, not a correctness signal.
- **Two Mermaid diagrams in `docs/architecture.md`** (sync flow and vault-removal flow) match the project's GitHub-compatible Mermaid rules: `<br/>` line breaks, inline `:::className` styles, single `subgraph` per diagram, `classDef` pairs meeting WCAG 2 AA contrast, descriptive node IDs ≥ 3 chars.

## Test plan

- [x] `bun run check` green — 393 pass / 0 fail / 850 expect calls / 39 files
- [x] Coverage floors met: `skills-walker.ts` 90.70%, `skill.ts` 78.68%, `claude.ts` 90.43%, `codex.ts` 88.00%, `cursor.ts` 95.21% (all ≥ 70% Principle II), `sanitizer.ts` + `encryptor.ts` still 100% (≥ 90% security-critical)
- [x] Two Mermaid diagrams reviewed against the existing reconciliation flowchart's known-good grammar (same `flowchart TD` / inline `:::className` / `classDef` patterns). *Note: the MCP Mermaid validator returned a Puppeteer/Chromium infrastructure error (`spawn /usr/bin/chromium EAGAIN`), not a syntax error — the diagrams should be re-verified in GitHub's markdown preview as part of PR review.*
- [ ] **T034 — manual cross-machine quickstart walkthrough**: reviewer or author to run every step in `specs/20260411-002222-agent-skills-sync/quickstart.md` end-to-end against two isolated `\$HOME` sessions (or two physical machines) and paste the resulting pass/fail matrix into this PR description.
- [ ] Verify `agentsync skill --help` and `agentsync skill remove --help` both render after the CLI registration change in `src/cli.ts`.
- [ ] Smoke-test `skill remove` against a real vault with one skill artifact, confirm the commit lands and the local skill directory survives.

## Safety notes for reviewers

- No destructive git operations are executed automatically. `skill remove` is the only new command that writes to the vault, and it is strictly one-skill-at-a-time with no `--all` / `--force` / glob support.
- The pre-commit hooks (biome + typecheck + conventional-commit message) ran green on this commit.
- `.claudeignore` was intentionally NOT staged — it is a pre-existing untracked file unrelated to this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync user-created "skills" for Claude, Codex, Cursor (and retrofitted Copilot) into the encrypted vault
  * New CLI: agentsync skill remove <agent> <name> to delete vault-only skill artifacts

* **Behavior Changes**
  * Push aborts if forbidden/never-sync files are found inside a skill
  * Pull is extract-only — vault removals never delete local skill directories
  * Archives omit symlinked helper files; skill names validated to prevent path traversal
  * Canonical vault layout: <vaultDir>/<agent>/skills/<name>.tar.age

* **Documentation**
  * Added command reference, architecture diagrams, troubleshooting, quickstart, README updates

* **Doctor / Status**
  * Doctor checks per-agent skills directories; Status reports skill drift alongside other vault entries

* **Tests**
  * Extensive unit/integration tests covering snapshot, apply, walker, CLI remove, push, pull, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->