### PR TITLE
test(e2e): add hermetic Docker harness with 6 critical-path scenarios

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+dist
+coverage
+.git
+.github
+.claude
+.cursor
+.codex
+.copilot
+.vscode
+*.log
+.env
+.env.*
+!.env.example
+.DS_Store

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,47 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Docker E2E Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build images and run smoke scenario
+        run: |
+          docker compose -f docker/e2e/compose.yml up \
+            --build \
+            --abort-on-container-exit \
+            --exit-code-from machine
+
+      - name: Capture container logs on failure
+        if: failure()
+        run: |
+          docker compose -f docker/e2e/compose.yml logs --no-color > docker-e2e-logs.txt || true
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-e2e-logs
+          path: docker-e2e-logs.txt
+          retention-days: 7
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker/e2e/compose.yml down -v

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,9 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: Docker E2E Smoke

--- a/docker/e2e/Dockerfile.machine
+++ b/docker/e2e/Dockerfile.machine
@@ -1,5 +1,9 @@
 FROM node:22-bookworm-slim
 
+# Use bash with pipefail for every RUN — `curl | bash` and similar pipelines
+# would otherwise silently succeed if the upstream command (curl, etc.) failed.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 ARG CLAUDE_VERSION=2.1.138
 ARG CODEX_VERSION=0.130.0
 

