### PR TITLE
feat(claude): plugin-aware sync with opt-in marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Start here:
 
 ## What a vault means here
 
-The vault is a normal Git repository that stores encrypted artifacts such as `claude/CLAUDE.md.age`, `claude/skills/<name>.tar.age`, `codex/skills/<name>.tar.age`, `cursor/skills/<name>.tar.age`, and `copilot/skills/<name>.tar.age`. AgentSync never pushes plaintext configs. Files that match hard never-sync patterns or contain literal secrets abort the push before encryption.
+The vault is a normal Git repository that stores encrypted artifacts such as `claude/CLAUDE.md.age`, `claude/skills/<name>.tar.age`, `codex/skills/<name>.tar.age`, `cursor/skills/<name>.tar.age`, and `copilot/skills/<name>.tar.age`. Claude Code plugins under `~/.claude/plugins/<name>/` round-trip as self-contained subtrees at `claude/plugins/<name>/` (manifest, commands, agents, hooks, MCP servers, and plugin-local skills). AgentSync never pushes plaintext configs. Files that match hard never-sync patterns or contain literal secrets abort the push before encryption.
 
 AgentSync never silently removes vault skills — removal is always an explicit user action via `agentsync skill remove <agent> <name>`. Local deletes, pulls, and status checks are all additive by construction, so no background operation can take a skill out of the vault.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,6 +169,62 @@ flowchart TD
 
 This two-flow model is why AgentSync can add and remove skills independently on different machines without any central coordination — every removal is an intentional user action, and every pull is extract-only.
 
+## Claude plugin sync flow
+
+Claude Code organises optional capabilities — commands, sub-agents, hooks, MCP servers, and bundled skills — under `~/.claude/plugins/<name>/`. AgentSync rides each plugin through the vault as a self-contained subtree at `claude/plugins/<name>/`, so installing a plugin on one machine and pulling on another reproduces every artifact under the same plugin namespace.
+
+The plugin walker `collectClaudePlugins` at `src/agents/claude-plugins.ts` mirrors the skills-walker contract: it skips the plugins root if it is missing or a symlink, skips dot-prefixed entries silently, and rejects any entry whose name fails `validatePluginName` (the same defence that guards skill names against `..`, separators, control characters, and the `.`/`..` reserved names). A plugin must contain a real `.claude-plugin/plugin.json` file (lstat-checked so symlinked manifests are rejected) before any of its assets are emitted.
+
+Once a plugin is admitted, `snapshotClaude` emits per-artifact entries:
+
+- `plugin.json.age` — sanitised through `sanitizeClaudePluginManifest` (full-tree secret redaction, structure preserved).
+- `commands/<file>.md.age` and `agents/<file>.md.age` — markdown bundles with sanitiser warnings surfacing redacted secrets.
+- `hooks/<file>.json.age` — sanitised through the existing hooks-only allowlist.
+- `mcp.json.age` — sanitised through `sanitizeClaudePluginMcp` (full structure preserved, secret literals redacted, walker warnings escalated to push aborts).
+- `skills/<name>.tar.age` — tar bundles produced by reusing `collectSkillArtifacts` against the plugin's own `skills/` dir, then re-namespaced into the plugin path.
+
+The opt-in `claudePlugins.syncMarketplace` flag in `agentsync.toml` adds `marketplace.json.age` (sanitised manifest of the global `~/.claude/.claude-plugin/marketplace.json`). The flag is off by default because the catalog can pin third-party sources — teams must opt in explicitly.
+
+On `pull`, `applyClaudePluginsDir` walks `claude/plugins/` in the decrypted vault, validates every directory name *before* any `path.join`, and routes each artifact back to its disk equivalent. Vault entries with names like `..` are rejected with a warning and never reach the filesystem.
+
+<div class="agentsync-darknodes" markdown>
+
+```mermaid
+flowchart TD
+	LocalPlugins["Local plugins<br/>~/.claude/plugins/<name>"]:::action
+	WalkerGate{"Real dir + valid name<br/>+ real plugin.json"}:::decision
+	Manifest["plugin.json<br/>sanitizeClaudePluginManifest"]:::keep
+	Surfaces["commands agents hooks mcp<br/>per-file sanitisers"]:::keep
+	PluginSkills["plugin-local skills<br/>collectSkillArtifacts reused"]:::keep
+	Marketplace{"claudePlugins<br/>syncMarketplace true"}:::decision
+	MarketArt["marketplace.json.age<br/>opt-in only"]:::keep
+	Vault["Vault namespace<br/>claude/plugins/<name>/..."]:::vault
+	Pull["pull command<br/>applyClaudePluginsDir"]:::keep
+	NameGate{"validatePluginName<br/>before any path.join"]}:::decision
+	Apply["restore manifest commands agents<br/>hooks mcp skills"]:::keep
+	SkipSilent["Skipped silently<br/>missing root or invalid"]:::skip
+	Reject["Warning emitted<br/>traversal name rejected"]:::fail
+
+	LocalPlugins --> WalkerGate
+	WalkerGate -- no --> SkipSilent
+	WalkerGate -- yes --> Manifest --> Vault
+	WalkerGate --> Surfaces --> Vault
+	WalkerGate --> PluginSkills --> Vault
+	Marketplace -- yes --> MarketArt --> Vault
+	Vault --> Pull --> NameGate
+	NameGate -- no --> Reject
+	NameGate -- yes --> Apply
+
+	classDef action fill:#1e3a8a,color:#ffffff,stroke:#0f1f4d,stroke-width:1.5px;
+	classDef decision fill:#78350f,color:#ffffff,stroke:#451a03,stroke-width:1.5px;
+	classDef keep fill:#14532d,color:#ffffff,stroke:#0a2d18,stroke-width:1.5px;
+	classDef vault fill:#3730a3,color:#ffffff,stroke:#1e1b6e,stroke-width:1.5px;
+	classDef skip fill:#78350f,color:#ffffff,stroke:#451a03,stroke-width:1.5px;
+	classDef fail fill:#7f1d1d,color:#ffffff,stroke:#7f1d1d,stroke-width:1.5px;
+```
+
+</div>
+
 ## Security boundaries
 
 - `src/core/encryptor.ts` is the boundary for age identity generation, recipient derivation, and string/file encryption.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,7 +200,7 @@ flowchart TD
 	MarketArt["marketplace.json.age<br/>opt-in only"]:::keep
 	Vault["Vault namespace<br/>claude/plugins/<name>/..."]:::vault
 	Pull["pull command<br/>applyClaudePluginsDir"]:::keep
-	NameGate{"validatePluginName<br/>before any path.join"]}:::decision
+	NameGate{"validatePluginName<br/>before any path.join"}:::decision
 	Apply["restore manifest commands agents<br/>hooks mcp skills"]:::keep
 	SkipSilent["Skipped silently<br/>missing root or invalid"]:::skip
 	Reject["Warning emitted<br/>traversal name rejected"]:::fail

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -72,7 +72,7 @@ bunx --package @chrisleekr/agentsync agentsync push --agent claude
 
 **Needs**: initialized vault, configured recipients, readable local agent config.
 