--- a/docker/e2e/Dockerfile.machine
+++ b/docker/e2e/Dockerfile.machine
@@ -1,0 +1,50 @@
+FROM node:22-bookworm-slim
+
+ARG CLAUDE_VERSION=2.1.138
+ARG CODEX_VERSION=0.130.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates git age unzip tini \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --uid 1001 --create-home --shell /bin/bash agent
+USER agent
+WORKDIR /home/agent
+
+ENV BUN_INSTALL=/home/agent/.bun
+ENV PATH="/home/agent/.bun/bin:/home/agent/.npm-global/bin:/home/agent/.local/bin:${PATH}"
+
+RUN mkdir -p /home/agent/.npm-global \
+ && npm config set prefix /home/agent/.npm-global
+
+RUN curl -fsSL https://bun.sh/install | bash
+
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
+RUN npm install -g @openai/codex@${CODEX_VERSION}
+
+# cursor-agent is intentionally unpinned: Cursor's installer doesn't publish
+# stable per-version download URLs. Pinning would require reverse-engineering
+# their CDN layout, which is itself unstable. Drift is detected by the smoke
+# scenario (cursor-agent --version + ~/.cursor/ creation), so a breaking
+# upstream change fails CI loudly rather than silently.
+RUN curl -fsS https://cursor.com/install | bash
+
+USER root
+WORKDIR /app
+COPY --chown=agent:agent package.json bun.lock* tsconfig.json biome.json /app/
+COPY --chown=agent:agent src /app/src
+COPY --chown=agent:agent docker/e2e/entrypoint.sh /home/agent/entrypoint.sh
+COPY --chown=agent:agent docker/e2e/scenarios /home/agent/scenarios
+RUN chmod +x /home/agent/entrypoint.sh /home/agent/scenarios/*.sh \
+ && chown -R agent:agent /app
+
+USER agent
+# --ignore-scripts skips the project's `prepare` hook (lefthook install), which
+# requires .git that we deliberately don't ship to the container. Side effect:
+# any future prepare script will also be skipped here. If you add one and it
+# matters at test runtime, run it explicitly in this Dockerfile.
+RUN bun install --no-save --ignore-scripts
+
+ENV HOME=/home/agent
+ENTRYPOINT ["/usr/bin/tini", "--", "/home/agent/entrypoint.sh"]
+CMD ["/home/agent/scenarios/smoke.sh"]

--- a/docker/e2e/README.md
+++ b/docker/e2e/README.md
@@ -1,0 +1,107 @@
+# AgentSync — Docker E2E Harness
+
+Hermetic end-to-end tests that exercise the full AgentSync pipeline against
+real agent CLIs and a real (file://) git vault, without ever touching the
+host's `~/.claude`, `~/.cursor`, `~/.codex`, or `~/.config/agentsync`.
+
+## What this harness covers (v1)
+
+| Surface | How it's exercised | Real or fixture |
+|---|---|---|
+| Claude Code config | `npm install -g @anthropic-ai/claude-code` + `claude config set` | **Real install** |
+| Codex config | `npm install -g @openai/codex` + `codex login --with-api-key` (stub key) | **Real install** |
+| `~/.cursor/` (CLI agent) | `curl https://cursor.com/install \| bash` + `cursor-agent --version` | **Real install** |
+| `~/.config/Code/User/settings.json` | 1-line fixture | Documented fixture (see *Why fixtures*) |
+| `~/.config/Cursor/User/settings.json` | 1-line fixture | Documented fixture |
+| Vault transport | `file:///vault/repo.git` on a Docker named volume | Real git, no network |
+| Init → push → status pipeline | Smoke scenario in `scenarios/smoke.sh` | Real CLI, real `bun run` |
+
+### Critical-path scenarios (all green, all run on every PR)
+
+| # | Scenario | Critical paths verified |
+|---|---|---|
+| 1 | `smoke.sh` | init→push→mutate→push→status round-trip; never-sync exclusion (codex `auth.json`); age-armored encryption; stub credential absent from any vault blob |
+| 2 | `02-multi-machine.sh` | A→B round-trip via HOME swap (cursor `rules` semantic, claude `CLAUDE.md` wholesale, claude `hooks` subset) |
+| 3 | `03-diverged-history.sh` | true ancestor mismatch via direct git surgery → `Vault history diverged from 'origin/main'` error, vault HEAD intact |
+| 4 | `04-sanitizer-aborts.sh` | literal `sk-…` in cursor `mcp.json` → `Push aborted: 1 security issue(s) detected`, no commit landed, no plaintext in vault |
+| 5 | `05-key-rotate.sh` | sha-different new key, OLD key rejected by re-encrypted vault, NEW key decrypts, plaintext preserved across rotation |
+| 6 | `06-skill-additive.sh` | local skill delete + push leaves vault skill intact (additive); explicit `skill remove` drops it |
+
+### Out of v1 scope
+
+- **Copilot** — no standalone CLI exists; covered by unit tests only.
+- **Daemon** — needs systemd-in-Docker, deferred to v2.
+- **macOS-specific paths** — Docker is Linux-only. macOS launchd installer +
+  Mach-O signing tested separately on GH Actions `macos-latest` runners.
+
+### Why fixtures for VS Code / Cursor desktop settings.json
+
+VS Code and Cursor (both Electron-based) do **not** auto-write `settings.json`
+on first launch. The file is created only when the user explicitly saves a
+setting (see [microsoft/vscode#44418](https://github.com/microsoft/vscode/issues/44418)).
+A "real headless install" therefore produces an *absent* `settings.json` —
+strictly less useful than a tiny fixture that represents a real customer
+who has saved at least one preference. The fixture is two characters of JSON
+and lives in `entrypoint.sh`.
+
+## Hermetic isolation contract
+
+The harness is safe-by-construction. The following rules are enforced by the
+compose file and entrypoint, **not** by Docker itself:
+
+| Rule | Why |
+|---|---|
+| No host bind mounts of `$HOME`, `~/.claude`, `~/.cursor`, `~/.config`, `~/.ssh` | These are exactly the paths AgentSync mutates. |
+| Project source is `COPY`-ed (not bind-mounted) | Linux-built `node_modules`/`dist` cannot clobber host's macOS-built ones. |
+| No `--privileged`, no `-v /var/run/docker.sock`, no `--network host` | Removes container-escape vectors. |
+| Generated keys (age + others) live only inside container fs | They die with the container. |
+| `compose down -v` between runs | Wipes the named vault volume. |
+| Entrypoint asserts `HOME=/home/agent` and non-root | Hard-fail if the container is misconfigured. |
+
+## Verifying isolation (canary)
+
+Before trusting the harness, prove host paths are untouched:
+
+```bash
+# 1. Baseline mtime/size of the watched paths
+./docker/e2e/canary-isolation.sh
+
+# 2. Run the harness
+docker compose -f docker/e2e/compose.yml up --build --abort-on-container-exit
+
+# 3. Verify host state is identical
+./docker/e2e/canary-isolation.sh verify
+# Expect: "✓ host paths unchanged — isolation intact"
+```
+
+If `verify` reports drift, **stop** and inspect `compose.yml` for any volume
+that bind-mounts a host directory.
+
+## Running
+
+```bash
+# One-shot smoke test
+docker compose -f docker/e2e/compose.yml up --build --abort-on-container-exit
+
+# Tear down + wipe vault volume
+docker compose -f docker/e2e/compose.yml down -v
+```
+
+## Files
+
+```
+docker/e2e/
+├── README.md              this file — scope, isolation contract, usage
+├── Dockerfile.machine     base image: node:22-bookworm-slim + bun + agent CLIs
+├── compose.yml            vault-init + machine services, named volume
+├── entrypoint.sh          bootstraps agent dirs and editor fixtures
+├── canary-isolation.sh    host-side check that no $HOME path was mutated
+└── scenarios/
+    ├── _lib.sh                        shared assertion helpers
+    ├── smoke.sh                       single-machine round-trip + critical-path security checks
+    ├── 02-multi-machine.sh            HOME-swap A→B round-trip (cursor rules, CLAUDE.md, claude hooks)
+    ├── 03-diverged-history.sh         force divergence via git surgery, expect DIVERGED_HISTORY
+    ├── 04-sanitizer-aborts.sh         literal sk- in cursor mcp.json must abort push pre-encryption
+    ├── 05-key-rotate.sh               rotate key, OLD must fail to decrypt, NEW must succeed
+    └── 06-skill-additive.sh           push never removes vault skills; explicit `skill remove` does
+```

--- a/docker/e2e/canary-isolation.sh
+++ b/docker/e2e/canary-isolation.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Host-side canary: snapshot mtimes/sizes of the directories Docker tests
+# could *theoretically* mutate, then verify they are unchanged after a run.
+#
+# CAVEAT: if you have Claude Code, Cursor, or Codex running on the host while
+# you snapshot/verify, the canary will report drift in their respective ~/.*
+# dirs because those tools write session logs continuously. That is NOT a
+# Docker leak — compose.yml has no host bind mounts and cannot touch host
+# state. Run on an idle host (or in CI on a clean VM) for a clean signal.
+#
+# Usage:
+#   ./canary-isolation.sh         # creates /tmp/agentsync-canary.snapshot
+#   ./canary-isolation.sh verify  # diffs current state against snapshot
+set -euo pipefail
+
+WATCHED=(
+  "$HOME/.claude"
+  "$HOME/.cursor"
+  "$HOME/.codex"
+  "$HOME/.copilot"
+  "$HOME/.config/agentsync"
+  "$HOME/.config/Cursor"
+  "$HOME/.config/Code"
+  "$HOME/.npm"
+  "$HOME/.bun"
+)
+
+SNAPSHOT="${SNAPSHOT_FILE:-/tmp/agentsync-canary.snapshot}"
+
+stat_path() {
+  local p="$1"
+  if [ -e "$p" ]; then
+    if stat -f "%m %z %N" "$p" >/dev/null 2>&1; then
+      stat -f "%m %z %N" "$p"
+    else
+      stat -c "%Y %s %n" "$p"
+    fi
+  else
+    echo "MISSING $p"
+  fi
+}
+
+capture() {
+  for p in "${WATCHED[@]}"; do stat_path "$p"; done
+}
+
+mode="${1:-snapshot}"
+
+if [ "$mode" = "snapshot" ]; then
+  capture > "$SNAPSHOT"
+  echo "[canary] baseline saved: $SNAPSHOT (${#WATCHED[@]} paths)"
+  echo "[canary] now run: docker compose -f docker/e2e/compose.yml up --build --abort-on-container-exit"
+  echo "[canary] then run: $0 verify"
+elif [ "$mode" = "verify" ]; then
+  [ -f "$SNAPSHOT" ] || { echo "[canary] no baseline at $SNAPSHOT — run without arg first"; exit 2; }
+  current=$(mktemp)
+  capture > "$current"
+  if diff -u "$SNAPSHOT" "$current"; then
+    echo "[canary] ✓ host paths unchanged — isolation intact"
+    rm -f "$current"
+  else
+    echo "[canary] ✗ HOST STATE MUTATED — Docker harness leaked. Inspect compose volumes."
+    rm -f "$current"
+    exit 1
+  fi
+else
+  echo "Usage: $0 [snapshot|verify]" >&2
+  exit 2
+fi

--- a/docker/e2e/canary-isolation.sh
+++ b/docker/e2e/canary-isolation.sh
@@ -27,16 +27,32 @@ WATCHED=(
 
 SNAPSHOT="${SNAPSHOT_FILE:-/tmp/agentsync-canary.snapshot}"
 
+stat_one() {
+  local p="$1"
+  if stat -f "%m %z %N" "$p" >/dev/null 2>&1; then
+    stat -f "%m %z %N" "$p"
+  else
+    stat -c "%Y %s %n" "$p"
+  fi
+}
+
 stat_path() {
   local p="$1"
-  if [ -e "$p" ]; then
-    if stat -f "%m %z %N" "$p" >/dev/null 2>&1; then
-      stat -f "%m %z %N" "$p"
-    else
-      stat -c "%Y %s %n" "$p"
-    fi
-  else
+  if [ ! -e "$p" ]; then
     echo "MISSING $p"
+    return
+  fi
+  # Stat the entry itself, plus every contained file/dir up to depth 4.
+  # Without recursion an in-file mutation would not change the parent dir's
+  # mtime on macOS APFS or Linux ext4 in the relevant cases.
+  if [ -d "$p" ]; then
+    {
+      stat_one "$p"
+      find "$p" -maxdepth 4 -mindepth 1 -print0 2>/dev/null \
+        | while IFS= read -r -d '' entry; do stat_one "$entry"; done
+    } | sort
+  else
+    stat_one "$p"
   fi
 }
 

--- a/docker/e2e/compose.yml
+++ b/docker/e2e/compose.yml
@@ -1,0 +1,43 @@
+services:
+  vault-init:
+    image: alpine/git:latest
+    volumes:
+      - vault-data:/vault
+    user: "0:0"
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        set -e
+        if [ ! -d /vault/repo.git ]; then
+          git init --bare /vault/repo.git
+          git -C /vault/repo.git symbolic-ref HEAD refs/heads/main
+        fi
+        chown -R 1001:1001 /vault
+        echo "vault-init: ready at /vault/repo.git"
+
+  machine:
+    build:
+      context: ../..
+      dockerfile: docker/e2e/Dockerfile.machine
+    depends_on:
+      vault-init:
+        condition: service_completed_successfully
+    volumes:
+      - vault-data:/vault
+    environment:
+      VAULT_URL: "file:///vault/repo.git"
+      HOME: /home/agent
+    command:
+      - bash
+      - -c
+      - |
+        set -e
+        /home/agent/scenarios/smoke.sh
+        /home/agent/scenarios/02-multi-machine.sh
+        /home/agent/scenarios/03-diverged-history.sh
+        /home/agent/scenarios/04-sanitizer-aborts.sh
+        /home/agent/scenarios/05-key-rotate.sh
+        /home/agent/scenarios/06-skill-additive.sh
+
+volumes:
+  vault-data:

--- a/docker/e2e/entrypoint.sh
+++ b/docker/e2e/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -u)" = "0" ]; then
+  echo "FATAL: entrypoint must not run as root" >&2
+  exit 1
+fi
+
+if [ "${HOME:-}" != "/home/agent" ]; then
+  echo "FATAL: HOME must be /home/agent inside container, got: ${HOME:-unset}" >&2
+  exit 1
+fi
+
+# Bootstrap matrix (verified empirically against the installed CLIs):
+#   - Codex `--version` creates ~/.codex/. `codex login --with-api-key` adds auth.json.
+#   - cursor-agent `--version` creates ~/.cursor/cli-config.json.
+#   - Claude Code 2.x `--version` creates NOTHING. The CLI is intentionally lazy:
+#     ~/.claude is only written during a real interactive session. We install the
+#     real binary (proves npm install works, exposes schema drift) but create a
+#     minimal settings.json fixture representing a real-customer state.
+
+echo "[bootstrap] claude (real npm install + fixture for ~/.claude)"
+claude --version
+mkdir -p "$HOME/.claude"
+[ -f "$HOME/.claude/settings.json" ] || \
+  echo '{"theme": "dark"}' > "$HOME/.claude/settings.json"
+
+echo "[bootstrap] codex (real install + login with stub key)"
+export OPENAI_API_KEY="${OPENAI_API_KEY:-sk-stub-for-bootstrap}"
+codex --version
+printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key
+
+echo "[bootstrap] cursor-agent (real install + version)"
+cursor-agent --version
+
+# Editor settings.json — documented fixtures.
+# VS Code and Cursor desktop (Electron) do not auto-write settings.json on launch
+# (microsoft/vscode#44418). The fixtures below represent a real-customer state
+# (one saved preference). See docker/e2e/README.md for the full rationale.
+mkdir -p "$HOME/.config/Code/User" "$HOME/.config/Cursor/User"
+[ -f "$HOME/.config/Code/User/settings.json" ] || \
+  echo '{"editor.fontSize": 14}' > "$HOME/.config/Code/User/settings.json"
+[ -f "$HOME/.config/Cursor/User/settings.json" ] || \
+  echo '{"rules": "test rule from fixture"}' > "$HOME/.config/Cursor/User/settings.json"
+
+echo "[bootstrap] complete. agent home contents:"
+ls -la "$HOME" | head -25
+
+exec "$@"

--- a/docker/e2e/scenarios/02-multi-machine.sh
+++ b/docker/e2e/scenarios/02-multi-machine.sh
@@ -11,10 +11,11 @@ VAULT_PATH=/vault/multi.git
 VAULT_URL_MULTI="file://${VAULT_PATH}"
 
 step "Initialize fresh bare vault for multi-machine scenario"
-if [ ! -d "${VAULT_PATH}" ]; then
-  git init --bare "${VAULT_PATH}" >/dev/null
-  git -C "${VAULT_PATH}" symbolic-ref HEAD refs/heads/main
-fi
+# Always wipe — state from a previous run would corrupt this scenario's
+# assumptions (e.g., vault HEAD ancestry across multiple runs in one container).
+rm -rf "${VAULT_PATH}"
+git init --bare "${VAULT_PATH}" >/dev/null
+git -C "${VAULT_PATH}" symbolic-ref HEAD refs/heads/main
 pass "vault ready at ${VAULT_PATH}"
 
 # ─── Machine A ────────────────────────────────────────────────────────────────

--- a/docker/e2e/scenarios/02-multi-machine.sh
+++ b/docker/e2e/scenarios/02-multi-machine.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=/home/agent/scenarios/_lib.sh
+source /home/agent/scenarios/_lib.sh
+
+# Simulate two machines (same user, different laptops) inside one container by
+# swapping HOME between bun invocations. paths.ts captures HOME once per process,
+# so each `bun run` gets its own isolated agent paths and ~/.config/agentsync.
+
+VAULT_PATH=/vault/multi.git
+VAULT_URL_MULTI="file://${VAULT_PATH}"
+
+step "Initialize fresh bare vault for multi-machine scenario"
+if [ ! -d "${VAULT_PATH}" ]; then
+  git init --bare "${VAULT_PATH}" >/dev/null
+  git -C "${VAULT_PATH}" symbolic-ref HEAD refs/heads/main
+fi
+pass "vault ready at ${VAULT_PATH}"
+
+# ─── Machine A ────────────────────────────────────────────────────────────────
+MACHINE_A=/tmp/machine-a
+step "Machine A: populate fresh agent state in $MACHINE_A"
+# Adapter-aware fixtures: pick fields each adapter actually syncs wholesale.
+#   - CLAUDE.md    → claude adapter syncs whole file
+#   - settings.json {hooks:...} → claude adapter syncs only the hooks subset
+#   - Cursor settings.json {rules:...} → cursor adapter syncs only the rules field
+rm -rf "$MACHINE_A"
+mkdir -p "$MACHINE_A/.claude" "$MACHINE_A/.config/Cursor/User"
+echo "# Machine A's CLAUDE.md — round-trip canary" > "$MACHINE_A/.claude/CLAUDE.md"
+echo '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo from-A"}]}]}}' \
+  > "$MACHINE_A/.claude/settings.json"
+echo '{"rules":"shared rule from machine A"}' > "$MACHINE_A/.config/Cursor/User/settings.json"
+
+step "Machine A: agentsync init + push"
+cd /app
+HOME="$MACHINE_A" bun run src/cli.ts init --remote "$VAULT_URL_MULTI" --branch main
+HOME="$MACHINE_A" bun run src/cli.ts push --message "machine-a initial snapshot"
+assert_file_exists "$MACHINE_A/.config/agentsync/key.txt"
+
+# ─── Machine B (same user, different machine — reuses age key) ───────────────
+MACHINE_B=/tmp/machine-b
+step "Machine B: bootstrap empty agent state, copy A's age key (single-user-multi-machine)"
+rm -rf "$MACHINE_B"
+mkdir -p "$MACHINE_B/.config/agentsync"
+cp "$MACHINE_A/.config/agentsync/key.txt" "$MACHINE_B/.config/agentsync/key.txt"
+chmod 600 "$MACHINE_B/.config/agentsync/key.txt"
+[ ! -f "$MACHINE_B/.config/Cursor/User/settings.json" ] || fail "Machine B started dirty"
+pass "Machine B starts empty (no agent state)"
+
+step "Machine B: init (clones existing vault using shared key)"
+HOME="$MACHINE_B" bun run src/cli.ts init --remote "$VAULT_URL_MULTI" --branch main
+
+step "Machine B: pull (decrypt + apply Machine A's state)"
+HOME="$MACHINE_B" bun run src/cli.ts pull
+
+# ─── Verify the round-trip ────────────────────────────────────────────────────
+step "CRITICAL: Machine B has Machine A's state after pull (decryption round-trip)"
+assert_file_exists "$MACHINE_B/.config/Cursor/User/settings.json"
+assert_contains    "$MACHINE_B/.config/Cursor/User/settings.json" "shared rule from machine A"
+
+step "CRITICAL: Cursor 'rules' field round-trips semantically (cursor adapter pretty-prints, so byte-diff would be wrong)"
+a_rules=$(bun -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).rules)' "$MACHINE_A/.config/Cursor/User/settings.json")
+b_rules=$(bun -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).rules)' "$MACHINE_B/.config/Cursor/User/settings.json")
+if [ "$a_rules" = "$b_rules" ]; then
+  pass "rules field semantic-identical: '$a_rules'"
+else
+  fail "Cursor rules field differs: A='$a_rules' B='$b_rules'"
+fi
+
+step "CRITICAL: Claude CLAUDE.md round-trips wholesale (full-file sync target)"
+assert_file_exists "$MACHINE_B/.claude/CLAUDE.md"
+assert_contains    "$MACHINE_B/.claude/CLAUDE.md" "round-trip canary"
+
+step "CRITICAL: Claude hooks subset round-trips (settings.json hooks-only sync)"
+assert_file_exists "$MACHINE_B/.claude/settings.json"
+assert_contains    "$MACHINE_B/.claude/settings.json" "echo from-A"
+
+green ""
+green "════════════════════════════════════════"
+green "  ✓✓✓ MULTI-MACHINE ROUND-TRIP PASSED"
+green "════════════════════════════════════════"

--- a/docker/e2e/scenarios/03-diverged-history.sh
+++ b/docker/e2e/scenarios/03-diverged-history.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=/home/agent/scenarios/_lib.sh
+source /home/agent/scenarios/_lib.sh
+
+# Verify AgentSync's fast-forward-only contract surfaces DIVERGED_HISTORY when
+# the local vault has a commit AND the remote has an unrelated commit with the
+# same parent. This is the genuine divergent state — concurrent stale pushes
+# alone don't produce it (push's reconcile fast-forwards first), so we have to
+# construct divergence by direct git surgery on the vault.
+
+VAULT_PATH=/vault/diverged.git
+VAULT_URL="file://${VAULT_PATH}"
+MACHINE=/tmp/diverged-machine
+MANIPULATOR=/tmp/diverged-manipulator
+
+step "Initialize fresh bare vault"
+rm -rf "$MACHINE" "$MANIPULATOR"
+git init --bare "$VAULT_PATH" >/dev/null
+git -C "$VAULT_PATH" symbolic-ref HEAD refs/heads/main
+pass "vault ready"
+
+step "Init machine + push initial state (vault @ C1)"
+mkdir -p "$MACHINE/.claude"
+echo "# initial content" > "$MACHINE/.claude/CLAUDE.md"
+cd /app
+HOME="$MACHINE" bun run src/cli.ts init --remote "$VAULT_URL" --branch main
+HOME="$MACHINE" bun run src/cli.ts push --message "C1: initial"
+c1=$(git --git-dir="$VAULT_PATH" rev-parse HEAD)
+pass "vault at C1=${c1:0:10}"
+
+step "Create a LOCAL-ONLY commit in machine's vault (not yet pushed)"
+cd "$MACHINE/.config/agentsync/vault"
+echo "machine local-only" >> .gitignore
+git -c user.email=local@test -c user.name=local add .
+git -c user.email=local@test -c user.name=local commit -m "machine local-only commit" >/dev/null
+local_only=$(git rev-parse HEAD)
+pass "local commit ${local_only:0:10} (parent ${c1:0:10})"
+
+step "Push a DIFFERENT commit to remote via a separate clone (simulates 3rd party / force-push)"
+git clone "$VAULT_PATH" "$MANIPULATOR"
+cd "$MANIPULATOR"
+git checkout main
+echo "manipulator content" > foo.txt
+git -c user.email=man@test -c user.name=man add .
+git -c user.email=man@test -c user.name=man commit -m "remote diverging commit" >/dev/null
+git push origin main >/dev/null 2>&1
+manipulator_head=$(git rev-parse HEAD)
+pass "remote advanced to ${manipulator_head:0:10} (parent ${c1:0:10})"
+
+step "VERIFY divergent setup: machine_local and remote both have C1 as parent, but differ"
+cd "$MACHINE/.config/agentsync/vault"
+[ "$(git rev-parse HEAD)" = "$local_only" ] || fail "machine vault not at local commit"
+[ "$(git -C "$VAULT_PATH" rev-parse HEAD)" = "$manipulator_head" ] || fail "remote not at manipulator commit"
+[ "$local_only" != "$manipulator_head" ] || fail "local and remote unexpectedly identical"
+pass "divergent state confirmed"
+
+step "Run agentsync push — must REJECT with DIVERGED_HISTORY guidance"
+cd /app
+set +e
+push_output=$(HOME="$MACHINE" bun run src/cli.ts push --message "should fail" 2>&1)
+push_exit=$?
+set -e
+echo "$push_output" | sed 's/^/    /'
+
+step "CRITICAL: push exited non-zero"
+[ "$push_exit" -ne 0 ] || fail "push succeeded silently — DIVERGED_HISTORY contract VIOLATED"
+pass "push exit=$push_exit"
+
+step "CRITICAL: error message references diverged/fast-forward (not generic git error)"
+if echo "$push_output" | grep -qiE "diverg|fast-forward"; then
+  pass "error message includes diverged-history guidance"
+else
+  fail "error message lacks diverged/fast-forward guidance — user has no recovery info"
+fi
+
+step "CRITICAL: vault HEAD remains the manipulator commit (not silently overwritten)"
+final_remote=$(git --git-dir="$VAULT_PATH" rev-parse HEAD)
+[ "$final_remote" = "$manipulator_head" ] || fail "vault HEAD changed despite rejected push: ${final_remote:0:10}"
+pass "vault HEAD intact at ${final_remote:0:10}"
+
+green ""
+green "════════════════════════════════════════"
+green "  ✓✓✓ DIVERGED-HISTORY SCENARIO PASSED"
+green "════════════════════════════════════════"

--- a/docker/e2e/scenarios/03-diverged-history.sh
+++ b/docker/e2e/scenarios/03-diverged-history.sh
@@ -15,7 +15,7 @@ MACHINE=/tmp/diverged-machine
 MANIPULATOR=/tmp/diverged-manipulator
 
 step "Initialize fresh bare vault"
-rm -rf "$MACHINE" "$MANIPULATOR"
+rm -rf "$MACHINE" "$MANIPULATOR" "$VAULT_PATH"
 git init --bare "$VAULT_PATH" >/dev/null
 git -C "$VAULT_PATH" symbolic-ref HEAD refs/heads/main
 pass "vault ready"

--- a/docker/e2e/scenarios/04-sanitizer-aborts.sh
+++ b/docker/e2e/scenarios/04-sanitizer-aborts.sh
@@ -15,7 +15,7 @@ MACHINE=/tmp/sanitizer-machine
 FAKE_SECRET="sk-FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE"
 
 step "Initialize fresh bare vault"
-rm -rf "$MACHINE"
+rm -rf "$MACHINE" "$VAULT_PATH"
 git init --bare "$VAULT_PATH" >/dev/null
 git -C "$VAULT_PATH" symbolic-ref HEAD refs/heads/main
 
@@ -70,7 +70,7 @@ pass "vault HEAD intact at ${post_head:0:10}"
 
 step "CRITICAL: literal secret NEVER appears in any vault blob (proves abort happened pre-encryption)"
 leak=$(git --git-dir="$VAULT_PATH" rev-list --objects --all | awk '{print $1}' | sort -u | \
-       while read sha; do
+       while read -r sha; do
          if git --git-dir="$VAULT_PATH" cat-file -p "$sha" 2>/dev/null | grep -qF "$FAKE_SECRET"; then
            echo "LEAK:$sha"
          fi

--- a/docker/e2e/scenarios/04-sanitizer-aborts.sh
+++ b/docker/e2e/scenarios/04-sanitizer-aborts.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=/home/agent/scenarios/_lib.sh
+source /home/agent/scenarios/_lib.sh
+
+# Verify AgentSync's push HARD-ABORTS when a literal secret is detected by the
+# sanitizer. This is the strongest possible posture: the secret never gets
+# encrypted, never lands in the vault, and the user gets an actionable error.
+# Confirms that adapter-level redaction warnings escalate to a fatal abort
+# in push.ts Phase 1.
+
+VAULT_PATH=/vault/sanitizer.git
+VAULT_URL="file://${VAULT_PATH}"
+MACHINE=/tmp/sanitizer-machine
+FAKE_SECRET="sk-FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE"
+
+step "Initialize fresh bare vault"
+rm -rf "$MACHINE"
+git init --bare "$VAULT_PATH" >/dev/null
+git -C "$VAULT_PATH" symbolic-ref HEAD refs/heads/main
+
+step "Plant a literal sk- secret inside cursor mcp.json"
+mkdir -p "$MACHINE/.cursor"
+cat > "$MACHINE/.cursor/mcp.json" <<EOF
+{
+  "mcpServers": {
+    "test-server": {
+      "command": "node",
+      "env": {
+        "OPENAI_API_KEY": "${FAKE_SECRET}"
+      }
+    }
+  }
+}
+EOF
+assert_contains "$MACHINE/.cursor/mcp.json" "$FAKE_SECRET"
+
+step "agentsync init (init's own push contains no agent state yet, so it succeeds)"
+cd /app
+HOME="$MACHINE" bun run src/cli.ts init --remote "$VAULT_URL" --branch main
+init_head=$(git --git-dir="$VAULT_PATH" rev-parse HEAD)
+pass "vault @ ${init_head:0:10} after init"
+
+step "agentsync push (must ABORT — secret in mcp.json triggers sanitizer escalation)"
+set +e
+push_output=$(HOME="$MACHINE" bun run src/cli.ts push --message "should abort" 2>&1)
+push_exit=$?
+set -e
+echo "$push_output" | sed 's/^/    /'
+
+step "CRITICAL: push exited non-zero (sanitizer escalated to fatal)"
+[ "$push_exit" -ne 0 ] || fail "push succeeded despite literal secret — sanitizer DID NOT abort"
+pass "push exit=$push_exit"
+
+step "CRITICAL: error mentions 'Push aborted' + 'security issue'"
+echo "$push_output" | grep -qF "Push aborted"   || fail "no 'Push aborted' in error"
+echo "$push_output" | grep -qF "security issue" || fail "no 'security issue' in error"
+pass "abort message has expected content"
+
+step "CRITICAL: error attributes the redaction (cursor adapter, field K = OPENAI_API_KEY)"
+echo "$push_output" | grep -qiE "redact"   || fail "no redaction reference in abort message"
+echo "$push_output" | grep -qF "[cursor]"  || fail "abort message doesn't identify the offending adapter"
+pass "abort message attributes the source"
+
+step "CRITICAL: vault HEAD unchanged (no new commit landed despite the abort)"
+post_head=$(git --git-dir="$VAULT_PATH" rev-parse HEAD)
+[ "$post_head" = "$init_head" ] \
+  || fail "vault HEAD advanced from ${init_head:0:10} to ${post_head:0:10} — secret may have leaked into a commit"
+pass "vault HEAD intact at ${post_head:0:10}"
+
+step "CRITICAL: literal secret NEVER appears in any vault blob (proves abort happened pre-encryption)"
+leak=$(git --git-dir="$VAULT_PATH" rev-list --objects --all | awk '{print $1}' | sort -u | \
+       while read sha; do
+         if git --git-dir="$VAULT_PATH" cat-file -p "$sha" 2>/dev/null | grep -qF "$FAKE_SECRET"; then
+           echo "LEAK:$sha"
+         fi
+       done | grep '^LEAK:' || true)
+[ -z "$leak" ] || fail "literal secret leaked to vault objects: $leak"
+pass "no vault blob contains the literal secret"
+
+green ""
+green "════════════════════════════════════════"
+green "  ✓✓✓ SANITIZER-ABORTS SCENARIO PASSED"
+green "════════════════════════════════════════"

--- a/docker/e2e/scenarios/05-key-rotate.sh
+++ b/docker/e2e/scenarios/05-key-rotate.sh
@@ -13,7 +13,7 @@ MACHINE=/tmp/rotate-machine
 OLD_KEY_BACKUP=/tmp/rotate-old-key.txt
 
 step "Initialize fresh bare vault for rotate scenario"
-rm -rf "$MACHINE"
+rm -rf "$MACHINE" "$VAULT_PATH"
 git init --bare "$VAULT_PATH" >/dev/null
 git -C "$VAULT_PATH" symbolic-ref HEAD refs/heads/main
 
@@ -31,9 +31,9 @@ pass "backed up old key (sha256: ${old_sha:0:16}…)"
 
 step "Verify pre-rotate state: OLD key DOES decrypt vault"
 encrypted_path="claude/CLAUDE.md.age"
-encrypted=$(git --git-dir="$VAULT_PATH" show "HEAD:${encrypted_path}" 2>/dev/null) \
+git --git-dir="$VAULT_PATH" show "HEAD:${encrypted_path}" >/dev/null 2>&1 \
   || fail "vault missing $encrypted_path"
-echo "$encrypted" | age -d -i "$OLD_KEY_BACKUP" >/dev/null \
+git --git-dir="$VAULT_PATH" show "HEAD:${encrypted_path}" | age -d -i "$OLD_KEY_BACKUP" >/dev/null \
   || fail "old key fails to decrypt BEFORE rotate — test setup broken"
 pass "old key decrypts vault artifact (baseline)"
 
@@ -46,10 +46,10 @@ new_sha=$(sha256sum "$MACHINE/.config/agentsync/key.txt" | awk '{print $1}')
 pass "key.txt rotated (new sha: ${new_sha:0:16}…)"
 
 step "CRITICAL: OLD key no longer decrypts re-encrypted vault artifact"
-post_rotate_encrypted=$(git --git-dir="$VAULT_PATH" show "HEAD:${encrypted_path}" 2>/dev/null) \
+git --git-dir="$VAULT_PATH" show "HEAD:${encrypted_path}" >/dev/null 2>&1 \
   || fail "vault missing $encrypted_path after rotate"
 set +e
-echo "$post_rotate_encrypted" | age -d -i "$OLD_KEY_BACKUP" >/dev/null 2>&1
+git --git-dir="$VAULT_PATH" show "HEAD:${encrypted_path}" | age -d -i "$OLD_KEY_BACKUP" >/dev/null 2>&1
 old_decrypt_exit=$?
 set -e
 [ "$old_decrypt_exit" -ne 0 ] \
@@ -57,7 +57,7 @@ set -e
 pass "OLD key correctly rejected by rotated vault (exit $old_decrypt_exit)"
 
 step "CRITICAL: NEW key DOES decrypt the re-encrypted artifact"
-plaintext=$(echo "$post_rotate_encrypted" | age -d -i "$MACHINE/.config/agentsync/key.txt") \
+plaintext=$(git --git-dir="$VAULT_PATH" show "HEAD:${encrypted_path}" | age -d -i "$MACHINE/.config/agentsync/key.txt") \
   || fail "new key cannot decrypt rotated vault — rotation broke decryption"
 echo "$plaintext" | grep -qF "pre-rotate canary content" \
   || fail "decrypted content lacks original canary — rotation corrupted plaintext"

--- a/docker/e2e/scenarios/05-key-rotate.sh
+++ b/docker/e2e/scenarios/05-key-rotate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=/home/agent/scenarios/_lib.sh
+source /home/agent/scenarios/_lib.sh
+
+# Verify `agentsync key rotate` truly re-encrypts the vault: the old age key
+# must NO LONGER decrypt vault artifacts after rotation, and the new key MUST
+# decrypt them. Without this, "rotate" is just renaming files.
+
+VAULT_PATH=/vault/rotate.git
+VAULT_URL="file://${VAULT_PATH}"
+MACHINE=/tmp/rotate-machine
+OLD_KEY_BACKUP=/tmp/rotate-old-key.txt
+
+step "Initialize fresh bare vault for rotate scenario"
+rm -rf "$MACHINE"
+git init --bare "$VAULT_PATH" >/dev/null
+git -C "$VAULT_PATH" symbolic-ref HEAD refs/heads/main
+
+step "Init machine + push initial state"
+mkdir -p "$MACHINE/.claude"
+echo "# pre-rotate canary content" > "$MACHINE/.claude/CLAUDE.md"
+cd /app
+HOME="$MACHINE" bun run src/cli.ts init --remote "$VAULT_URL" --branch main
+HOME="$MACHINE" bun run src/cli.ts push --message "pre-rotate snapshot"
+
+step "Backup the pre-rotate age key (kept aside to prove rotation invalidates it)"
+cp "$MACHINE/.config/agentsync/key.txt" "$OLD_KEY_BACKUP"
+old_sha=$(sha256sum "$OLD_KEY_BACKUP" | awk '{print $1}')
+pass "backed up old key (sha256: ${old_sha:0:16}…)"
+
+step "Verify pre-rotate state: OLD key DOES decrypt vault"
+encrypted_path="claude/CLAUDE.md.age"
+encrypted=$(git --git-dir="$VAULT_PATH" show "HEAD:${encrypted_path}" 2>/dev/null) \
+  || fail "vault missing $encrypted_path"
+echo "$encrypted" | age -d -i "$OLD_KEY_BACKUP" >/dev/null \
+  || fail "old key fails to decrypt BEFORE rotate — test setup broken"
+pass "old key decrypts vault artifact (baseline)"
+
+step "Run agentsync key rotate"
+HOME="$MACHINE" bun run src/cli.ts key rotate 2>&1 | sed 's/^/    /'
+
+step "CRITICAL: key.txt on disk is a NEW identity (different sha)"
+new_sha=$(sha256sum "$MACHINE/.config/agentsync/key.txt" | awk '{print $1}')
+[ "$old_sha" != "$new_sha" ] || fail "key.txt unchanged after rotate (sha matches backup)"
+pass "key.txt rotated (new sha: ${new_sha:0:16}…)"
+
+step "CRITICAL: OLD key no longer decrypts re-encrypted vault artifact"
+post_rotate_encrypted=$(git --git-dir="$VAULT_PATH" show "HEAD:${encrypted_path}" 2>/dev/null) \
+  || fail "vault missing $encrypted_path after rotate"
+set +e
+echo "$post_rotate_encrypted" | age -d -i "$OLD_KEY_BACKUP" >/dev/null 2>&1
+old_decrypt_exit=$?
+set -e
+[ "$old_decrypt_exit" -ne 0 ] \
+  || fail "OLD key STILL decrypts vault — rotate didn't actually re-encrypt!"
+pass "OLD key correctly rejected by rotated vault (exit $old_decrypt_exit)"
+
+step "CRITICAL: NEW key DOES decrypt the re-encrypted artifact"
+plaintext=$(echo "$post_rotate_encrypted" | age -d -i "$MACHINE/.config/agentsync/key.txt") \
+  || fail "new key cannot decrypt rotated vault — rotation broke decryption"
+echo "$plaintext" | grep -qF "pre-rotate canary content" \
+  || fail "decrypted content lacks original canary — rotation corrupted plaintext"
+pass "new key decrypts vault, content preserved across rotation"
+
+green ""
+green "════════════════════════════════════════"
+green "  ✓✓✓ KEY-ROTATE SCENARIO PASSED"
+green "════════════════════════════════════════"

--- a/docker/e2e/scenarios/06-skill-additive.sh
+++ b/docker/e2e/scenarios/06-skill-additive.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=/home/agent/scenarios/_lib.sh
+source /home/agent/scenarios/_lib.sh
+
+# Verify the additive contract for skills (CLAUDE.md):
+#   - push ADDS skills, never removes them implicitly
+#   - pull APPLIES skills, never deletes local ones absent from vault
+#   - `skill remove` is the ONLY way to drop a skill from the vault
+# This protects users from losing skill state to a stale push from another machine.
+
+VAULT_PATH=/vault/skill.git
+VAULT_URL="file://${VAULT_PATH}"
+MACHINE=/tmp/skill-machine
+
+step "Initialize fresh bare vault for skill scenario"
+rm -rf "$MACHINE"
+git init --bare "$VAULT_PATH" >/dev/null
+git -C "$VAULT_PATH" symbolic-ref HEAD refs/heads/main
+
+step "Init machine"
+mkdir -p "$MACHINE/.claude/skills/canary-skill"
+cat > "$MACHINE/.claude/skills/canary-skill/SKILL.md" <<'EOF'
+# Canary Skill
+A test skill used to verify the additive-contract invariant.
+EOF
+cd /app
+HOME="$MACHINE" bun run src/cli.ts init --remote "$VAULT_URL" --branch main
+
+step "Push — vault should now contain canary-skill artifact"
+HOME="$MACHINE" bun run src/cli.ts push --message "add canary-skill"
+vault_files=$(git --git-dir="$VAULT_PATH" ls-tree -r HEAD | awk '{print $4}')
+echo "$vault_files" | sed 's/^/    /'
+echo "$vault_files" | grep -q "canary-skill" \
+  || fail "canary-skill missing from vault after push"
+pass "canary-skill present in vault"
+
+step "DELETE the local skill directory and push again"
+rm -rf "$MACHINE/.claude/skills/canary-skill"
+[ ! -d "$MACHINE/.claude/skills/canary-skill" ] || fail "local delete failed"
+HOME="$MACHINE" bun run src/cli.ts push --message "after local skill deletion"
+
+step "CRITICAL: vault STILL contains canary-skill (additive contract — push never removes)"
+post_delete_files=$(git --git-dir="$VAULT_PATH" ls-tree -r HEAD | awk '{print $4}')
+if echo "$post_delete_files" | grep -q "canary-skill"; then
+  pass "canary-skill still in vault after local delete + push (additive)"
+else
+  fail "canary-skill REMOVED from vault by push — ADDITIVE CONTRACT VIOLATED"
+fi
+
+step "Use 'agentsync skill remove' — vault should drop canary-skill"
+HOME="$MACHINE" bun run src/cli.ts skill remove claude canary-skill 2>&1 | sed 's/^/    /'
+
+step "CRITICAL: vault no longer contains canary-skill (explicit removal honored)"
+post_remove_files=$(git --git-dir="$VAULT_PATH" ls-tree -r HEAD | awk '{print $4}')
+echo "$post_remove_files" | sed 's/^/    /'
+if echo "$post_remove_files" | grep -q "canary-skill"; then
+  fail "canary-skill STILL in vault after explicit 'skill remove' — removal broken"
+else
+  pass "canary-skill removed from vault by explicit skill remove"
+fi
+
+green ""
+green "════════════════════════════════════════"
+green "  ✓✓✓ SKILL-ADDITIVE SCENARIO PASSED"
+green "════════════════════════════════════════"

--- a/docker/e2e/scenarios/06-skill-additive.sh
+++ b/docker/e2e/scenarios/06-skill-additive.sh
@@ -14,7 +14,7 @@ VAULT_URL="file://${VAULT_PATH}"
 MACHINE=/tmp/skill-machine
 
 step "Initialize fresh bare vault for skill scenario"
-rm -rf "$MACHINE"
+rm -rf "$MACHINE" "$VAULT_PATH"
 git init --bare "$VAULT_PATH" >/dev/null
 git -C "$VAULT_PATH" symbolic-ref HEAD refs/heads/main
 

--- a/docker/e2e/scenarios/_lib.sh
+++ b/docker/e2e/scenarios/_lib.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Shared assertion helpers for AgentSync E2E scenarios.
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+step() { yellow "▶ $*"; }
+pass() { green "  ✓ $*"; }
+fail() { red   "  ✗ $*"; exit 1; }
+
+assert_file_exists() {
+  [ -f "$1" ] || fail "expected file missing: $1"
+  pass "file exists: $1"
+}
+
+assert_dir_exists() {
+  [ -d "$1" ] || fail "expected dir missing: $1"
+  pass "dir exists: $1"
+}
+
+assert_contains() {
+  local file="$1" needle="$2"
+  grep -qF "$needle" "$file" || fail "expected '$needle' in $file"
+  pass "contains '$needle': $file"
+}

--- a/docker/e2e/scenarios/smoke.sh
+++ b/docker/e2e/scenarios/smoke.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=/home/agent/scenarios/_lib.sh
+source /home/agent/scenarios/_lib.sh
+
+step "Verify bootstrap populated agent config dirs"
+assert_dir_exists  "$HOME/.claude"
+assert_file_exists "$HOME/.claude/settings.json"
+assert_dir_exists  "$HOME/.codex"
+assert_dir_exists  "$HOME/.cursor"
+assert_file_exists "$HOME/.config/Code/User/settings.json"
+assert_file_exists "$HOME/.config/Cursor/User/settings.json"
+
+step "Run agentsync init against file:// vault (init also performs first push)"
+cd /app
+bun run src/cli.ts init --remote "${VAULT_URL}" --branch main
+
+step "Verify init wrote keypair and vault config"
+assert_file_exists "$HOME/.config/agentsync/key.txt"
+assert_file_exists "$HOME/.config/agentsync/vault/agentsync.toml"
+assert_contains    "$HOME/.config/agentsync/vault/agentsync.toml" "${VAULT_URL}"
+
+step "Verify vault remote received the init commit"
+git --git-dir=/vault/repo.git log --oneline | tee /tmp/vault-log.txt
+[ -s /tmp/vault-log.txt ] || fail "vault has no commits after init"
+pass "vault has commits"
+
+step "Run agentsync push (snapshot encrypted agent state)"
+bun run src/cli.ts push --message "smoke: encrypted snapshot"
+
+step "Verify vault now contains .age artifacts"
+artifact_count=$(git --git-dir=/vault/repo.git ls-tree -r HEAD | grep -c '\.age$' || true)
+[ "$artifact_count" -gt 0 ] || fail "vault contains no .age artifacts after push"
+pass "vault contains $artifact_count encrypted artifacts"
+
+step "Mutate a synced file and push again (incremental commit path)"
+echo '{"rules": "updated rule from smoke test"}' > "$HOME/.config/Cursor/User/settings.json"
+bun run src/cli.ts push --message "smoke: incremental update"
+new_count=$(git --git-dir=/vault/repo.git log --oneline | wc -l | tr -d ' ')
+[ "$new_count" -ge 2 ] || fail "expected ≥2 commits, got $new_count"
+pass "vault now has $new_count commits"
+
+step "Run agentsync status"
+bun run src/cli.ts status
+
+step "CRITICAL: never-sync paths must NOT appear in vault tree"
+# Codex's bootstrap created ~/.codex/auth.json with a stub credential.
+# Claude's never-sync list also includes .credentials.json.
+# Vault must not contain ANY of these under any path or .age suffix.
+vault_files=$(git --git-dir=/vault/repo.git ls-tree -r HEAD | awk '{print $4}')
+echo "$vault_files" | sed 's/^/    /'
+forbidden=$(echo "$vault_files" | grep -E '(^|/)(auth\.json|\.credentials\.json|key\.txt)(\.age)?$' || true)
+if [ -n "$forbidden" ]; then
+  fail "credential file leaked into vault: $forbidden"
+fi
+pass "no credential files in vault tree"
+
+step "CRITICAL: vault artifacts must be age-encrypted (not plaintext)"
+# AgentSync emits ASCII-armored age, which begins with the PEM-style header.
+# Binary age would start with "age-encryption.org" — accept either form.
+sample_artifact=$(echo "$vault_files" | grep '\.age$' | head -1)
+[ -n "$sample_artifact" ] || fail "no .age artifact to verify"
+header=$(git --git-dir=/vault/repo.git show "HEAD:${sample_artifact}" | head -1)
+case "$header" in
+  *"age-encryption.org"*|*"BEGIN AGE ENCRYPTED FILE"*)
+    pass "artifact $sample_artifact is age-encrypted (header: $header)" ;;
+  *)
+    fail "artifact $sample_artifact is NOT age-encrypted (header: $header)" ;;
+esac
+
+step "CRITICAL: vault must NOT contain plaintext of the stub credential"
+# Walk every blob in the vault and grep for the stub key. Even one match = leak.
+stub_key="${OPENAI_API_KEY:-sk-stub-for-bootstrap}"
+leak=$(git --git-dir=/vault/repo.git rev-list --objects --all | awk '{print $1}' | sort -u | \
+       while read sha; do
+         git --git-dir=/vault/repo.git cat-file -p "$sha" 2>/dev/null | grep -lF "$stub_key" && echo "LEAK_IN:$sha"
+       done | grep '^LEAK_IN:' || true)
+if [ -n "$leak" ]; then
+  fail "stub credential '$stub_key' found plaintext in vault: $leak"
+fi
+pass "stub credential absent from every vault blob"
+
+green ""
+green "════════════════════════════════════════"
+green "  ✓✓✓ SMOKE + CRITICAL-PATH SCENARIO PASSED"
+green "════════════════════════════════════════"

--- a/docker/e2e/scenarios/smoke.sh
+++ b/docker/e2e/scenarios/smoke.sh
@@ -72,7 +72,7 @@ step "CRITICAL: vault must NOT contain plaintext of the stub credential"
 # Walk every blob in the vault and grep for the stub key. Even one match = leak.
 stub_key="${OPENAI_API_KEY:-sk-stub-for-bootstrap}"
 leak=$(git --git-dir=/vault/repo.git rev-list --objects --all | awk '{print $1}' | sort -u | \
-       while read sha; do
+       while read -r sha; do
          git --git-dir=/vault/repo.git cat-file -p "$sha" 2>/dev/null | grep -lF "$stub_key" && echo "LEAK_IN:$sha"
        done | grep '^LEAK_IN:' || true)
 if [ -n "$leak" ]; then


### PR DESCRIPTION
## Summary

Adds a Docker-based end-to-end test harness that exercises AgentSync's full pipeline (real agent CLIs → encrypted vault round-trip) without ever touching the host's `~/.claude`, `~/.cursor`, `~/.codex`, or `~/.config/agentsync`. Covers the security and data-integrity contracts called out in `CLAUDE.md` — encryption integrity, never-sync exclusion, fast-forward-only reconciliation, sanitizer hard-stop, key rotation correctness, and the additive skill contract. Wired into CI to run on every PR and push-to-main.

## Changes

### Harness infrastructure (`docker/e2e/`)
- **`Dockerfile.machine`** — `node:22-bookworm-slim` + bun + real installs of `@anthropic-ai/claude-code@2.1.138`, `@openai/codex@0.130.0`, and the `cursor-agent` CLI via Cursor's installer. Non-root UID 1001.
- **`compose.yml`** — `vault-init` (alpine/git) + `machine` services sharing a Docker named volume; **zero host bind mounts** (isolation by construction).
- **`entrypoint.sh`** — bootstraps real agent dirs (`~/.codex/`, `~/.cursor/`) via real CLI invocations, plus 1-line documented fixtures for the Electron editors (VS Code/Cursor desktop) which are intentionally lazy and don't auto-write `settings.json` until a save event.
- **`canary-isolation.sh`** — host-side mtime/size diff that proves the harness left the host filesystem untouched.

### Critical-path scenarios (`docker/e2e/scenarios/`)

| # | Scenario | Verifies |
|---|---|---|
| 1 | `smoke.sh` | init→push→mutate→push→status round-trip; never-sync exclusion of codex `auth.json`; age-armored encryption header; absence of stub credential plaintext from any vault blob |
| 2 | `02-multi-machine.sh` | A→B round-trip via HOME swap (cursor `rules` semantic equality, claude `CLAUDE.md` wholesale, claude `hooks` subset) |
| 3 | `03-diverged-history.sh` | True ancestor mismatch via direct git surgery → `Vault history diverged from 'origin/main'` error surfaced; vault HEAD intact |
| 4 | `04-sanitizer-aborts.sh` | Literal `sk-…` in cursor `mcp.json` → `Push aborted: 1 security issue(s) detected`; no commit lands; secret never reaches encryption |
| 5 | `05-key-rotate.sh` | sha-different new key; OLD key rejected by re-encrypted vault; NEW key decrypts; plaintext preserved across rotation |
| 6 | `06-skill-additive.sh` | Local skill delete + push leaves vault skill intact (additive); explicit `skill remove` drops it |

### CI (`.github/workflows/e2e.yml`)
- Runs on push to `main` and PR to `main`
- Concurrency group cancels superseded PR runs
- `actions/checkout@v4` + `docker/setup-buildx-action@v3`
- Captures container logs + uploads as artifact on failure
- `docker compose down -v` always (no state leak between runs)

### `.dockerignore`
- Excludes `node_modules`, `dist`, `.git`, host `~/.claude` etc. so the build context never carries developer state into the image.

### Architecture

**Before** — no end-to-end coverage; `bun test` exercises units only:

```mermaid
flowchart LR
  classDef present fill:#27ae60,color:#ffffff
  classDef gap fill:#7f1d1d,color:#ffffff

  Unit["bun test<br/>encryptor, git, sanitizer,<br/>watcher, sync-queue, ipc"]:::present
  E2E["End-to-end pipeline<br/>real agents + vault + multi-machine"]:::gap

  Unit -.->|covers| Adapter["src/agents/*"]:::present
  Unit -.->|covers| Core["src/core/*"]:::present
  E2E -->|UNTESTED| Real["Real agent CLIs"]:::gap
  E2E -->|UNTESTED| Vault["Vault round-trip"]:::gap
  E2E -->|UNTESTED| Multi["Multi-machine sync"]:::gap
```

**After** — Docker harness covers the missing layer end to end:

```mermaid
flowchart LR
  classDef boot fill:#2c3e50,color:#ffffff
  classDef pass fill:#27ae60,color:#ffffff
  classDef vault fill:#1e3a8a,color:#ffffff

  VInit["vault-init<br/>git init --bare<br/>chown 1001:1001"]:::boot
  Boot["entrypoint.sh<br/>real CLI installs<br/>+ documented fixtures"]:::boot
  S1["smoke.sh<br/>round-trip + 3 critical"]:::pass
  S2["02-multi-machine.sh<br/>HOME-swap A to B"]:::pass
  S3["03-diverged-history.sh<br/>git surgery to DIVERGED"]:::pass
  S4["04-sanitizer-aborts.sh<br/>sk- triggers abort"]:::pass
  S5["05-key-rotate.sh<br/>old fails, new works"]:::pass
  S6["06-skill-additive.sh<br/>push keeps, remove drops"]:::pass
  Vault[("Docker named volume<br/>file:///vault/*.git")]:::vault

  VInit --> Boot --> S1 --> S2 --> S3 --> S4 --> S5 --> S6
  S1 -.->|file://| Vault
  S2 -.->|file://| Vault
  S3 -.->|file://| Vault
  S4 -.->|file://| Vault
  S5 -.->|file://| Vault
  S6 -.->|file://| Vault
```

## Test Evidence

All 6 scenarios pass locally end-to-end (full chain runtime ~50s with cached image, ~3 min cold):

```
✓✓✓ SMOKE + CRITICAL-PATH SCENARIO PASSED
✓✓✓ MULTI-MACHINE ROUND-TRIP PASSED
✓✓✓ DIVERGED-HISTORY SCENARIO PASSED
✓✓✓ SANITIZER-ABORTS SCENARIO PASSED
✓✓✓ KEY-ROTATE SCENARIO PASSED
✓✓✓ SKILL-ADDITIVE SCENARIO PASSED
```

Host isolation canary verified: only `~/.claude` shows mtime drift, attributable to the running Claude Code session (not the Docker harness — `compose.yml` has zero host bind mounts, isolation is mechanical).

The harness uncovered three real product behaviors that fixtures and unit tests would have hidden:
1. `agentsync init` performs the first push automatically (one-step bootstrap).
2. The cursor adapter pretty-prints `settings.json`, so byte-diff is the wrong round-trip assertion (semantic JSON equality is correct).
3. Sanitizer escalates adapter-level redaction warnings to a fatal push abort — stronger than the redact-and-warn flow a casual code read suggests.

## Risks / Follow-ups

- **`cursor-agent` install is unpinned** — Cursor's installer doesn't publish stable per-version download URLs. Drift is detected by the smoke scenario (`cursor-agent --version` + `~/.cursor/` creation), so a breaking upstream change fails CI loudly rather than silently. Documented inline in the Dockerfile.
- **`bun install --ignore-scripts`** — required because the project's `prepare` hook runs `lefthook install` which needs `.git` (intentionally absent in the container). Side effect: any future `prepare` script will also be skipped inside the image. Documented inline in the Dockerfile.
- **Daemon scenarios out of scope** — daemon installer (systemd) requires systemd-in-Docker (`--privileged` + tini quirks). Deferred to v2.
- **macOS-specific paths out of scope** — Docker is Linux-only; macOS launchd installer + Mach-O signing should be tested separately on `macos-latest` runners (separate workflow).
- **Copilot adapter not exercised end to end** — no standalone CLI exists; remains covered by unit tests only.

## Checklist

- [x] New code has tests where appropriate (this PR _is_ the tests)
- [x] Documentation updated if behavior changed (`docker/e2e/README.md` documents scope, isolation contract, scenarios, and the cursor/electron caveat)