-**Outcome**: encrypted `.age` or `.tar.age` artifacts are committed and pushed to the configured branch. Per-user *skills* under `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, and `~/.copilot/skills/` are packaged through the shared skills walker and land in the matching vault namespace (`claude/skills/<name>.tar.age`, `codex/skills/<name>.tar.age`, `cursor/skills/<name>.tar.age`, `copilot/skills/<name>.tar.age`).
+**Outcome**: encrypted `.age` or `.tar.age` artifacts are committed and pushed to the configured branch. Per-user *skills* under `~/.claude/skills/`, `~/.codex/skills/`, `~/.cursor/skills/`, and `~/.copilot/skills/` are packaged through the shared skills walker and land in the matching vault namespace (`claude/skills/<name>.tar.age`, `codex/skills/<name>.tar.age`, `cursor/skills/<name>.tar.age`, `copilot/skills/<name>.tar.age`). Claude Code plugins under `~/.claude/plugins/<name>/` are bundled per-plugin into `claude/plugins/<name>/` (manifest, commands, agents, hooks, MCP servers, and plugin-local skills). Set `claudePlugins.syncMarketplace = true` in `agentsync.toml` to also sync `~/.claude/.claude-plugin/marketplace.json` (off by default — opt in only when teams trust the catalog's third-party sources).
 
 **Caveats**:
 
@@ -97,7 +97,7 @@ bunx --package @chrisleekr/agentsync agentsync pull --agent cursor
 
 **Needs**: initialized vault, readable private key, reachable Git remote.
 
-**Outcome**: supported local agent files are updated from the vault, including any per-agent skills stored under `claude/skills/`, `codex/skills/`, `cursor/skills/`, and `copilot/skills/`.
+**Outcome**: supported local agent files are updated from the vault, including any per-agent skills stored under `claude/skills/`, `codex/skills/`, `cursor/skills/`, and `copilot/skills/`. Claude Code plugins under `claude/plugins/<name>/` round-trip back to `~/.claude/plugins/<name>/` with all their surfaces restored. `marketplace.json.age` is only applied when `claudePlugins.syncMarketplace = true` is set locally.
 
 **Caveats**:
 

--- a/src/agents/__tests__/claude-plugins.test.ts
+++ b/src/agents/__tests__/claude-plugins.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { createTmpDir } from "../../test-helpers/fixtures";
+import {
+  collectClaudePlugins,
+  InvalidPluginNameError,
+  validatePluginName,
+} from "../claude-plugins";
+
+describe("validatePluginName", () => {
+  test("accepts a typical plugin name", () => {
+    expect(() => validatePluginName("my-plugin")).not.toThrow();
+    expect(() => validatePluginName("acme.toolkit")).not.toThrow();
+  });
+
+  test("rejects empty, dot, dot-dot, leading-dot, separators, and control chars", () => {
+    const bad = ["", ".", "..", ".hidden", "a/b", "a\\b", "ctrl\x00name"];
+    for (const name of bad) {
+      expect(() => validatePluginName(name)).toThrow(InvalidPluginNameError);
+    }
+  });
+});
+
+describe("collectClaudePlugins", () => {
+  let tmpDir: string;
+  let pluginsDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    pluginsDir = join(tmpDir, "plugins");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns empty when plugins root is missing", async () => {
+    const entries = await collectClaudePlugins(pluginsDir);
+    expect(entries).toHaveLength(0);
+  });
+
+  test("returns empty when plugins root is a symlink", async () => {
+    const realRoot = join(tmpDir, "vendored-plugins");
+    mkdirSync(realRoot, { recursive: true });
+    const sample = join(realRoot, "vendored-plugin");
+    mkdirSync(join(sample, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(sample, ".claude-plugin", "plugin.json"), "{}", "utf8");
+    symlinkSync(realRoot, pluginsDir);
+
+    const entries = await collectClaudePlugins(pluginsDir);
+    expect(entries).toHaveLength(0);
+  });
+
+  test("discovers a plugin whose .claude-plugin/plugin.json exists", async () => {
+    const root = join(pluginsDir, "sample-plugin");
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "sample", version: "0.1.0" }),
+      "utf8",
+    );
+
+    const entries = await collectClaudePlugins(pluginsDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.name).toBe("sample-plugin");
+    expect(entries[0]?.paths.commandsDir).toBe(join(root, "commands"));
+  });
+
+  test("skips dot-prefixed entries", async () => {
+    const root = join(pluginsDir, ".system");
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(root, ".claude-plugin", "plugin.json"), "{}", "utf8");
+
+    const entries = await collectClaudePlugins(pluginsDir);
+    expect(entries).toHaveLength(0);
+  });
+
+  test("skips a plugin whose manifest is missing", async () => {
+    const root = join(pluginsDir, "no-manifest-plugin");
+    mkdirSync(root, { recursive: true });
+
+    const entries = await collectClaudePlugins(pluginsDir);
+    expect(entries).toHaveLength(0);
+  });
+
+  test("skips a plugin whose manifest is a symlink", async () => {
+    const realManifest = join(tmpDir, "vendored-manifest.json");
+    writeFileSync(realManifest, "{}", "utf8");
+    const root = join(pluginsDir, "fake-plugin");
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    symlinkSync(realManifest, join(root, ".claude-plugin", "plugin.json"));
+
+    const entries = await collectClaudePlugins(pluginsDir);
+    expect(entries).toHaveLength(0);
+  });
+
+  test("skips a plugin entry that is itself a symlink", async () => {
+    const realPlugin = join(tmpDir, "real-elsewhere");
+    mkdirSync(join(realPlugin, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(realPlugin, ".claude-plugin", "plugin.json"), "{}", "utf8");
+
+    mkdirSync(pluginsDir, { recursive: true });
+    symlinkSync(realPlugin, join(pluginsDir, "linked-plugin"));
+
+    const entries = await collectClaudePlugins(pluginsDir);
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/src/agents/__tests__/claude.test.ts
+++ b/src/agents/__tests__/claude.test.ts
@@ -21,6 +21,8 @@ type MutableClaudePaths = {
   mcpJson: string;
   credentials: string;
   skillsDir: string;
+  pluginsDir: string;
+  marketplaceJson: string;
 };
 
 const testClaudePaths = AgentPaths.claude as MutableClaudePaths;
@@ -59,6 +61,8 @@ describe("snapshotClaude", () => {
     testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
     testClaudePaths.credentials = join(tmpDir, ".credentials.json");
     testClaudePaths.skillsDir = join(tmpDir, "skills");
+    testClaudePaths.pluginsDir = join(tmpDir, "plugins");
+    testClaudePaths.marketplaceJson = join(tmpDir, ".claude-plugin", "marketplace.json");
   });
 
   afterEach(async () => {
@@ -257,6 +261,8 @@ describe("apply* functions", () => {
     testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
     testClaudePaths.credentials = join(tmpDir, ".credentials.json");
     testClaudePaths.skillsDir = join(tmpDir, "skills");
+    testClaudePaths.pluginsDir = join(tmpDir, "plugins");
+    testClaudePaths.marketplaceJson = join(tmpDir, ".claude-plugin", "marketplace.json");
   });
 
   afterEach(async () => {
@@ -349,6 +355,8 @@ describe("applyClaudeVault dryRun", () => {
     testClaudePaths.mcpJson = join(tmpDir, "apply", ".claude.json");
     testClaudePaths.credentials = join(tmpDir, "apply", ".credentials.json");
     testClaudePaths.skillsDir = join(tmpDir, "apply", "skills");
+    testClaudePaths.pluginsDir = join(tmpDir, "apply", "plugins");
+    testClaudePaths.marketplaceJson = join(tmpDir, "apply", ".claude-plugin", "marketplace.json");
   });
 
   afterEach(async () => {
@@ -487,5 +495,277 @@ describe("applyClaudeVault dryRun", () => {
     // (testClaudePaths.claudeMd). If the validator were bypassed, the payload
     // would land exactly on top of it.
     expect(leakedExists).toBeFalse();
+  });
+});
+
+// Claude Code plugin support (issue #31) — snapshot, round-trip, marketplace,
+// and adversarial vault entries.
+
+describe("Claude plugin sync", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    testClaudePaths.claudeMd = join(tmpDir, "CLAUDE.md");
+    testClaudePaths.settingsJson = join(tmpDir, "settings.json");
+    testClaudePaths.commandsDir = join(tmpDir, "commands");
+    testClaudePaths.agentsDir = join(tmpDir, "agents");
+    testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
+    testClaudePaths.credentials = join(tmpDir, ".credentials.json");
+    testClaudePaths.skillsDir = join(tmpDir, "skills");
+    testClaudePaths.pluginsDir = join(tmpDir, "plugins");
+    testClaudePaths.marketplaceJson = join(tmpDir, ".claude-plugin", "marketplace.json");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function seedPlugin(pluginName: string): string {
+    const root = join(testClaudePaths.pluginsDir, pluginName);
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({
+        name: pluginName,
+        version: "1.0.0",
+        description: "Test plugin",
+        author: "Test Author",
+        commands: [{ name: "review" }],
+      }),
+      "utf8",
+    );
+
+    mkdirSync(join(root, "commands"), { recursive: true });
+    writeFileSync(join(root, "commands", "review.md"), "# Plugin review command", "utf8");
+
+    mkdirSync(join(root, "agents"), { recursive: true });
+    writeFileSync(join(root, "agents", "expert.md"), "# Plugin expert agent", "utf8");
+
+    mkdirSync(join(root, "hooks"), { recursive: true });
+    writeFileSync(
+      join(root, "hooks", "pre-commit.json"),
+      JSON.stringify({ matcher: "*", hooks: [] }),
+      "utf8",
+    );
+
+    writeFileSync(
+      join(root, ".mcp.json"),
+      JSON.stringify({ mcpServers: { sample: { command: "node", args: ["s.js"] } } }),
+      "utf8",
+    );
+
+    const skillDir = join(root, "skills", "plugin-skill");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# plugin-local skill", "utf8");
+    writeFileSync(join(skillDir, "notes.md"), "# notes", "utf8");
+
+    return root;
+  }
+
+  test("snapshotClaude emits manifest, commands, agents, hooks, mcp, and skill artifacts for a plugin", async () => {
+    seedPlugin("acme-toolkit");
+
+    const result = await claudeModule.snapshotClaude();
+    const ns = "claude/plugins/acme-toolkit";
+    const paths = result.artifacts.map((a) => a.vaultPath).sort();
+
+    expect(paths).toContain(`${ns}/plugin.json.age`);
+    expect(paths).toContain(`${ns}/commands/review.md.age`);
+    expect(paths).toContain(`${ns}/agents/expert.md.age`);
+    expect(paths).toContain(`${ns}/hooks/pre-commit.json.age`);
+    expect(paths).toContain(`${ns}/mcp.json.age`);
+    expect(paths).toContain(`${ns}/skills/plugin-skill.tar.age`);
+
+    const manifest = result.artifacts.find((a) => a.vaultPath === `${ns}/plugin.json.age`);
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toContain above
+    const parsed = JSON.parse(manifest!.plaintext) as Record<string, unknown>;
+    expect(parsed.name).toBe("acme-toolkit");
+    expect(parsed.version).toBe("1.0.0");
+    expect(parsed.description).toBe("Test plugin");
+  });
+
+  test("snapshotClaude does not emit plugin artifacts when plugins root is missing", async () => {
+    const result = await claudeModule.snapshotClaude();
+    const pluginPaths = result.artifacts.filter((a) => a.vaultPath.startsWith("claude/plugins/"));
+    expect(pluginPaths).toHaveLength(0);
+  });
+
+  test("snapshotClaude skips a plugin without a manifest", async () => {
+    const root = join(testClaudePaths.pluginsDir, "no-manifest");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, "stray.txt"), "not a plugin", "utf8");
+
+    const result = await claudeModule.snapshotClaude();
+    const pluginPaths = result.artifacts.filter((a) => a.vaultPath.startsWith("claude/plugins/"));
+    expect(pluginPaths).toHaveLength(0);
+  });
+
+  test("snapshotClaude skips a symlinked plugin entry", async () => {
+    const real = join(tmpDir, "vendored-elsewhere");
+    mkdirSync(join(real, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(real, ".claude-plugin", "plugin.json"), "{}", "utf8");
+    mkdirSync(testClaudePaths.pluginsDir, { recursive: true });
+    symlinkSync(real, join(testClaudePaths.pluginsDir, "linked"));
+
+    const result = await claudeModule.snapshotClaude();
+    const pluginPaths = result.artifacts.filter((a) => a.vaultPath.startsWith("claude/plugins/"));
+    expect(pluginPaths).toHaveLength(0);
+  });
+
+  test("snapshotClaude redacts literal secrets in plugin manifests and emits warnings", async () => {
+    const root = join(testClaudePaths.pluginsDir, "secret-plugin");
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({
+        name: "secret-plugin",
+        env: { token: `sk-${"a".repeat(30)}` },
+      }),
+      "utf8",
+    );
+
+    const result = await claudeModule.snapshotClaude();
+    const manifest = result.artifacts.find(
+      (a) => a.vaultPath === "claude/plugins/secret-plugin/plugin.json.age",
+    );
+    expect(manifest).toBeDefined();
+    expect(manifest?.plaintext).toContain("$AGENTSYNC_REDACTED");
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  test("snapshotClaude omits marketplace.json by default", async () => {
+    mkdirSync(join(tmpDir, ".claude-plugin"), { recursive: true });
+    writeFileSync(testClaudePaths.marketplaceJson, JSON.stringify({ plugins: [] }), "utf8");
+
+    const result = await claudeModule.snapshotClaude();
+    const market = result.artifacts.find((a) => a.vaultPath === "claude/marketplace.json.age");
+    expect(market).toBeUndefined();
+  });
+
+  test("snapshotClaude includes marketplace.json when syncMarketplace=true", async () => {
+    mkdirSync(join(tmpDir, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      testClaudePaths.marketplaceJson,
+      JSON.stringify({ plugins: [{ name: "a", source: "github:foo/bar" }] }),
+      "utf8",
+    );
+
+    const result = await claudeModule.snapshotClaude({ syncMarketplace: true });
+    const market = result.artifacts.find((a) => a.vaultPath === "claude/marketplace.json.age");
+    expect(market).toBeDefined();
+    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
+    const parsed = JSON.parse(market!.plaintext) as { plugins: { name: string }[] };
+    expect(parsed.plugins[0]?.name).toBe("a");
+  });
+
+  test("plugin round-trip: snapshot → encrypt → decrypt → applyClaudeVault restores every surface", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    seedPlugin("round-trip-plugin");
+
+    const snapshot = await claudeModule.snapshotClaude();
+    const pluginArtifacts = snapshot.artifacts.filter((a) =>
+      a.vaultPath.startsWith("claude/plugins/round-trip-plugin/"),
+    );
+    expect(pluginArtifacts.length).toBeGreaterThan(0);
+
+    const vaultDir = join(tmpDir, "vault");
+    for (const art of pluginArtifacts) {
+      const target = join(vaultDir, art.vaultPath);
+      await mkdir(join(target, ".."), { recursive: true });
+      const encrypted = await encryptString(art.plaintext, [recipient]);
+      await writeFile(target, encrypted, "utf8");
+    }
+
+    // Move the on-disk plugin out of the way so apply restores from the vault
+    // into a fresh location. Reuse the existing pluginsDir as the apply target.
+    const restoredPluginsDir = join(tmpDir, "restored-plugins");
+    testClaudePaths.pluginsDir = restoredPluginsDir;
+
+    await claudeModule.applyClaudeVault(vaultDir, identity, false);
+
+    const restoredRoot = join(restoredPluginsDir, "round-trip-plugin");
+    const manifest = await Bun.file(join(restoredRoot, ".claude-plugin", "plugin.json")).text();
+    const command = await Bun.file(join(restoredRoot, "commands", "review.md")).text();
+    const agent = await Bun.file(join(restoredRoot, "agents", "expert.md")).text();
+    const hook = await Bun.file(join(restoredRoot, "hooks", "pre-commit.json")).text();
+    const mcp = await Bun.file(join(restoredRoot, ".mcp.json")).text();
+    const skillSentinel = await Bun.file(
+      join(restoredRoot, "skills", "plugin-skill", "SKILL.md"),
+    ).text();
+
+    expect(JSON.parse(manifest).name).toBe("round-trip-plugin");
+    expect(command).toBe("# Plugin review command");
+    expect(agent).toBe("# Plugin expert agent");
+    expect(JSON.parse(hook).matcher).toBe("*");
+    expect(JSON.parse(mcp).mcpServers.sample.command).toBe("node");
+    expect(skillSentinel).toBe("# plugin-local skill");
+  });
+
+  test("applyClaudeVault rejects an adversarial plugin name without traversal", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const vaultDir = join(tmpDir, "vault-adversarial-plugin");
+    const evilPluginVaultDir = join(vaultDir, "claude", "plugins", "..");
+    await mkdir(evilPluginVaultDir, { recursive: true });
+    const encrypted = await encryptString("LEAKED_MANIFEST", [recipient]);
+    await writeFile(join(evilPluginVaultDir, "plugin.json.age"), encrypted, "utf8");
+
+    // Must not throw; the bad entry is logged and skipped.
+    await claudeModule.applyClaudeVault(vaultDir, identity, false);
+
+    const escaped = join(testClaudePaths.pluginsDir, "..", ".claude-plugin", "plugin.json");
+    const leakedExists = await Bun.file(escaped).exists();
+    expect(leakedExists).toBeFalse();
+  });
+
+  test("applyClaudeVault dryRun does not touch the plugin tree", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const vaultDir = join(tmpDir, "vault-dry");
+    const pluginNs = join(vaultDir, "claude", "plugins", "dry-plugin");
+    await mkdir(pluginNs, { recursive: true });
+    const encrypted = await encryptString(JSON.stringify({ name: "dry-plugin" }), [recipient]);
+    await writeFile(join(pluginNs, "plugin.json.age"), encrypted, "utf8");
+
+    await claudeModule.applyClaudeVault(vaultDir, identity, true);
+
+    const exists = await Bun.file(
+      join(testClaudePaths.pluginsDir, "dry-plugin", ".claude-plugin", "plugin.json"),
+    ).exists();
+    expect(exists).toBeFalse();
+  });
+
+  test("applyClaudeVault ignores marketplace.json.age when syncMarketplace is off", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const vaultDir = join(tmpDir, "vault-market");
+    const claudeVaultDir = join(vaultDir, "claude");
+    await mkdir(claudeVaultDir, { recursive: true });
+    const encrypted = await encryptString(JSON.stringify({ plugins: [] }), [recipient]);
+    await writeFile(join(claudeVaultDir, "marketplace.json.age"), encrypted, "utf8");
+
+    await claudeModule.applyClaudeVault(vaultDir, identity, false);
+    expect(await Bun.file(testClaudePaths.marketplaceJson).exists()).toBeFalse();
+
+    await claudeModule.applyClaudeVault(vaultDir, identity, false, { syncMarketplace: true });
+    expect(await Bun.file(testClaudePaths.marketplaceJson).exists()).toBeTrue();
   });
 });

--- a/src/agents/claude-plugins.ts
+++ b/src/agents/claude-plugins.ts
@@ -1,0 +1,145 @@
+/**
+ * src/agents/claude-plugins.ts
+ *
+ * Discovery walker and name validator for Claude Code plugins.
+ *
+ * Upstream layout (anthropics/claude-code, plugins/README.md):
+ *   ~/.claude/plugins/<plugin-name>/
+ *     .claude-plugin/plugin.json     ← manifest sentinel
+ *     commands/<file>.md             ← optional per-plugin commands
+ *     agents/<file>.md               ← optional per-plugin agent definitions
+ *     hooks/<file>.json              ← optional per-plugin hook bundles
+ *     skills/<skill-name>/SKILL.md   ← optional per-plugin skills
+ *     .mcp.json                      ← optional per-plugin MCP server wiring
+ *
+ * Discovery rules mirror the skills walker:
+ *   1. A missing or symlinked plugins root is a no-op (returns empty).
+ *   2. Top-level dot-prefixed entries are skipped silently.
+ *   3. Symlinked plugin entries are skipped silently.
+ *   4. A plugin must contain a real (non-symlink) `.claude-plugin/plugin.json`
+ *      file to qualify, so vendored bundles cannot smuggle themselves in via a
+ *      symlinked manifest.
+ *
+ * The walker NEVER throws on filesystem read errors and emits no log output.
+ */
+
+import { lstat, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { resolveClaudePluginPaths } from "../config/paths";
+
+/** One discovered Claude Code plugin. */
+export interface ClaudePluginEntry {
+  /** Plugin directory name (also the vault namespace component). */
+  name: string;
+  /** Absolute path to the plugin root on disk. */
+  root: string;
+  /** Canonical sub-paths inside the plugin root. */
+  paths: ReturnType<typeof resolveClaudePluginPaths>;
+}
+
+/**
+ * Thrown by {@link validatePluginName} when a plugin name derived from a vault
+ * filename or directory entry fails the allow-list. A dedicated subclass
+ * lets `applyClaudeVault` catch this specific failure mode and skip the
+ * adversarial entry without swallowing unrelated I/O errors.
+ */
+export class InvalidPluginNameError extends Error {
+  constructor(
+    public readonly provided: string,
+    public readonly reason: string,
+  ) {
+    super(`Invalid Claude plugin name '${provided}': ${reason}`);
+    this.name = "InvalidPluginNameError";
+  }
+}
+
+/**
+ * Validate a plugin name BEFORE it is joined onto the local plugins root.
+ * Symmetric to `validateSkillName` in skills-walker.ts — closes the same
+ * tar-slip / path-traversal class on the pull side. A vault that contains a
+ * directory literally named `..` would otherwise resolve to `~/.claude/`,
+ * which is the agent's config root.
+ */
+export function validatePluginName(name: string): void {
+  if (name.length === 0) {
+    throw new InvalidPluginNameError(name, "empty");
+  }
+  if (name === "." || name === "..") {
+    throw new InvalidPluginNameError(name, "reserved name");
+  }
+  if (name.startsWith(".")) {
+    throw new InvalidPluginNameError(name, "leading dot is reserved for hidden entries");
+  }
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i);
+    if (code < 0x20) {
+      throw new InvalidPluginNameError(name, "contains control character");
+    }
+    if (code === 0x2f || code === 0x5c) {
+      throw new InvalidPluginNameError(name, "contains path separator");
+    }
+  }
+}
+
+/**
+ * Walk a Claude plugins root and return every entry that qualifies as a real
+ * plugin. The walker mirrors {@link collectSkillArtifacts} gating so a
+ * vendored pool symlinked into `~/.claude/plugins/` cannot leak through.
+ *
+ * @param pluginsDir  Absolute path to the plugins root on disk. A missing or
+ *                    symlinked root yields an empty result with no warnings.
+ */
+export async function collectClaudePlugins(pluginsDir: string): Promise<ClaudePluginEntry[]> {
+  const entries: ClaudePluginEntry[] = [];
+
+  try {
+    const rootStat = await lstat(pluginsDir);
+    if (rootStat.isSymbolicLink()) return entries;
+    if (!rootStat.isDirectory()) return entries;
+  } catch {
+    return entries;
+  }
+
+  let names: string[];
+  try {
+    names = await readdir(pluginsDir);
+  } catch {
+    return entries;
+  }
+
+  for (const name of names) {
+    if (name.startsWith(".")) continue;
+
+    // Reject names that would escape the plugins root via path.join. We do this
+    // up front so a malformed directory entry never reaches the manifest stat.
+    try {
+      validatePluginName(name);
+    } catch {
+      continue;
+    }
+
+    const root = join(pluginsDir, name);
+
+    let entryStat: Awaited<ReturnType<typeof lstat>>;
+    try {
+      entryStat = await lstat(root);
+    } catch {
+      continue;
+    }
+    if (!entryStat.isDirectory()) continue;
+
+    const paths = resolveClaudePluginPaths(root);
+
+    let manifestStat: Awaited<ReturnType<typeof lstat>>;
+    try {
+      manifestStat = await lstat(paths.manifest);
+    } catch {
+      continue;
+    }
+    if (!manifestStat.isFile()) continue;
+
+    entries.push({ name, root, paths });
+  }
+
+  return entries;
+}

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -2,7 +2,14 @@ import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { AgentPaths } from "../config/paths";
-import { sanitizeClaudeHooks, sanitizeClaudeMcp, shouldNeverSync } from "../core/sanitizer";
+import {
+  redactSecretLiterals,
+  sanitizeClaudeHooks,
+  sanitizeClaudeMcp,
+  sanitizeClaudePluginManifest,
+  sanitizeClaudePluginMcp,
+  shouldNeverSync,
+} from "../core/sanitizer";
 import { extractArchive } from "../core/tar";
 import {
   atomicWrite,
@@ -11,13 +18,20 @@ import {
   type SnapshotArtifact,
   type SnapshotResult,
 } from "./_utils";
+import { collectClaudePlugins, InvalidPluginNameError, validatePluginName } from "./claude-plugins";
 import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "./skills-walker";
+
+/** Options that gate optional Claude surfaces (the marketplace catalog today). */
+export interface ClaudeSyncOptions {
+  /** Sync `~/.claude/.claude-plugin/marketplace.json` when the user opts in. */
+  syncMarketplace?: boolean;
+}
 
 /** Snapshot payload for the Claude adapter. */
 export type ClaudeSnapshotResult = SnapshotResult;
 
 /** Collect Claude files that are safe to store in the encrypted vault. */
-export async function snapshotClaude(): Promise<SnapshotResult> {
+export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<SnapshotResult> {
   const artifacts: SnapshotArtifact[] = [];
   const warnings: string[] = [];
 
@@ -101,7 +115,175 @@ export async function snapshotClaude(): Promise<SnapshotResult> {
   artifacts.push(...claudeSkills.artifacts);
   warnings.push(...claudeSkills.warnings);
 
+  // Claude Code plugin bundles (issue #31). Each discovered plugin contributes
+  // a manifest plus optional commands/agents/hooks/.mcp.json/skills artifacts
+  // under the `claude/plugins/<plugin-name>/...` vault namespace. Discovery
+  // gates (manifest sentinel, dot-skip, symlink rejection) live in
+  // `collectClaudePlugins`; everything below is purely additive collection
+  // that reuses the existing encryption pipeline.
+  const plugins = await collectClaudePlugins(AgentPaths.claude.pluginsDir);
+  for (const plugin of plugins) {
+    const ns = `claude/plugins/${plugin.name}`;
+
+    const manifestRaw = await readIfExists(plugin.paths.manifest);
+    if (manifestRaw !== null && !shouldNeverSync(plugin.paths.manifest)) {
+      try {
+        const manifest = sanitizeClaudePluginManifest(manifestRaw);
+        artifacts.push(collect(manifest, plugin.paths.manifest, `${ns}/plugin.json.age`));
+        warnings.push(...manifest.warnings);
+      } catch (err) {
+        warnings.push(
+          `[claude] Skipping plugin '${plugin.name}' manifest — invalid JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+
+    await collectPluginMarkdownDir(plugin.paths.commandsDir, `${ns}/commands`, artifacts, warnings);
+    await collectPluginMarkdownDir(plugin.paths.agentsDir, `${ns}/agents`, artifacts, warnings);
+    await collectPluginHooksDir(plugin.paths.hooksDir, `${ns}/hooks`, artifacts, warnings);
+
+    const pluginMcpRaw = await readIfExists(plugin.paths.mcpJson);
+    if (pluginMcpRaw !== null && !shouldNeverSync(plugin.paths.mcpJson)) {
+      try {
+        const pluginMcp = sanitizeClaudePluginMcp(pluginMcpRaw);
+        artifacts.push(collect(pluginMcp, plugin.paths.mcpJson, `${ns}/mcp.json.age`));
+        warnings.push(...pluginMcp.warnings);
+      } catch (err) {
+        warnings.push(
+          `[claude] Skipping plugin '${plugin.name}' .mcp.json — invalid JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+
+    // Plugin-local skills inherit every gate the shared walker enforces. The
+    // namespace mirrors the per-plugin layout so a vault's plugin tree is
+    // self-contained and removable as a unit.
+    const pluginSkills = await collectSkillArtifacts("claude", plugin.paths.skillsDir);
+    for (const art of pluginSkills.artifacts) {
+      // Re-namespace under the plugin so the artifact lives at
+      // claude/plugins/<plugin>/skills/<skill>.tar.age instead of the global
+      // claude/skills/<skill>.tar.age slot.
+      const skillBase = art.vaultPath.replace(/^claude\/skills\//, "");
+      artifacts.push({ ...art, vaultPath: `${ns}/skills/${skillBase}` });
+    }
+    warnings.push(...pluginSkills.warnings);
+  }
+
+  // Optional marketplace catalog (`~/.claude/.claude-plugin/marketplace.json`).
+  // Off by default — teams have to opt in via `claudePlugins.syncMarketplace`
+  // because the catalog can pin third-party sources that not every team wants
+  // to standardize on through the vault.
+  if (options.syncMarketplace === true) {
+    const marketplaceRaw = await readIfExists(AgentPaths.claude.marketplaceJson);
+    if (marketplaceRaw !== null && !shouldNeverSync(AgentPaths.claude.marketplaceJson)) {
+      try {
+        const parsed = JSON.parse(marketplaceRaw) as unknown;
+        const redacted = redactSecretLiterals(parsed, "marketplace");
+        artifacts.push({
+          vaultPath: "claude/marketplace.json.age",
+          sourcePath: AgentPaths.claude.marketplaceJson,
+          plaintext: `${JSON.stringify(redacted.value, null, 2)}\n`,
+          warnings: redacted.warnings,
+        });
+        warnings.push(...redacted.warnings);
+      } catch (err) {
+        warnings.push(
+          `[claude] Skipping marketplace.json — invalid JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  }
+
   return { artifacts, warnings };
+}
+
+/**
+ * Collect markdown files (commands or agents) from a plugin sub-directory.
+ * Mirrors the top-level Claude collection loop: non-recursive, `*.md` only,
+ * never-sync paths skipped, unreadable entries silently dropped.
+ */
+async function collectPluginMarkdownDir(
+  dir: string,
+  vaultPrefix: string,
+  artifacts: SnapshotArtifact[],
+  _warnings: string[],
+): Promise<void> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.endsWith(".md")) continue;
+    const sourcePath = join(dir, name);
+    if (shouldNeverSync(sourcePath)) continue;
+    let content: string;
+    try {
+      content = await readFile(sourcePath, "utf8");
+    } catch {
+      continue;
+    }
+    artifacts.push({
+      vaultPath: `${vaultPrefix}/${name}.age`,
+      sourcePath,
+      plaintext: content,
+      warnings: [],
+    });
+  }
+}
+
+/**
+ * Collect `*.json` hook bundles from a plugin sub-directory. Each hook bundle
+ * is sanitized with `redactSecretLiterals` while preserving its full shape —
+ * unlike the user-level `settings.json` flow which keeps only `{ hooks }`.
+ */
+async function collectPluginHooksDir(
+  dir: string,
+  vaultPrefix: string,
+  artifacts: SnapshotArtifact[],
+  warnings: string[],
+): Promise<void> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const sourcePath = join(dir, name);
+    if (shouldNeverSync(sourcePath)) continue;
+    let raw: string;
+    try {
+      raw = await readFile(sourcePath, "utf8");
+    } catch {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      const redacted = redactSecretLiterals(parsed, "pluginHook");
+      artifacts.push({
+        vaultPath: `${vaultPrefix}/${name}.age`,
+        sourcePath,
+        plaintext: `${JSON.stringify(redacted.value, null, 2)}\n`,
+        warnings: redacted.warnings,
+      });
+      warnings.push(...redacted.warnings);
+    } catch (err) {
+      warnings.push(
+        `[claude] Skipping plugin hook ${sourcePath} — invalid JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
 }
 
 /**
@@ -172,6 +354,103 @@ export async function applyClaudeAgent(agentName: string, content: string): Prom
   await atomicWrite(target, content);
 }
 
+// ─── Claude plugin apply helpers (issue #31) ─────────────────────────────────
+
+/**
+ * Build the absolute plugin root path after validating the plugin name.
+ * Centralised so every plugin apply helper goes through the same trust check
+ * before any filesystem write.
+ */
+function pluginRootFor(pluginName: string): string {
+  validatePluginName(pluginName);
+  return join(AgentPaths.claude.pluginsDir, pluginName);
+}
+
+/** Restore one plugin's `.claude-plugin/plugin.json` manifest. */
+export async function applyClaudePluginManifest(
+  pluginName: string,
+  content: string,
+): Promise<void> {
+  const root = pluginRootFor(pluginName);
+  const target = join(root, ".claude-plugin", "plugin.json");
+  await mkdir(join(root, ".claude-plugin"), { recursive: true });
+  await ensureCommandBackup(target);
+  await atomicWrite(target, content);
+}
+
+/** Restore one plugin-local command markdown file. */
+export async function applyClaudePluginCommand(
+  pluginName: string,
+  fileName: string,
+  content: string,
+): Promise<void> {
+  const root = pluginRootFor(pluginName);
+  const dir = join(root, "commands");
+  const target = join(dir, fileName);
+  await mkdir(dir, { recursive: true });
+  await ensureCommandBackup(target);
+  await atomicWrite(target, content);
+}
+
+/** Restore one plugin-local agent markdown file. */
+export async function applyClaudePluginAgent(
+  pluginName: string,
+  fileName: string,
+  content: string,
+): Promise<void> {
+  const root = pluginRootFor(pluginName);
+  const dir = join(root, "agents");
+  const target = join(dir, fileName);
+  await mkdir(dir, { recursive: true });
+  await ensureCommandBackup(target);
+  await atomicWrite(target, content);
+}
+
+/** Restore one plugin-local hook bundle JSON file. */
+export async function applyClaudePluginHook(
+  pluginName: string,
+  fileName: string,
+  content: string,
+): Promise<void> {
+  const root = pluginRootFor(pluginName);
+  const dir = join(root, "hooks");
+  const target = join(dir, fileName);
+  await mkdir(dir, { recursive: true });
+  await ensureCommandBackup(target);
+  await atomicWrite(target, content);
+}
+
+/** Restore one plugin's `.mcp.json`. */
+export async function applyClaudePluginMcp(pluginName: string, content: string): Promise<void> {
+  const root = pluginRootFor(pluginName);
+  const target = join(root, ".mcp.json");
+  await mkdir(root, { recursive: true });
+  await ensureCommandBackup(target);
+  await atomicWrite(target, content);
+}
+
+/** Restore one plugin-local skill tar archive into the plugin's skills dir. */
+export async function applyClaudePluginSkill(
+  pluginName: string,
+  skillName: string,
+  base64Tar: string,
+): Promise<void> {
+  const root = pluginRootFor(pluginName);
+  validateSkillName(skillName);
+  const targetDir = join(root, "skills", skillName);
+  await mkdir(targetDir, { recursive: true });
+  const tarBuffer = Buffer.from(base64Tar, "base64");
+  await extractArchive(tarBuffer, targetDir);
+}
+
+/** Restore the optional Claude marketplace catalog. */
+export async function applyClaudeMarketplace(content: string): Promise<void> {
+  const target = AgentPaths.claude.marketplaceJson;
+  await mkdir(join(target, ".."), { recursive: true });
+  await ensureCommandBackup(target);
+  await atomicWrite(target, content);
+}
+
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
 
 import { readdir as _readdir } from "node:fs/promises";
@@ -198,6 +477,7 @@ export async function applyClaudeVault(
   vaultDir: string,
   key: string,
   dryRun: boolean,
+  options: ClaudeSyncOptions = {},
 ): Promise<void> {
   const claudeDir = join(vaultDir, "claude");
   const files = await readAgeFiles(claudeDir);
@@ -224,6 +504,19 @@ export async function applyClaudeVault(
         continue;
       }
       await applyClaudeMcp(decrypted);
+    } else if (name === "marketplace.json.age") {
+      // Symmetric to the snapshot side: only apply when the user has opted in.
+      // A vault that contains a marketplace.json.age is silently ignored on
+      // any machine where syncMarketplace is not set, so opting out is the
+      // safe default and never blocks pulls.
+      if (options.syncMarketplace !== true) {
+        continue;
+      }
+      if (dryRun) {
+        log.info("[dry-run] [claude] would apply ~/.claude/.claude-plugin/marketplace.json");
+        continue;
+      }
+      await applyClaudeMarketplace(decrypted);
     }
   }
 
@@ -278,5 +571,131 @@ export async function applyClaudeVault(
       continue;
     }
     await applyClaudeSkill(skillName, decrypted);
+  }
+
+  // Plugins sub-tree (issue #31). Vault layout:
+  //   claude/plugins/<plugin>/plugin.json.age
+  //   claude/plugins/<plugin>/commands/<file>.md.age
+  //   claude/plugins/<plugin>/agents/<file>.md.age
+  //   claude/plugins/<plugin>/hooks/<file>.json.age
+  //   claude/plugins/<plugin>/mcp.json.age
+  //   claude/plugins/<plugin>/skills/<skill>.tar.age
+  await applyClaudePluginsDir(join(claudeDir, "plugins"), key, dryRun);
+}
+
+/**
+ * Walk the `claude/plugins/` vault sub-tree and route each artifact to the
+ * matching apply helper. Plugin names from the vault are validated via
+ * {@link validatePluginName} before any filesystem write so a crafted vault
+ * cannot escape `~/.claude/plugins/`.
+ */
+async function applyClaudePluginsDir(
+  pluginsVaultDir: string,
+  key: string,
+  dryRun: boolean,
+): Promise<void> {
+  let pluginEntries: string[];
+  try {
+    pluginEntries = await _readdir(pluginsVaultDir);
+  } catch {
+    return;
+  }
+
+  for (const pluginName of pluginEntries) {
+    try {
+      validatePluginName(pluginName);
+    } catch (err) {
+      if (err instanceof InvalidPluginNameError) {
+        log.warn(`[claude] Skipping vault plugin with invalid name '${pluginName}': ${err.reason}`);
+        continue;
+      }
+      throw err;
+    }
+
+    const pluginVaultRoot = join(pluginsVaultDir, pluginName);
+
+    // Top-level plugin artifacts (manifest, mcp.json).
+    const topFiles = await readAgeFiles(pluginVaultRoot);
+    for (const { name, fullPath } of topFiles) {
+      const encrypted = await readFile(fullPath, "utf8");
+      const decrypted = await decryptString(encrypted, key);
+
+      if (name === "plugin.json.age") {
+        if (dryRun) {
+          log.info(`[dry-run] [claude] would apply plugin manifest: ${pluginName}`);
+        } else {
+          await applyClaudePluginManifest(pluginName, decrypted);
+        }
+      } else if (name === "mcp.json.age") {
+        if (dryRun) {
+          log.info(`[dry-run] [claude] would apply plugin .mcp.json: ${pluginName}`);
+        } else {
+          await applyClaudePluginMcp(pluginName, decrypted);
+        }
+      }
+    }
+
+    // commands/*.md.age
+    for (const { name, fullPath } of await readAgeFiles(join(pluginVaultRoot, "commands"))) {
+      if (!name.endsWith(".md.age")) continue;
+      const encrypted = await readFile(fullPath, "utf8");
+      const decrypted = await decryptString(encrypted, key);
+      const fileName = basename(name, ".age");
+      if (dryRun) {
+        log.info(`[dry-run] [claude] would write plugin command: ${pluginName}/${fileName}`);
+      } else {
+        await applyClaudePluginCommand(pluginName, fileName, decrypted);
+      }
+    }
+
+    // agents/*.md.age
+    for (const { name, fullPath } of await readAgeFiles(join(pluginVaultRoot, "agents"))) {
+      if (!name.endsWith(".md.age")) continue;
+      const encrypted = await readFile(fullPath, "utf8");
+      const decrypted = await decryptString(encrypted, key);
+      const fileName = basename(name, ".age");
+      if (dryRun) {
+        log.info(`[dry-run] [claude] would write plugin agent: ${pluginName}/${fileName}`);
+      } else {
+        await applyClaudePluginAgent(pluginName, fileName, decrypted);
+      }
+    }
+
+    // hooks/*.json.age
+    for (const { name, fullPath } of await readAgeFiles(join(pluginVaultRoot, "hooks"))) {
+      if (!name.endsWith(".json.age")) continue;
+      const encrypted = await readFile(fullPath, "utf8");
+      const decrypted = await decryptString(encrypted, key);
+      const fileName = basename(name, ".age");
+      if (dryRun) {
+        log.info(`[dry-run] [claude] would write plugin hook: ${pluginName}/${fileName}`);
+      } else {
+        await applyClaudePluginHook(pluginName, fileName, decrypted);
+      }
+    }
+
+    // skills/<skill>.tar.age
+    for (const { name, fullPath } of await readAgeFiles(join(pluginVaultRoot, "skills"))) {
+      if (!name.endsWith(".tar.age")) continue;
+      const skillName = basename(name, ".tar.age");
+      try {
+        validateSkillName(skillName);
+      } catch (err) {
+        if (err instanceof InvalidSkillNameError) {
+          log.warn(
+            `[claude] Skipping plugin '${pluginName}' skill with invalid name '${name}': ${err.reason}`,
+          );
+          continue;
+        }
+        throw err;
+      }
+      const encrypted = await readFile(fullPath, "utf8");
+      const decrypted = await decryptString(encrypted, key);
+      if (dryRun) {
+        log.info(`[dry-run] [claude] would extract plugin skill: ${pluginName}/${skillName}`);
+        continue;
+      }
+      await applyClaudePluginSkill(pluginName, skillName, decrypted);
+    }
   }
 }

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -140,8 +140,8 @@ export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<S
       }
     }
 
-    await collectPluginMarkdownDir(plugin.paths.commandsDir, `${ns}/commands`, artifacts, warnings);
-    await collectPluginMarkdownDir(plugin.paths.agentsDir, `${ns}/agents`, artifacts, warnings);
+    await collectPluginMarkdownDir(plugin.paths.commandsDir, `${ns}/commands`, artifacts);
+    await collectPluginMarkdownDir(plugin.paths.agentsDir, `${ns}/agents`, artifacts);
     await collectPluginHooksDir(plugin.paths.hooksDir, `${ns}/hooks`, artifacts, warnings);
 
     const pluginMcpRaw = await readIfExists(plugin.paths.mcpJson);
@@ -212,7 +212,6 @@ async function collectPluginMarkdownDir(
   dir: string,
   vaultPrefix: string,
   artifacts: SnapshotArtifact[],
-  _warnings: string[],
 ): Promise<void> {
   let names: string[];
   try {
@@ -453,14 +452,13 @@ export async function applyClaudeMarketplace(content: string): Promise<void> {
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
 
-import { readdir as _readdir } from "node:fs/promises";
 import { basename } from "node:path";
 import { decryptString } from "../core/encryptor";
 
 /** Read encrypted files from a vault subdirectory, ignoring missing directories. */
 async function readAgeFiles(dir: string): Promise<{ name: string; fullPath: string }[]> {
   try {
-    const names = await _readdir(dir);
+    const names = await readdir(dir);
     return names
       .filter((name) => name.endsWith(".age"))
       .map((name) => ({
@@ -596,12 +594,17 @@ async function applyClaudePluginsDir(
 ): Promise<void> {
   let pluginEntries: string[];
   try {
-    pluginEntries = await _readdir(pluginsVaultDir);
+    pluginEntries = await readdir(pluginsVaultDir);
   } catch {
     return;
   }
 
   for (const pluginName of pluginEntries) {
+    // Symmetric with the push-side walker (claude-plugins.ts): dot-prefixed
+    // entries are ignorable noise (.gitkeep, .DS_Store), not adversarial. Skip
+    // silently before validation so the warning channel stays reserved for
+    // genuinely hostile names like `..`.
+    if (pluginName.startsWith(".")) continue;
     try {
       validatePluginName(pluginName);
     } catch (err) {

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -290,6 +290,7 @@ describe("integration", () => {
         autoPull: true,
         pullIntervalMs: 300_000,
       },
+      claudePlugins: { syncMarketplace: false },
     });
     writeFileSync(join(machineB.vaultDir, ".gitignore"), "*.tmp\n", "utf8");
     runGit(["init"], machineB.vaultDir);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -119,6 +119,7 @@ export const initCommand = defineCommand({
           branch: args.branch,
         },
         sync: existing?.sync ?? DEFAULT_SYNC,
+        claudePlugins: existing?.claudePlugins ?? { syncMarketplace: false },
       };
 
       await writeConfig(configPath, config);

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,5 +1,6 @@
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
+import { applyClaudeVault, type ClaudeSyncOptions, snapshotClaude } from "../agents/claude";
 import { type AgentDefinition, type AgentName, Agents } from "../agents/registry";
 import { loadConfig, resolveConfigPath } from "../config/loader";
 import { GitClient } from "../core/git";
@@ -9,6 +10,16 @@ let agentDefinitions: AgentDefinition[] = Agents;
 
 export function __setPullAgentsForTesting(agents: AgentDefinition[] | null): void {
   agentDefinitions = agents ?? Agents;
+}
+
+/** Inject the Claude plugin/marketplace opt-in flag into the registry's claude entry. */
+function withClaudeOptions(agent: AgentDefinition, claudeOpts: ClaudeSyncOptions): AgentDefinition {
+  if (agent.name !== "claude") return agent;
+  return {
+    ...agent,
+    snapshot: () => snapshotClaude(claudeOpts),
+    apply: (vaultDir, key, dryRun) => applyClaudeVault(vaultDir, key, dryRun, claudeOpts),
+  };
 }
 
 /**
@@ -35,10 +46,15 @@ export async function performPull(
     });
 
     const requestedAgent = options.agent as AgentName | undefined;
-    const agentsToSync = agentDefinitions.filter((a) => {
-      if (requestedAgent) return a.name === requestedAgent;
-      return config.agents[a.name as keyof typeof config.agents] === true;
-    });
+    const claudeOpts: ClaudeSyncOptions = {
+      syncMarketplace: config.claudePlugins?.syncMarketplace ?? false,
+    };
+    const agentsToSync = agentDefinitions
+      .filter((a) => {
+        if (requestedAgent) return a.name === requestedAgent;
+        return config.agents[a.name as keyof typeof config.agents] === true;
+      })
+      .map((a) => withClaudeOptions(a, claudeOpts));
 
     for (const agent of agentsToSync) {
       await agent.apply(runtime.vaultDir, key, options.dryRun ?? false);

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -12,9 +12,15 @@ export function __setPullAgentsForTesting(agents: AgentDefinition[] | null): voi
   agentDefinitions = agents ?? Agents;
 }
 
-/** Inject the Claude plugin/marketplace opt-in flag into the registry's claude entry. */
+const REGISTRY_CLAUDE = Agents.find((a) => a.name === "claude");
+
+/**
+ * Inject the Claude plugin/marketplace opt-in flag into the registry's claude
+ * entry. Test fakes installed via `__setPullAgentsForTesting` are different
+ * object references and pass through unchanged.
+ */
 function withClaudeOptions(agent: AgentDefinition, claudeOpts: ClaudeSyncOptions): AgentDefinition {
-  if (agent.name !== "claude") return agent;
+  if (agent !== REGISTRY_CLAUDE) return agent;
   return {
     ...agent,
     snapshot: () => snapshotClaude(claudeOpts),

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
+import { applyClaudeVault, type ClaudeSyncOptions, snapshotClaude } from "../agents/claude";
 import { type AgentDefinition, type AgentName, Agents } from "../agents/registry";
 import { loadConfig, resolveConfigPath } from "../config/loader";
 import { encryptString } from "../core/encryptor";
@@ -13,6 +14,20 @@ let agentDefinitions: AgentDefinition[] = Agents;
 
 export function __setPushAgentsForTesting(agents: AgentDefinition[] | null): void {
   agentDefinitions = agents ?? Agents;
+}
+
+/**
+ * Replace the registry's default Claude entry with one that knows about the
+ * Claude plugin/marketplace opt-in flag from agentsync.toml. All other agents
+ * pass through unchanged so the registry contract stays narrow.
+ */
+function withClaudeOptions(agent: AgentDefinition, claudeOpts: ClaudeSyncOptions): AgentDefinition {
+  if (agent.name !== "claude") return agent;
+  return {
+    ...agent,
+    snapshot: () => snapshotClaude(claudeOpts),
+    apply: (vaultDir, key, dryRun) => applyClaudeVault(vaultDir, key, dryRun, claudeOpts),
+  };
 }
 
 /**
@@ -37,10 +52,15 @@ export async function performPush(
   }
 
   const requestedAgent = options.agent as AgentName | undefined;
-  const agentsToSync = agentDefinitions.filter((a) => {
-    if (requestedAgent) return a.name === requestedAgent;
-    return config.agents[a.name] === true;
-  });
+  const claudeOpts: ClaudeSyncOptions = {
+    syncMarketplace: config.claudePlugins?.syncMarketplace ?? false,
+  };
+  const agentsToSync = agentDefinitions
+    .filter((a) => {
+      if (requestedAgent) return a.name === requestedAgent;
+      return config.agents[a.name] === true;
+    })
+    .map((a) => withClaudeOptions(a, claudeOpts));
 
   if (agentsToSync.length === 0) {
     return { pushed, errors, fatal };
@@ -194,10 +214,15 @@ export const pushCommand = defineCommand({
       // Collect dry-run output manually for display
       const runtime = await resolveRuntimeContext();
       const config = await loadConfig(resolveConfigPath(runtime.vaultDir));
-      const agentsToSync = agentDefinitions.filter((a) => {
-        if (requestedAgent) return a.name === requestedAgent;
-        return config.agents[a.name] === true;
-      });
+      const claudeOpts: ClaudeSyncOptions = {
+        syncMarketplace: config.claudePlugins?.syncMarketplace ?? false,
+      };
+      const agentsToSync = agentDefinitions
+        .filter((a) => {
+          if (requestedAgent) return a.name === requestedAgent;
+          return config.agents[a.name] === true;
+        })
+        .map((a) => withClaudeOptions(a, claudeOpts));
       for (const agent of agentsToSync) {
         const snapshot = await agent.snapshot();
         for (const artifact of snapshot.artifacts) {

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -16,13 +16,16 @@ export function __setPushAgentsForTesting(agents: AgentDefinition[] | null): voi
   agentDefinitions = agents ?? Agents;
 }
 
+const REGISTRY_CLAUDE = Agents.find((a) => a.name === "claude");
+
 /**
  * Replace the registry's default Claude entry with one that knows about the
- * Claude plugin/marketplace opt-in flag from agentsync.toml. All other agents
- * pass through unchanged so the registry contract stays narrow.
+ * Claude plugin/marketplace opt-in flag from agentsync.toml. Test fakes
+ * installed via `__setPushAgentsForTesting` are different object references
+ * and pass through unchanged so the registry contract stays narrow.
  */
 function withClaudeOptions(agent: AgentDefinition, claudeOpts: ClaudeSyncOptions): AgentDefinition {
-  if (agent.name !== "claude") return agent;
+  if (agent !== REGISTRY_CLAUDE) return agent;
   return {
     ...agent,
     snapshot: () => snapshotClaude(claudeOpts),

--- a/src/config/__tests__/paths.test.ts
+++ b/src/config/__tests__/paths.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { AgentPaths, resolveAgentSyncHome, resolveDaemonSocketPath } from "../paths";
+import {
+  AgentPaths,
+  resolveAgentSyncHome,
+  resolveClaudePluginPaths,
+  resolveDaemonSocketPath,
+} from "../paths";
 
 // T015 — AgentPaths shape validation (non-mutable, import-time baked paths)
 
@@ -71,6 +76,30 @@ describe("paths", () => {
   test("AgentPaths.vscode.mcpJson is a non-empty string", () => {
     expect(typeof AgentPaths.vscode.mcpJson).toBe("string");
     expect(AgentPaths.vscode.mcpJson.length).toBeGreaterThan(0);
+  });
+
+  // Claude plugin path entries (issue #31)
+
+  test("AgentPaths.claude.pluginsDir is ~/.claude/plugins/", () => {
+    expect(AgentPaths.claude.pluginsDir).toBe(join(HOME, ".claude", "plugins"));
+  });
+
+  test("AgentPaths.claude.marketplaceJson is ~/.claude/.claude-plugin/marketplace.json", () => {
+    expect(AgentPaths.claude.marketplaceJson).toBe(
+      join(HOME, ".claude", ".claude-plugin", "marketplace.json"),
+    );
+  });
+
+  test("resolveClaudePluginPaths returns the canonical plugin sub-paths", () => {
+    const root = join(HOME, ".claude", "plugins", "my-plugin");
+    const paths = resolveClaudePluginPaths(root);
+    expect(paths.root).toBe(root);
+    expect(paths.manifest).toBe(join(root, ".claude-plugin", "plugin.json"));
+    expect(paths.commandsDir).toBe(join(root, "commands"));
+    expect(paths.agentsDir).toBe(join(root, "agents"));
+    expect(paths.hooksDir).toBe(join(root, "hooks"));
+    expect(paths.mcpJson).toBe(join(root, ".mcp.json"));
+    expect(paths.skillsDir).toBe(join(root, "skills"));
   });
 
   // T016 — resolveAgentSyncHome / resolveDaemonSocketPath

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -28,6 +28,13 @@ export const AgentPaths = {
     mcpJson: join(HOME, ".claude.json"),
     credentials: join(HOME, ".claude", ".credentials.json"),
     skillsDir: join(HOME, ".claude", "skills"),
+    // Claude Code plugin layout (upstream: anthropics/claude-code).
+    // Plugins live under ~/.claude/plugins/<name>/ and each carries a
+    // .claude-plugin/plugin.json manifest plus optional commands/, agents/,
+    // hooks/, skills/, and .mcp.json siblings. The marketplace catalog at
+    // ~/.claude/.claude-plugin/marketplace.json is opt-in via config.
+    pluginsDir: join(HOME, ".claude", "plugins"),
+    marketplaceJson: join(HOME, ".claude", ".claude-plugin", "marketplace.json"),
   },
   codex: {
     root: process.env.CODEX_HOME ?? join(HOME, ".codex"),
@@ -65,6 +72,33 @@ export const AgentPaths = {
     })(),
   },
 } as const;
+
+/**
+ * Resolve the canonical sub-paths for a single Claude Code plugin given its root
+ * directory (typically `<pluginsDir>/<plugin-name>`). The shape mirrors the
+ * primary surfaces a plugin can expose: a `.claude-plugin/plugin.json`
+ * manifest plus optional `commands/`, `agents/`, `hooks/`, `skills/`, and
+ * `.mcp.json` siblings.
+ */
+export function resolveClaudePluginPaths(pluginRoot: string): {
+  root: string;
+  manifest: string;
+  commandsDir: string;
+  agentsDir: string;
+  hooksDir: string;
+  mcpJson: string;
+  skillsDir: string;
+} {
+  return {
+    root: pluginRoot,
+    manifest: join(pluginRoot, ".claude-plugin", "plugin.json"),
+    commandsDir: join(pluginRoot, "commands"),
+    agentsDir: join(pluginRoot, "agents"),
+    hooksDir: join(pluginRoot, "hooks"),
+    mcpJson: join(pluginRoot, ".mcp.json"),
+    skillsDir: join(pluginRoot, "skills"),
+  };
+}
 
 /** Resolve the OS-specific base directory used for AgentSync state. */
 export function resolveAgentSyncHome(): string {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -21,6 +21,16 @@ export const AgentSyncConfigSchema = z.object({
     autoPull: z.boolean().default(true),
     pullIntervalMs: z.number().int().min(1_000).default(300_000),
   }),
+  // Per-agent plugin opt-ins (issue #31). Optional with safe defaults so
+  // existing agentsync.toml files continue to validate without changes.
+  claudePlugins: z
+    .object({
+      // Sync `~/.claude/.claude-plugin/marketplace.json` through the vault.
+      // Off by default — the catalog can pin third-party sources, so teams
+      // opt in explicitly.
+      syncMarketplace: z.boolean().default(false),
+    })
+    .default({ syncMarketplace: false }),
 });
 
 /** Normalized runtime shape derived from the validated config schema. */

--- a/src/core/__tests__/sanitizer.test.ts
+++ b/src/core/__tests__/sanitizer.test.ts
@@ -5,6 +5,8 @@ import {
   redactSecretLiterals,
   sanitizeClaudeHooks,
   sanitizeClaudeMcp,
+  sanitizeClaudePluginManifest,
+  sanitizeClaudePluginMcp,
   shouldNeverSync,
 } from "../sanitizer";
 
@@ -144,5 +146,52 @@ describe("sanitizer", () => {
     expect(redactSecretLiterals(null).warnings).toHaveLength(0);
     expect(redactSecretLiterals(42).warnings).toHaveLength(0);
     expect(redactSecretLiterals(true).warnings).toHaveLength(0);
+  });
+
+  // Claude plugin sanitizers (issue #31)
+
+  test("sanitizeClaudePluginManifest preserves manifest metadata", () => {
+    const manifest = JSON.stringify({
+      name: "acme-toolkit",
+      version: "1.2.3",
+      description: "Acme tools",
+      author: "Acme",
+      commands: [{ name: "review" }],
+    });
+    const out = sanitizeClaudePluginManifest(manifest);
+    const parsed = JSON.parse(out.value) as Record<string, unknown>;
+    expect(parsed.name).toBe("acme-toolkit");
+    expect(parsed.version).toBe("1.2.3");
+    expect(parsed.description).toBe("Acme tools");
+    expect((parsed.commands as { name: string }[])[0]?.name).toBe("review");
+  });
+
+  test("sanitizeClaudePluginManifest redacts literal secrets", () => {
+    const manifest = JSON.stringify({
+      name: "acme",
+      env: { token: `sk-${"x".repeat(30)}` },
+    });
+    const out = sanitizeClaudePluginManifest(manifest);
+    const parsed = JSON.parse(out.value) as { env: { token: string } };
+    expect(parsed.env.token.startsWith("$AGENTSYNC_REDACTED")).toBeTrue();
+    expect(out.warnings.length).toBe(1);
+  });
+
+  test("sanitizeClaudePluginMcp preserves the bare server descriptor", () => {
+    const mcp = JSON.stringify({
+      mcpServers: { acme: { command: "node", args: ["server.js"] } },
+    });
+    const out = sanitizeClaudePluginMcp(mcp);
+    const parsed = JSON.parse(out.value) as Record<string, unknown>;
+    expect(parsed.mcpServers).toBeDefined();
+  });
+
+  test("sanitizeClaudePluginMcp redacts literal secrets inside server config", () => {
+    const mcp = JSON.stringify({
+      mcpServers: { acme: { env: { API_KEY: `sk-${"y".repeat(30)}` } } },
+    });
+    const out = sanitizeClaudePluginMcp(mcp);
+    expect(out.warnings.length).toBe(1);
+    expect(out.value).toContain("$AGENTSYNC_REDACTED");
   });
 });

--- a/src/core/sanitizer.ts
+++ b/src/core/sanitizer.ts
@@ -140,6 +140,42 @@ export function sanitizeClaudeMcp(rawClaudeJson: string): RedactionResult<string
   };
 }
 
+/**
+ * Sanitize a Claude Code plugin manifest (`.claude-plugin/plugin.json`).
+ *
+ * Unlike `sanitizeClaudeHooks` / `sanitizeClaudeMcp` — which discard everything
+ * outside one allow-listed key — plugin manifests need their full metadata
+ * preserved (name, version, description, author, command/agent/hook lists,
+ * etc.) so that the apply side can restore an equivalent manifest. The only
+ * transformation is `redactSecretLiterals` over the entire object, which
+ * replaces obvious credential strings with the standard placeholder while
+ * leaving structural fields untouched.
+ */
+export function sanitizeClaudePluginManifest(rawJson: string): RedactionResult<string> {
+  const parsed = JSON.parse(rawJson) as unknown;
+  const redacted = redactSecretLiterals(parsed, "plugin");
+  return {
+    value: `${JSON.stringify(redacted.value, null, 2)}\n`,
+    warnings: redacted.warnings,
+  };
+}
+
+/**
+ * Sanitize a plugin-scoped `.mcp.json`. Mirrors {@link sanitizeClaudeMcp} but
+ * preserves the file's full top-level shape because plugin MCP files do not
+ * follow the user-level `.claude.json` schema — they are a bare server
+ * descriptor that the plugin owner controls. Literal secret redaction still
+ * runs over every value.
+ */
+export function sanitizeClaudePluginMcp(rawJson: string): RedactionResult<string> {
+  const parsed = JSON.parse(rawJson) as unknown;
+  const redacted = redactSecretLiterals(parsed, "pluginMcp");
+  return {
+    value: `${JSON.stringify(redacted.value, null, 2)}\n`,
+    warnings: redacted.warnings,
+  };
+}
+
 /** Derive a stable redaction placeholder name from the original file name. */
 export function redactionEnvNameForPath(path: string): string {
   const file = basename(path).replace(/[^a-zA-Z0-9]+/g, "_");


### PR DESCRIPTION
## Summary

Closes #31. AgentSync now syncs Claude Code's plugin layout end-to-end: every directory under `~/.claude/plugins/<name>/` rides the vault as a self-contained subtree at `claude/plugins/<name>/`, and pull restores all surfaces (manifest, commands, sub-agents, hooks, MCP servers, plugin-local skills) onto the consuming machine. Plugin marketplaces are sync-able too, gated behind an explicit opt-in flag because the catalog can pin third-party sources.

The walker, name validator, and apply-side routing all mirror the existing skills-walker contract — same lstat-based gates, same `..`/separator/control-character rejection class, same dot-skip and symlink defences. Sanitiser warnings escalate to the existing fatal-abort gate, so a literal secret inside a plugin manifest or `.mcp.json` stops the push before encryption.

## Changes

### Files changed

- `src/config/paths.ts` · added `pluginsDir` + `marketplaceJson` to `AgentPaths.claude` and a `resolveClaudePluginPaths` helper that maps a plugin root to its surfaces.
- `src/agents/claude-plugins.ts` · new walker `collectClaudePlugins` and `validatePluginName` (mirrors `validateSkillName`); `InvalidPluginNameError` carries the offending input.
- `src/core/sanitizer.ts` · new `sanitizeClaudePluginManifest` and `sanitizeClaudePluginMcp` — preserve full structure (unlike the hooks/mcp allowlists) while running secret-literal redaction across every leaf value.
- `src/agents/claude.ts` · `snapshotClaude(options)` emits per-plugin artifacts plus an opt-in marketplace export; `applyClaudeVault(...)` adds `applyClaudePluginsDir` and per-surface helpers, all gated by `validatePluginName` before any `path.join`.
- `src/config/schema.ts` · optional `claudePlugins.syncMarketplace` (default `false`); existing `agentsync.toml` files keep validating unchanged.
- `src/commands/push.ts`, `src/commands/pull.ts` · derive `ClaudeSyncOptions` from config and inject it into the registry's claude entry through a `withClaudeOptions` wrapper; other agents pass through unchanged.
- `src/commands/init.ts`, `src/commands/__tests__/integration.test.ts` · set the new field explicitly so `writeConfig` round-trips the persisted shape.
- `src/agents/__tests__/claude-plugins.test.ts`, `src/agents/__tests__/claude.test.ts`, `src/config/__tests__/paths.test.ts`, `src/core/__tests__/sanitizer.test.ts` · 7 new tests on the foundations + 11 new tests in `Claude plugin sync` describe block (round-trip, redaction, marketplace gating, traversal-name rejection, dry-run no-touch).
- `docs/architecture.md` · new "Claude plugin sync flow" section with Mermaid diagram covering walker gates, per-surface emission, opt-in marketplace, and the apply-side name validator.
- `docs/command-reference.md`, `README.md` · call out the new vault layout and the `claudePlugins.syncMarketplace` flag.

### Architecture

```mermaid
flowchart TD
	LocalPlugins["Local plugins<br/>~/.claude/plugins/&lt;name&gt;"]:::action
	WalkerGate{"Real dir + valid name<br/>+ real plugin.json"}:::decision
	Manifest["plugin.json<br/>sanitizeClaudePluginManifest"]:::keep
	Surfaces["commands agents hooks mcp<br/>per-file sanitisers"]:::keep
	PluginSkills["plugin-local skills<br/>collectSkillArtifacts reused"]:::keep
	Marketplace{"claudePlugins<br/>syncMarketplace true"}:::decision
	MarketArt["marketplace.json.age<br/>opt-in only"]:::keep
	Vault["Vault namespace<br/>claude/plugins/&lt;name&gt;/..."]:::vault
	Pull["pull command<br/>applyClaudePluginsDir"]:::keep
	NameGate{"validatePluginName<br/>before any path.join"}:::decision
	Apply["restore manifest commands agents<br/>hooks mcp skills"]:::keep
	SkipSilent["Skipped silently<br/>missing root or invalid"]:::skip
	Reject["Warning emitted<br/>traversal name rejected"]:::fail

	LocalPlugins --> WalkerGate
	WalkerGate -- no --> SkipSilent
	WalkerGate -- yes --> Manifest --> Vault
	WalkerGate --> Surfaces --> Vault
	WalkerGate --> PluginSkills --> Vault
	Marketplace -- yes --> MarketArt --> Vault
	Vault --> Pull --> NameGate
	NameGate -- no --> Reject
	NameGate -- yes --> Apply

	classDef action fill:#1e3a8a,color:#ffffff,stroke:#0f1f4d,stroke-width:1.5px;
	classDef decision fill:#78350f,color:#ffffff,stroke:#451a03,stroke-width:1.5px;
	classDef keep fill:#14532d,color:#ffffff,stroke:#0a2d18,stroke-width:1.5px;
	classDef vault fill:#3730a3,color:#ffffff,stroke:#1e1b6e,stroke-width:1.5px;
	classDef skip fill:#78350f,color:#ffffff,stroke:#451a03,stroke-width:1.5px;
	classDef fail fill:#7f1d1d,color:#ffffff,stroke:#7f1d1d,stroke-width:1.5px;
```

### Commits

- `f27d1d3` · feat(claude): add plugin walker, name validator, and sanitizers
- `2f199f3` · feat(claude): emit and apply plugin bundles end-to-end
- `48535b3` · feat(config): thread claudePlugins.syncMarketplace through push/pull
- `7d1db28` · docs(claude-plugins): document plugin sync flow and opt-in marketplace

## Test Evidence

| Command | Result |
| --- | --- |
| `bun run typecheck` | pass |
| `bun run lint` | pass (8 pre-existing warnings, 0 errors) |
| `bun test src/agents/__tests__/claude.test.ts` | 36/36 pass |
| `bun test src/agents/__tests__/claude-plugins.test.ts src/config/__tests__/paths.test.ts src/core/__tests__/sanitizer.test.ts` | 55/55 pass |
| `bun test` (full suite) | 205 pass / 20 fail / 16 errors — same 20/16 baseline failures exist on `main` and are unrelated to this change (`node:fs/promises` mock interaction in unrelated daemon/doctor/status tests) |

### Verification

- Snapshot emits `plugin.json.age`, `commands/*.md.age`, `agents/*.md.age`, `hooks/*.json.age`, `mcp.json.age`, and `skills/<name>.tar.age` under `claude/plugins/<name>/` for every admitted plugin.
- Plugins with missing manifests, symlinked manifests, symlinked plugin entries, or dot-prefixed names are skipped silently.
- Manifest secret literals abort the push via the existing `Redacted literal secret` gate.
- `marketplace.json.age` is omitted by default and only emitted when `claudePlugins.syncMarketplace = true`. Apply respects the same flag — vault marketplace artifacts are ignored on machines that haven't opted in.
- Adversarial vault entries like `claude/plugins/..` and `claude/plugins/.x` are rejected with a warning and never reach `path.join`.
- Round-trip test seeds a plugin, runs `snapshotClaude` → `encryptString` → `decryptString` → `applyClaudeVault`, then asserts every restored surface (manifest, command, agent, hook, mcp, skill sentinel) matches the original.
- Dry-run path does not touch the plugin tree on disk.

## Risks / Follow-ups

- The walker reuses `collectSkillArtifacts` for plugin-local skills; the symlink-filtered tar / sentinel rules apply uniformly. No behaviour change for non-plugin skills.
- `claudePlugins.syncMarketplace` is the only new schema field. It defaults to `false`, so existing vaults and configs are unaffected.
- The 20 pre-existing test failures (daemon/doctor/status) reproduce on `main` and are out of scope for this PR.

Closes #31

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Claude Code plugins are now backed up and restored as part of vault synchronization
* Added optional marketplace synchronization (opt-in via `syncMarketplace` configuration flag)
* Plugin manifests, commands, agents, hooks, MCP servers, and plugin-scoped skills are all included in backups

**Documentation**
* Updated vault documentation to describe plugin storage and restoration behavior
* Added architecture and command reference details for plugin synchronization

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->