### PR TITLE
docs(comments): drop spec-tracker refs, rewrite WHY-only comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,12 @@ bun run check:act     # run CI workflow locally via nektos/act
 - **Imports**: ES modules only (`"type": "module"`). Use Node-style
   imports with explicit `.ts` paths where Bun requires them; let Biome
   organise import order.
+- **No spec-tracker refs in code**: never embed `FR-###`, `SC-###`,
+  `US#`, `T###`, `NC-#`, or `(research R#)`-style references in
+  comments, test names, JSDoc, or string literals. Future readers will
+  not have spec context. Write the WHY directly: name the rule, name
+  the failure mode the check prevents, or describe the invariant. Spec
+  IDs belong in commit messages and PR descriptions, not source.
 
 ## Speckit
 

--- a/src/agents/__tests__/_utils.test.ts
+++ b/src/agents/__tests__/_utils.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
 import { atomicWrite, collect, readIfExists } from "../_utils";
 
-// T017 — _utils helpers
+// _utils helpers
 
 describe("agents/_utils", () => {
   let tmpDir: string;

--- a/src/agents/__tests__/claude.test.ts
+++ b/src/agents/__tests__/claude.test.ts
@@ -47,7 +47,7 @@ afterAll(() => {
   Object.assign(testClaudePaths, originalClaudePaths);
 });
 
-// T018 — snapshotClaude
+// snapshotClaude
 
 describe("snapshotClaude", () => {
   let tmpDir: string;
@@ -144,7 +144,7 @@ describe("snapshotClaude", () => {
     expect(result.warnings.length).toBeGreaterThanOrEqual(0);
   });
 
-  // T014 — US1 Claude skill round-trip happy path (FR-001, FR-003, FR-004)
+  // Claude skill round-trip happy path
 
   test("snapshots a real Claude skill directory as a base64 tar artifact", async () => {
     const skillDir = join(testClaudePaths.skillsDir, "my-skill");
@@ -162,9 +162,9 @@ describe("snapshotClaude", () => {
     expect(art!.plaintext.length).toBeGreaterThan(0);
   });
 
-  // T014(5) — FR-009 missing-dir case at the agent layer
+  // missing-dir case at the agent layer
 
-  test("snapshotClaude does not throw when the skills directory is missing (FR-009)", async () => {
+  test("snapshotClaude does not throw when the skills directory is missing", async () => {
     testClaudePaths.skillsDir = join(tmpDir, "skills-does-not-exist");
 
     const result = await claudeModule.snapshotClaude();
@@ -173,9 +173,9 @@ describe("snapshotClaude", () => {
     expect(result.warnings.filter((w) => w.startsWith("never-sync"))).toHaveLength(0);
   });
 
-  // T014(6) — FR-016 interior-symlink defense-in-depth at the agent layer
+  // interior-symlink defense-in-depth at the agent layer
 
-  test("snapshotClaude omits interior symlink helper files from the tar (FR-016 inner)", async () => {
+  test("snapshotClaude omits interior symlink helper files from the tar", async () => {
     // Vendored helper outside the skills root.
     const helperTargetParent = join(tmpDir, "vendored-helpers");
     mkdirSync(helperTargetParent, { recursive: true });
@@ -207,10 +207,10 @@ describe("snapshotClaude", () => {
     expect(entries).not.toContain("helper.md");
   });
 
-  // T015 — Claude-specific edge cases that prove the walker is correctly
+  // Claude-specific edge cases that prove the walker is correctly
   // wired into snapshotClaude (not just the walker module in isolation).
 
-  test("snapshotClaude skips a top-level symlinked skill root (FR-016 outer)", async () => {
+  test("snapshotClaude skips a top-level symlinked skill root", async () => {
     const vendoredTarget = join(tmpDir, "vendored-pool", "vendor-skill");
     mkdirSync(vendoredTarget, { recursive: true });
     writeFileSync(join(vendoredTarget, "SKILL.md"), "# vendored", "utf8");
@@ -223,7 +223,7 @@ describe("snapshotClaude", () => {
     expect(skillArts).toHaveLength(0);
   });
 
-  test("snapshotClaude skips a top-level .system directory (FR-017 dot-skip)", async () => {
+  test("snapshotClaude skips a top-level .system directory", async () => {
     const systemSkill = join(testClaudePaths.skillsDir, ".system", "vendor");
     mkdirSync(systemSkill, { recursive: true });
     writeFileSync(join(systemSkill, "SKILL.md"), "# vendor", "utf8");
@@ -233,7 +233,7 @@ describe("snapshotClaude", () => {
     expect(skillArts).toHaveLength(0);
   });
 
-  test("snapshotClaude skips a skill whose SKILL.md sentinel is a symlink (FR-016 sentinel)", async () => {
+  test("snapshotClaude skips a skill whose SKILL.md sentinel is a symlink", async () => {
     const realSentinel = join(tmpDir, "vendored-sentinel.md");
     writeFileSync(realSentinel, "# vendored", "utf8");
 
@@ -247,7 +247,7 @@ describe("snapshotClaude", () => {
   });
 });
 
-// T024 — applyClaudeMd / applyClaudeHooks / applyClaudeMcp / applyClaudeCommand / applyClaudeAgent
+// applyClaudeMd / applyClaudeHooks / applyClaudeMcp / applyClaudeCommand / applyClaudeAgent
 
 describe("apply* functions", () => {
   let tmpDir: string;
@@ -318,7 +318,7 @@ describe("apply* functions", () => {
     expect(content).toBe("# Agent content");
   });
 
-  // T014(2) — applyClaudeSkill direct extraction test
+  // applyClaudeSkill direct extraction test
 
   test("applyClaudeSkill extracts a tar archive into the local skills dir", async () => {
     // Build a source skill, archive it via the same helper the walker uses,
@@ -341,7 +341,7 @@ describe("apply* functions", () => {
   });
 });
 
-// T028 — dryRun (applyClaudeVault)
+// dryRun (applyClaudeVault)
 
 describe("applyClaudeVault dryRun", () => {
   let tmpDir: string;
@@ -384,7 +384,7 @@ describe("applyClaudeVault dryRun", () => {
     expect(exists).toBeFalse();
   });
 
-  // T014(3) — applyClaudeVault round-trip restores skill from encrypted vault
+  // applyClaudeVault round-trip restores skill from encrypted vault
 
   test("applyClaudeVault restores a Claude skill from an encrypted vault artifact", async () => {
     const { generateIdentity, identityToRecipient, encryptString } = await import(
@@ -418,7 +418,7 @@ describe("applyClaudeVault dryRun", () => {
     expect(restoredGuide).toBe("# guide");
   });
 
-  // T014(4) — applyClaudeVault dryRun=true must NOT touch the local skills dir
+  // applyClaudeVault dryRun=true must NOT touch the local skills dir
 
   test("applyClaudeVault dryRun=true does not extract skill artifacts", async () => {
     const { generateIdentity, identityToRecipient, encryptString } = await import(

--- a/src/agents/__tests__/codex.test.ts
+++ b/src/agents/__tests__/codex.test.ts
@@ -40,7 +40,7 @@ afterAll(() => {
   Object.assign(testCodexPaths, originalCodexPaths);
 });
 
-// T019 — snapshotCodex
+// snapshotCodex
 
 describe("snapshotCodex", () => {
   let tmpDir: string;
@@ -100,7 +100,7 @@ describe("snapshotCodex", () => {
     expect(authArt).toBeUndefined();
   });
 
-  // T017(1) — US2 Codex skill round-trip happy path (FR-001, FR-003, FR-004)
+  // Codex skill round-trip happy path
 
   test("snapshots a real Codex skill directory as a base64 tar artifact", async () => {
     const skillDir = join(testCodexPaths.skillsDir, "my-skill");
@@ -118,9 +118,9 @@ describe("snapshotCodex", () => {
     expect(art!.plaintext.length).toBeGreaterThan(0);
   });
 
-  // T017(5) — FR-009 missing-dir case at the agent layer
+  // missing-dir case at the agent layer
 
-  test("snapshotCodex does not throw when the skills directory is missing (FR-009)", async () => {
+  test("snapshotCodex does not throw when the skills directory is missing", async () => {
     testCodexPaths.skillsDir = join(tmpDir, "skills-does-not-exist");
 
     const result = await codexModule.snapshotCodex();
@@ -129,9 +129,9 @@ describe("snapshotCodex", () => {
     expect(result.warnings.filter((w) => w.startsWith("never-sync"))).toHaveLength(0);
   });
 
-  // T017(6) — FR-016 interior-symlink defense-in-depth at the agent layer
+  // interior-symlink defense-in-depth at the agent layer
 
-  test("snapshotCodex omits interior symlink helper files from the tar (FR-016 inner)", async () => {
+  test("snapshotCodex omits interior symlink helper files from the tar", async () => {
     // Vendored helper outside the skills root.
     const helperTargetParent = join(tmpDir, "vendored-helpers");
     mkdirSync(helperTargetParent, { recursive: true });
@@ -163,9 +163,9 @@ describe("snapshotCodex", () => {
     expect(entries).not.toContain("helper.md");
   });
 
-  // T018 — FR-017 dot-skip regression specific to Codex (.system vendor bundle)
+  // dot-skip regression specific to Codex (.system vendor bundle)
 
-  test("snapshotCodex skips a top-level .system directory (FR-017 dot-skip)", async () => {
+  test("snapshotCodex skips a top-level .system directory", async () => {
     // Real skill alongside a .system/ directory which represents a vendor bundle
     // that Codex may ship with its installer. The dot-skip rule MUST filter this
     // out regardless of whether it contains a valid SKILL.md sentinel.
@@ -184,7 +184,7 @@ describe("snapshotCodex", () => {
   });
 });
 
-// T025 — applyCodexAgentsMd / applyCodexConfig / applyCodexRule
+// applyCodexAgentsMd / applyCodexConfig / applyCodexRule
 
 describe("apply* functions", () => {
   let tmpDir: string;
@@ -231,7 +231,7 @@ describe("apply* functions", () => {
     expect(content).toBe("## Testing rules");
   });
 
-  // T017(2) — applyCodexSkill direct extraction test
+  // applyCodexSkill direct extraction test
 
   test("applyCodexSkill extracts a tar archive into the local skills dir", async () => {
     const srcSkill = join(tmpDir, "src-skill");
@@ -252,7 +252,7 @@ describe("apply* functions", () => {
   });
 });
 
-// T028 — dryRun (applyCodexVault)
+// dryRun (applyCodexVault)
 
 describe("applyCodexVault dryRun", () => {
   let tmpDir: string;
@@ -290,7 +290,7 @@ describe("applyCodexVault dryRun", () => {
     expect(exists).toBeFalse();
   });
 
-  // T017(3) — applyCodexVault restores a Codex skill from an encrypted artifact
+  // applyCodexVault restores a Codex skill from an encrypted artifact
 
   test("applyCodexVault restores a Codex skill from an encrypted vault artifact", async () => {
     const { generateIdentity, identityToRecipient, encryptString } = await import(
@@ -322,7 +322,7 @@ describe("applyCodexVault dryRun", () => {
     expect(restoredGuide).toBe("# guide");
   });
 
-  // T017(4) — applyCodexVault dryRun=true must NOT touch the local skills dir
+  // applyCodexVault dryRun=true must NOT touch the local skills dir
 
   test("applyCodexVault dryRun=true does not extract skill artifacts", async () => {
     const { generateIdentity, identityToRecipient, encryptString } = await import(

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -40,7 +40,7 @@ afterAll(() => {
   Object.assign(testCopilotPaths, originalCopilotPaths);
 });
 
-// T020 — snapshotCopilot
+// snapshotCopilot
 
 describe("snapshotCopilot", () => {
   let tmpDir: string;
@@ -144,10 +144,10 @@ describe("snapshotCopilot", () => {
     expect(() => Buffer.from(art!.plaintext, "base64")).not.toThrow();
   });
 
-  // T010 — walker retrofit regression: the new snapshotCopilot must inherit
-  // the FR-016 (symlink) and FR-017 (dot-skip) rules from the shared walker.
+  // walker retrofit regression: snapshotCopilot must inherit the
+  // symlink-rejection and dot-skip rules from the shared walker.
 
-  test("retrofit: top-level symlinked skill root produces zero artifacts (FR-016)", async () => {
+  test("retrofit: top-level symlinked skill root produces zero artifacts", async () => {
     // Build a "vendored pool" outside the skills root and symlink it in.
     const vendoredTarget = join(tmpDir, "vendored-pool", "vendor-skill");
     mkdirSync(vendoredTarget, { recursive: true });
@@ -161,7 +161,7 @@ describe("snapshotCopilot", () => {
     expect(skillArts).toHaveLength(0);
   });
 
-  test("retrofit: top-level .system directory is skipped (FR-017)", async () => {
+  test("retrofit: top-level .system directory is skipped", async () => {
     const systemSkill = join(testCopilotPaths.skillsDir, ".system", "vendor");
     mkdirSync(systemSkill, { recursive: true });
     writeFileSync(join(systemSkill, "SKILL.md"), "# vendor", "utf8");
@@ -171,7 +171,7 @@ describe("snapshotCopilot", () => {
     expect(skillArts).toHaveLength(0);
   });
 
-  test("retrofit: real skill with interior symlink helper omits the helper (FR-016 inner)", async () => {
+  test("retrofit: real skill with interior symlink helper omits the helper", async () => {
     // Vendored helper file outside the skills root.
     const helperTargetDir = join(tmpDir, "vendored-helpers");
     mkdirSync(helperTargetDir, { recursive: true });
@@ -205,7 +205,7 @@ describe("snapshotCopilot", () => {
   });
 });
 
-// T026 — applyCopilotInstructions / applyCopilotSkill / applyCopilotAgent
+// applyCopilotInstructions / applyCopilotSkill / applyCopilotAgent
 
 describe("apply* functions", () => {
   let tmpDir: string;
@@ -278,7 +278,7 @@ describe("apply* functions", () => {
   });
 });
 
-// T028 — dryRun (applyCopilotVault)
+// dryRun (applyCopilotVault)
 
 describe("applyCopilotVault dryRun", () => {
   let tmpDir: string;

--- a/src/agents/__tests__/cursor.test.ts
+++ b/src/agents/__tests__/cursor.test.ts
@@ -38,7 +38,7 @@ afterAll(() => {
   Object.assign(testCursorPaths, originalCursorPaths);
 });
 
-// ── T021 — snapshotCursor ─────────────────────────────────────────────────────
+// ── snapshotCursor ─────────────────────────────────────────────────────
 
 describe("snapshotCursor", () => {
   let tmpDir: string;
@@ -129,7 +129,7 @@ describe("snapshotCursor", () => {
     expect(commands.some((a) => a.vaultPath === "cursor/commands/explain.md.age")).toBe(true);
   });
 
-  // T020(1) — US3 Cursor skill round-trip happy path (FR-001, FR-003, FR-004)
+  // Cursor skill round-trip happy path
 
   test("snapshots a real Cursor skill directory as a base64 tar artifact", async () => {
     const { snapshotCursor } = cursorModule;
@@ -148,9 +148,9 @@ describe("snapshotCursor", () => {
     expect(art!.plaintext.length).toBeGreaterThan(0);
   });
 
-  // T020(5) — FR-009 missing-dir case at the agent layer
+  // missing-dir case at the agent layer
 
-  test("snapshotCursor does not throw when the skills directory is missing (FR-009)", async () => {
+  test("snapshotCursor does not throw when the skills directory is missing", async () => {
     const { snapshotCursor } = cursorModule;
     testCursorPaths.skillsDir = join(tmpDir, "skills-does-not-exist");
 
@@ -160,9 +160,9 @@ describe("snapshotCursor", () => {
     expect(result.warnings.filter((w) => w.startsWith("never-sync"))).toHaveLength(0);
   });
 
-  // T020(6) — FR-016 interior-symlink defense-in-depth at the agent layer
+  // interior-symlink defense-in-depth at the agent layer
 
-  test("snapshotCursor omits interior symlink helper files from the tar (FR-016 inner)", async () => {
+  test("snapshotCursor omits interior symlink helper files from the tar", async () => {
     const { snapshotCursor } = cursorModule;
     const helperTargetParent = join(tmpDir, "vendored-helpers");
     mkdirSync(helperTargetParent, { recursive: true });
@@ -193,12 +193,12 @@ describe("snapshotCursor", () => {
     expect(entries).not.toContain("helper.md");
   });
 
-  // T021 — FR-010 negative assertion: ~/.cursor/skills-cursor/ is never read.
-  // This is the load-bearing test for US3 because it is the only direct
+  // negative assertion: ~/.cursor/skills-cursor/ is never read.
+  // This is the load-bearing test because it is the only direct
   // evidence that the Cursor adapter is pointed at the canonical "skills"
   // path and never touches the bundled "skills-cursor" directory.
 
-  test("snapshotCursor never touches ~/.cursor/skills-cursor/ (FR-010)", async () => {
+  test("snapshotCursor never touches ~/.cursor/skills-cursor/", async () => {
     const { snapshotCursor } = cursorModule;
     // Real skill at the canonical path.
     const realSkill = join(testCursorPaths.skillsDir, "my-skill");
@@ -220,7 +220,7 @@ describe("snapshotCursor", () => {
   });
 });
 
-// ── T027 — cursor apply functions ─────────────────────────────────────────────
+// ── cursor apply functions ─────────────────────────────────────────────
 
 describe("cursor apply functions", () => {
   let tmpDir: string;
@@ -282,7 +282,7 @@ describe("cursor apply functions", () => {
     expect(await Bun.file(target).text()).toBe("# My Cmd\nDo things.");
   });
 
-  // T020(2) — applyCursorSkill direct extraction test
+  // applyCursorSkill direct extraction test
 
   test("applyCursorSkill extracts a tar archive into the local skills dir", async () => {
     const { applyCursorSkill } = cursorModule;
@@ -304,7 +304,7 @@ describe("cursor apply functions", () => {
   });
 });
 
-// ── T028 — dryRun vault apply ─────────────────────────────────────────────────
+// ── dryRun vault apply ─────────────────────────────────────────────────
 
 describe("applyCursorVault dryRun", () => {
   let tmpDir: string;
@@ -339,7 +339,7 @@ describe("applyCursorVault dryRun", () => {
     expect(await Bun.file(testCursorPaths.settingsJson).exists()).toBe(false);
   });
 
-  // T020(3) — applyCursorVault restores a Cursor skill from an encrypted artifact
+  // applyCursorVault restores a Cursor skill from an encrypted artifact
 
   test("applyCursorVault restores a Cursor skill from an encrypted vault artifact", async () => {
     const { applyCursorVault } = cursorModule;
@@ -369,7 +369,7 @@ describe("applyCursorVault dryRun", () => {
     expect(restoredGuide).toBe("# guide");
   });
 
-  // T020(4) — applyCursorVault dryRun=true must NOT touch the local skills dir
+  // applyCursorVault dryRun=true must NOT touch the local skills dir
 
   test("applyCursorVault dryRun=true does not extract skill artifacts", async () => {
     const { applyCursorVault } = cursorModule;

--- a/src/agents/__tests__/registry.test.ts
+++ b/src/agents/__tests__/registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Agents } from "../registry";
 
-// T023 — Agents registry
+// Agents registry
 
 describe("Agents registry", () => {
   test("contains exactly 5 agents", () => {

--- a/src/agents/__tests__/skills-walker.test.ts
+++ b/src/agents/__tests__/skills-walker.test.ts
@@ -30,8 +30,8 @@ describe("collectSkillArtifacts", () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  // Row 2 — missing skills root (FR-009)
-  test("returns empty result when skills root does not exist (FR-009)", async () => {
+  // Row 2 — missing skills root
+  test("returns empty result when skills root does not exist", async () => {
     const result = await collectSkillArtifacts("claude", join(tmpDir, "does-not-exist"));
     expect(result.artifacts).toHaveLength(0);
     expect(result.warnings).toHaveLength(0);
@@ -54,7 +54,7 @@ describe("collectSkillArtifacts", () => {
   });
 
   // Row 4 — directory missing SKILL.md sentinel
-  test("skips a directory that has no SKILL.md sentinel (FR-002)", async () => {
+  test("skips a directory that has no SKILL.md sentinel", async () => {
     const skillDir = join(tmpDir, "no-sentinel");
     await mkdir(skillDir, { recursive: true });
     await writeFile(join(skillDir, "README.md"), "# notes", "utf8");
@@ -64,8 +64,8 @@ describe("collectSkillArtifacts", () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  // Row 5 — SKILL.md is itself a symlink (FR-016 sentinel back-door)
-  test("skips a skill whose SKILL.md is itself a symlink (FR-016 sentinel guard)", async () => {
+  // Row 5 — SKILL.md is itself a symlink
+  test("skips a skill whose SKILL.md is itself a symlink", async () => {
     const realSentinel = join(tmpDir, ".vendored-sentinel.md");
     await writeFile(realSentinel, "# vendored", "utf8");
 
@@ -78,8 +78,8 @@ describe("collectSkillArtifacts", () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  // Row 6 — top-level symlink root pointing into a vendored pool (FR-016 outer)
-  test("skips a top-level symlinked skill root (FR-016 outer tier)", async () => {
+  // Row 6 — top-level symlink root pointing into a vendored pool
+  test("skips a top-level symlinked skill root", async () => {
     const targetSkill = join(tmpDir, ".vendored-pool", "real-target");
     await mkdir(targetSkill, { recursive: true });
     await writeFile(join(targetSkill, "SKILL.md"), "# vendored skill", "utf8");
@@ -91,8 +91,8 @@ describe("collectSkillArtifacts", () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  // Row 7 — top-level .system directory containing a real skill (FR-017)
-  test("skips a top-level .system directory (FR-017 dot-skip)", async () => {
+  // Row 7 — top-level .system directory containing a real skill
+  test("skips a top-level .system directory", async () => {
     const systemSkill = join(tmpDir, ".system", "vendor-skill");
     await mkdir(systemSkill, { recursive: true });
     await writeFile(join(systemSkill, "SKILL.md"), "# vendor", "utf8");
@@ -102,8 +102,8 @@ describe("collectSkillArtifacts", () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  // Row 8 — top-level .DS_Store regular file (FR-017)
-  test("skips a top-level .DS_Store file (FR-017 dot-skip)", async () => {
+  // Row 8 — top-level .DS_Store regular file
+  test("skips a top-level .DS_Store file", async () => {
     await writeFile(join(tmpDir, ".DS_Store"), "binary", "utf8");
     const result = await collectSkillArtifacts("claude", tmpDir);
     expect(result.artifacts).toHaveLength(0);
@@ -132,8 +132,8 @@ describe("collectSkillArtifacts", () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  // Row 10 — real skill with interior symlink helper file (FR-016 inner)
-  test("archives a real skill while omitting interior symlink helper files (FR-016 inner tier)", async () => {
+  // Row 10 — real skill with interior symlink helper file
+  test("archives a real skill while omitting interior symlink helper files", async () => {
     const helperTargetParent = join(tmpDir, ".helper-pool");
     await mkdir(helperTargetParent, { recursive: true });
     const helperTarget = join(helperTargetParent, "shared.md");
@@ -161,8 +161,8 @@ describe("collectSkillArtifacts", () => {
     expect(entries).not.toContain("helper.md");
   });
 
-  // Row 11 — skill containing a never-sync file (FR-006)
-  test("rejects a skill that contains a never-sync file (FR-006)", async () => {
+  // Row 11 — skill containing a never-sync file
+  test("rejects a skill that contains a never-sync file", async () => {
     const skillDir = join(tmpDir, "dirty-skill");
     await mkdir(skillDir, { recursive: true });
     await writeFile(join(skillDir, "SKILL.md"), "# dirty", "utf8");
@@ -199,13 +199,13 @@ describe("collectSkillArtifacts", () => {
     expect(result.warnings[0]?.startsWith("never-sync inside skill: ")).toBe(true);
   });
 
-  // Row 13 — the skills root path itself is a symlink (NC-1 from PR review).
-  // Resolves the spec ambiguity toward the conservative "skills I created"
-  // intent: if the entire root is a symlink (e.g., a power user has done
+  // Row 13 — the skills root path itself is a symlink. Resolves the spec
+  // ambiguity toward the conservative "skills I created" intent: if the
+  // entire root is a symlink (e.g., a power user has done
   // `ln -s /srv/team-pool ~/.claude/skills`), the walker MUST refuse to
-  // enumerate it. The same anti-vendoring rule that FR-016 applies to
-  // individual entries extends to the root by consistency.
-  test("returns empty when the skills root path is itself a symlink (NC-1)", async () => {
+  // enumerate it. The anti-vendoring rule that rejects symlinked entries
+  // extends to the root by consistency.
+  test("returns empty when the skills root path is itself a symlink", async () => {
     const realRoot = join(tmpDir, "real-pool");
     await mkdir(realRoot, { recursive: true });
     // Populate it with a real skill so we can prove the walker WOULD have

--- a/src/agents/__tests__/vscode.test.ts
+++ b/src/agents/__tests__/vscode.test.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
   vsCodeModule = await import("../vscode");
 });
 
-// ── T022 — snapshotVsCode ─────────────────────────────────────────────────────
+// ── snapshotVsCode ─────────────────────────────────────────────────────
 
 describe("snapshotVsCode", () => {
   let tmpDir: string;
@@ -92,7 +92,7 @@ describe("snapshotVsCode", () => {
   });
 });
 
-// ── T027 — applyVsCodeMcp ─────────────────────────────────────────────────────
+// ── applyVsCodeMcp ─────────────────────────────────────────────────────
 
 describe("applyVsCodeMcp", () => {
   let tmpDir: string;
@@ -114,7 +114,7 @@ describe("applyVsCodeMcp", () => {
   });
 });
 
-// ── T028 — dryRun vault apply ─────────────────────────────────────────────────
+// ── dryRun vault apply ─────────────────────────────────────────────────
 
 describe("applyVsCodeVault dryRun", () => {
   let tmpDir: string;

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -107,7 +107,7 @@ export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<S
     // agents dir may not exist yet.
   }
 
-  // Skills — delegated to the shared walker (FR-001/FR-002/FR-006/FR-016/FR-017).
+  // Skills — delegated to the shared walker.
   // The walker handles dot-skip, symlink rejection, sentinel verification, the
   // never-sync interior scan, and the symlink-filtered tar archival in one
   // place so every skill-bearing agent inherits identical rules.
@@ -546,7 +546,7 @@ export async function applyClaudeVault(
     }
   }
 
-  // Skills sub-directory — stored as <name>.tar.age (FR-005). Mirrors the
+  // Skills sub-directory — stored as <name>.tar.age. Mirrors the
   // Copilot apply path: each entry is decrypted, then the inner base64 tar
   // is extracted into ~/.claude/skills/<name>/ via applyClaudeSkill.
   const skillFiles = await readAgeFiles(join(claudeDir, "skills"));

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -86,9 +86,9 @@ export async function snapshotCodex(): Promise<SnapshotResult> {
     // rules dir may not exist yet
   }
 
-  // Skills — delegated to the shared walker (FR-001/FR-002/FR-006/FR-016/FR-017).
+  // Skills — delegated to the shared walker.
   // The walker enforces dot-skip (which covers Codex's vendored `.system/`
-  // bundle — FR-017), symlink rejection at the root, sentinel verification,
+  // bundle), symlink rejection at the root, sentinel verification,
   // the never-sync interior scan, and the symlink-filtered tar archival in one
   // place so every skill-bearing agent inherits identical rules.
   const codexSkills = await collectSkillArtifacts("codex", AgentPaths.codex.skillsDir);
@@ -214,7 +214,7 @@ export async function applyCodexVault(
     }
   }
 
-  // Skills sub-directory — stored as <name>.tar.age (FR-005). Mirrors the
+  // Skills sub-directory — stored as <name>.tar.age. Mirrors the
   // Claude/Copilot apply path: each entry is decrypted, then the inner base64
   // tar is extracted into ~/.codex/skills/<name>/ via applyCodexSkill.
   const skillFiles = await readAgeFiles(join(codexDir, "skills"));

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -68,11 +68,11 @@ export async function snapshotCopilot(): Promise<SnapshotResult> {
     // directory may not exist
   }
 
-  // Skills — delegated to the shared walker so the FR-002, FR-006, FR-016,
-  // and FR-017 rules from the agent-skills-sync feature are enforced
-  // identically across every skill-bearing agent. The walker uses lstat
-  // throughout, so symlinked roots and symlinked SKILL.md sentinels (the
-  // vendored-pool patterns observed on real machines) are correctly skipped.
+  // Skills — delegated to the shared walker so dot-skip, symlink rejection,
+  // sentinel verification, never-sync interior scan, and symlink-filtered
+  // archival stay identical across every skill-bearing agent. The walker
+  // uses lstat throughout, so symlinked roots and symlinked SKILL.md
+  // sentinels (the vendored-pool pattern seen on real machines) are skipped.
   const copilotSkills = await collectSkillArtifacts("copilot", AgentPaths.copilot.skillsDir);
   artifacts.push(...copilotSkills.artifacts);
   warnings.push(...copilotSkills.warnings);

--- a/src/agents/cursor.ts
+++ b/src/agents/cursor.ts
@@ -92,7 +92,7 @@ export async function snapshotCursor(): Promise<SnapshotResult> {
 
   // Skills — delegated to the shared walker. The walker is pointed at
   // `AgentPaths.cursor.skillsDir` which resolves to `~/.cursor/skills/` —
-  // the FR-010 canonical path. The bundled `~/.cursor/skills-cursor/`
+  // the canonical user-skills path. The bundled `~/.cursor/skills-cursor/`
   // directory is NEVER read because `paths.ts` does not expose it and the
   // walker is not given a pointer to it, so there is no code path through
   // which vendor bundles can leak into the vault.
@@ -132,7 +132,7 @@ export async function applyCursorCommand(commandName: string, content: string): 
 /**
  * Restore one Cursor skill directory from the vault by extracting its
  * encrypted tar archive into `~/.cursor/skills/<name>/` — NEVER into the
- * bundled `~/.cursor/skills-cursor/` path (FR-010).
+ * bundled `~/.cursor/skills-cursor/` path.
  *
  * Mirrors {@link applyClaudeSkill}: parents are created on demand and the
  * tar's interior layout is preserved bit-for-bit.
@@ -212,7 +212,7 @@ export async function applyCursorVault(
     }
   }
 
-  // Skills sub-directory — stored as <name>.tar.age (FR-005). Mirrors the
+  // Skills sub-directory — stored as <name>.tar.age. Mirrors the
   // Claude/Codex/Copilot apply path: each entry is decrypted, then the inner
   // base64 tar is extracted into ~/.cursor/skills/<name>/ via applyCursorSkill.
   // The top-level unrecognised-file warning above is inspecting only top-level

--- a/src/agents/skills-walker.ts
+++ b/src/agents/skills-walker.ts
@@ -1,22 +1,21 @@
 /**
- * src/agents/skills-walker.ts
+ * Shared skill-collection helper for every skill-bearing agent (Claude,
+ * Cursor, Codex, Copilot). Lives in one place so adapters cannot drift
+ * apart on the gating rules. Gates applied in order:
  *
- * Shared skill-collection helper used by every skill-bearing agent adapter
- * (Claude, Cursor, Codex, Copilot). Encapsulates the five gates required by
- * the agent-skills-sync feature so the rules live in exactly one place:
+ *   1. Dot-prefixed top-level entries are skipped silently (hidden by convention).
+ *   2. Symlinked top-level entries are skipped silently so vendored or
+ *      shared-pool skills the user did not author cannot slip in.
+ *   3. Entries without a real, non-symlink `SKILL.md` sentinel are skipped
+ *      silently so only authored skills sync.
+ *   4. Interior paths matching `NEVER_SYNC_PATTERNS` emit a
+ *      `never-sync inside skill: ` warning that the push pipeline escalates
+ *      to a fatal abort, so secrets nested inside a skill cannot leak.
+ *   5. Interior symlinks are filtered from the tar archive so vendored
+ *      files cannot smuggle in through a symlinked child.
  *
- *   1. FR-017 — top-level dot-prefixed entries are skipped (silent).
- *   2. FR-016 — entries that are symlinks are skipped (silent).
- *   3. FR-002 — entries without a real (non-symlink) `SKILL.md` sentinel are
- *               skipped (silent).
- *   4. FR-006 — interior file paths matching `NEVER_SYNC_PATTERNS` cause the
- *               skill to be rejected with a `never-sync inside skill:`
- *               warning that the push pipeline escalates to a fatal error.
- *   5. FR-016 — interior symlink files and sub-directories are omitted from
- *               the archive while real surrounding content is still archived.
- *
- * The walker NEVER throws on filesystem read errors and NEVER emits log
- * output. Quiet by design — see contracts/walker-interface.md for the rules.
+ * Silent by design: never throws on filesystem errors, never logs. Errors
+ * travel back as warnings on the result so the caller decides how to surface.
  */
 
 import { lstat, readdir } from "node:fs/promises";
@@ -81,8 +80,8 @@ export class InvalidSkillNameError extends Error {
  *   - resolve to a different directory under `path.join` (`.`, `..`, empty)
  *   - contain a path separator on any platform (`/` on POSIX, `\` on Windows)
  *   - collide with hidden-file rules the walker applies on the push side
- *     (dot-prefixed names are silently skipped during push, so pull should
- *     not manufacture them either — see FR-017)
+ *     (dot-prefixed names are silently skipped during push, so pull must
+ *     not manufacture them or the next push would drop them)
  *   - smuggle control characters or NUL bytes that shell or filesystem
  *     layers might interpret inconsistently
  *
@@ -120,15 +119,15 @@ export function validateSkillName(name: string): void {
  * @param agent      Vault namespace this walker writes under (`claude`, `cursor`, `codex`, `copilot`).
  * @param skillsDir  Absolute path to the agent's skills root on disk. A
  *                   missing directory is NOT an error — the walker returns
- *                   an empty result (FR-009). A skills root that is itself a
+ *                   an empty result. A skills root that is itself a
  *                   symbolic link is also rejected (returns empty) under the
  *                   "skills I created" spec intent — the same anti-vendoring
- *                   rule that FR-016 applies to individual skill entries
+ *                   rule that rejects symlinked entries individually
  *                   extends to the root by consistency.
  * @returns          A {@link SkillsWalkerResult} with one artifact per
  *                   qualifying skill and zero or more warnings: each
  *                   `never-sync inside skill: ` warning is escalated to a
- *                   fatal abort by the push pipeline (FR-006), and each
+ *                   fatal abort by the push pipeline, and each
  *                   `skill archive failed: ` warning is surfaced as a soft
  *                   warning to the user without aborting the push.
  *                   The walker NEVER throws on filesystem read errors.
@@ -145,7 +144,7 @@ export async function collectSkillArtifacts(
   // `~/.claude/skills -> /srv/team-pool` would silently sync every team
   // skill as if it were their own. The check is intentionally `lstat` so a
   // missing path falls through to the catch block below and yields the same
-  // empty no-op as a missing directory (FR-009).
+  // empty no-op as a missing directory.
   try {
     const rootStat = await lstat(skillsDir);
     if (rootStat.isSymbolicLink()) return { artifacts, warnings };
@@ -157,12 +156,12 @@ export async function collectSkillArtifacts(
   try {
     entries = await readdir(skillsDir);
   } catch {
-    // FR-009: missing or unreadable skills root is a no-op, not an error.
+    // missing or unreadable skills root is a no-op, not an error.
     return { artifacts, warnings };
   }
 
   for (const entryName of entries) {
-    // Gate 1 (FR-017): skip dot-prefixed entries silently.
+    // Gate 1: skip dot-prefixed entries silently.
     if (entryName.startsWith(".")) continue;
 
     const entryPath = join(skillsDir, entryName);
@@ -174,12 +173,12 @@ export async function collectSkillArtifacts(
       continue;
     }
 
-    // Gate 2 (FR-016 outer): reject anything that is not a real directory.
+    // Gate 2: reject anything that is not a real directory.
     // A symlink (even one pointing at a directory) fails isDirectory() under
     // lstat — there is no separate symlink check needed.
     if (!entryStat.isDirectory()) continue;
 
-    // Gate 3 (FR-002 + FR-016 sentinel guard): require a REAL `SKILL.md` file.
+    // Gate 3: require a REAL `SKILL.md` file.
     // Using lstat means a symlinked SKILL.md fails the isFile() check, so
     // vendored skills cannot smuggle themselves in via a symlinked sentinel.
     const sentinelPath = join(entryPath, "SKILL.md");
@@ -191,7 +190,7 @@ export async function collectSkillArtifacts(
     }
     if (!sentinelStat.isFile()) continue;
 
-    // Gate 4 (FR-006): never-sync interior walk. The walker collects every
+    // Gate 4: never-sync interior walk. The walker collects every
     // matching path in the skill — not just the first — so the user sees
     // every offender in one push instead of fixing them one at a time.
     const neverSyncHits = await collectNeverSyncHits(entryPath);
@@ -204,12 +203,12 @@ export async function collectSkillArtifacts(
       continue;
     }
 
-    // Gate 5 (FR-016 inner): archive with interior symlinks filtered out.
+    // Gate 5: archive with interior symlinks filtered out.
     let tarBuffer: Buffer;
     try {
       tarBuffer = await archiveDirectory(entryPath, { skipSymlinks: true });
     } catch (err) {
-      // Distinct from the FR-017 / FR-016 silent skips: a tar failure here
+      // Distinct from the dot-skip and symlink silent skips: a tar failure here
       // means the user DID intend the skill to sync but the machine failed
       // (EACCES, EMFILE, transient I/O, etc.). Surfacing this as a warning
       // gives the user a fighting chance to notice and fix it. The push
@@ -239,7 +238,7 @@ export async function collectSkillArtifacts(
  * file whose path matches a {@link shouldNeverSync} rule.
  *
  * Symlinks (files OR sub-directories) are NOT followed and NOT inspected,
- * which is consistent with FR-016: vendored content reached via a symlink is
+ * which is consistent with the archive step: vendored content reached via a symlink is
  * out of scope for this feature and will not be archived in gate 5 either.
  */
 async function collectNeverSyncHits(rootDir: string): Promise<string[]> {
@@ -263,8 +262,8 @@ async function collectNeverSyncHits(rootDir: string): Promise<string[]> {
       }
 
       if (childStat.isSymbolicLink()) {
-        // Don't follow vendored content. The interior-symlink rule (FR-016
-        // inner) means it would be omitted from the tar in gate 5 anyway.
+        // Skip vendored content. The archive step filters interior symlinks
+        // out anyway, so inspecting them here would only produce noise.
         continue;
       }
 

--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the doctor command's skills-directory checks (FR-008).
+ * Tests for the doctor command's skills-directory checks.
  *
  * The check rows are produced by `buildSkillsDirChecks` so we can unit-test
  * the rule directly without mocking the rest of the doctor pipeline (private
@@ -20,7 +20,7 @@ type MutablePaths = {
 };
 const mutablePaths = AgentPaths as unknown as MutablePaths;
 
-describe("buildSkillsDirChecks (FR-008)", () => {
+describe("buildSkillsDirChecks", () => {
   let tmpDir: string;
   const saved = {
     claude: mutablePaths.claude.skillsDir,
@@ -108,12 +108,12 @@ describe("buildSkillsDirChecks (FR-008)", () => {
     expect(claudeRow?.detail).toContain("not a directory");
   });
 
-  // Thread 8 — parity with the walker's FR-016 rule. The walker refuses to
+  // Parity with the walker's symlink-rejection rule. The walker refuses to
   // enumerate a skills root that is itself a symlink, so doctor must not
   // report `pass` for that same layout. Using `stat` alone would follow the
   // link and see a real directory, hiding the walker's silent refusal from
   // the user.
-  test("reports `warn` when a skills path is a symlink (FR-016 parity)", async () => {
+  test("reports `warn` when a skills path is a symlink", async () => {
     const realRoot = join(tmpDir, "real-claude-skills");
     mkdirSync(realRoot, { recursive: true });
     const linkedRoot = join(tmpDir, "linked-claude-skills");
@@ -127,6 +127,5 @@ describe("buildSkillsDirChecks (FR-008)", () => {
     const claudeRow = rows.find((r) => r.name === "Claude skills directory");
     expect(claudeRow?.status).toBe("warn");
     expect(claudeRow?.detail).toContain("Symlinked skills root");
-    expect(claudeRow?.detail).toContain("FR-016");
   });
 });

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests (T038–T044, T052) — end-to-end command coverage.
+ * Integration tests — end-to-end command coverage.
  *
  * Strategy
  * --------
@@ -213,7 +213,7 @@ describe("integration", () => {
     process.exitCode = 0;
   });
 
-  test("T038 — init command writes agentsync.toml and key.txt in a fresh vault", async () => {
+  test("init command writes agentsync.toml and key.txt in a fresh vault", async () => {
     const initRoot = join(tmpDir, "init-empty-remote");
     mkdirSync(initRoot, { recursive: true });
     const initBare = await createBareRepo(initRoot);
@@ -318,7 +318,7 @@ describe("integration", () => {
     expect(fakeLogs.success.some((message) => message.includes("Initialized vault"))).toBe(false);
   });
 
-  test("T039 — performPush encrypts artifact and writes .age file to vault", async () => {
+  test("performPush encrypts artifact and writes .age file to vault", async () => {
     fakeArtifacts.push({
       vaultPath: "claude/CLAUDE.age",
       sourcePath: "/fake/.claude/CLAUDE.md",
@@ -339,7 +339,7 @@ describe("integration", () => {
     expect(content).toContain("BEGIN AGE ENCRYPTED FILE");
   });
 
-  test("T040 — performPull calls agent.apply for each enabled agent", async () => {
+  test("performPull calls agent.apply for each enabled agent", async () => {
     const result = await pullMod.performPull({ agent: "claude" });
 
     expect(result.fatal).toBe(false);
@@ -348,7 +348,7 @@ describe("integration", () => {
     expect(fakeApplyCalls).toContain(vaultDir);
   });
 
-  test("T052 — performPush aborts when an artifact warning contains 'Redacted literal secret'", async () => {
+  test("performPush aborts when an artifact warning contains 'Redacted literal secret'", async () => {
     fakeArtifacts.push({
       vaultPath: "claude/settings.age",
       sourcePath: "/fake/.claude/settings.json",
@@ -365,7 +365,7 @@ describe("integration", () => {
     expect(result.errors.some((message) => message.includes("Redacted literal secret"))).toBe(true);
   });
 
-  test("T041 — status command runs without throwing", async () => {
+  test("status command runs without throwing", async () => {
     const statusMod = await import("../../commands/status");
     await statusMod.statusCommand.run?.({
       args: { verbose: false },
@@ -374,7 +374,7 @@ describe("integration", () => {
     } as never);
   });
 
-  test("T042 — doctor command runs without throwing", async () => {
+  test("doctor command runs without throwing", async () => {
     const doctorMod = await import("../../commands/doctor");
     await doctorMod.doctorCommand.run?.({
       args: {},
@@ -383,7 +383,7 @@ describe("integration", () => {
     } as never);
   });
 
-  test("T043 — key add appends recipient to config and re-encrypts vault files", async () => {
+  test("key add appends recipient to config and re-encrypts vault files", async () => {
     fakeArtifacts.push({
       vaultPath: "claude/CLAUDE.age",
       sourcePath: "/fake/.claude/CLAUDE.md",
@@ -460,7 +460,7 @@ describe("integration", () => {
     expect(machineBConfig.recipients["work-laptop"]).toBe(remoteRecipient);
   });
 
-  test("T044 — key rotate replaces private key and updates config recipient", async () => {
+  test("key rotate replaces private key and updates config recipient", async () => {
     const oldKeyContent = await readFile(keyPath, "utf8");
 
     await (keyMod.keyCommand.subCommands as unknown as Record<string, CommandDef>).rotate.run?.({
@@ -600,14 +600,14 @@ describe("integration", () => {
   });
 });
 
-// ─── T026 — agent-skills-sync integration guarantees ─────────────────────────
+// ─── agent-skills-sync integration guarantees ─────────────────────────
 //
 // These tests run AFTER the main `describe("integration")` block above, so its
 // `afterAll` has already reset the push/pull agent registries to the real
 // `Agents` list. We therefore exercise the REAL Claude adapter (and its
 // walker wiring) rather than the mocked test-only fake used above.
 
-describe("T026 — skills sync integration guarantees", () => {
+describe("skills sync integration guarantees", () => {
   let tmpDir: string;
   let machine: TestMachineFixture;
   type MutableClaudePaths = {
@@ -696,7 +696,7 @@ describe("T026 — skills sync integration guarantees", () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  // FR-013 — pull-side no-delete guarantee.
+  // pull-side no-delete guarantee.
   //
   // This test proves that deleting a skill artifact from the vault (as the
   // `skill remove` verb does) followed by a `pull` on another machine DOES
@@ -705,7 +705,7 @@ describe("T026 — skills sync integration guarantees", () => {
   // `unlink` — so any future regression that adds a local-delete sweep will
   // fail this test.
 
-  test("FR-013 — applyClaudeVault does not delete a local skill when the vault artifact is gone", async () => {
+  test("applyClaudeVault does not delete a local skill when the vault artifact is gone", async () => {
     const { mkdir: mkdirAsync, writeFile: writeFileAsync } = await import("node:fs/promises");
     const { archiveDirectory } = await import("../../core/tar");
     const { encryptString, generateIdentity, identityToRecipient } = await import(
@@ -742,8 +742,9 @@ describe("T026 — skills sync integration guarantees", () => {
     const { unlink: unlinkAsync } = await import("node:fs/promises");
     await unlinkAsync(vaultFile);
 
-    // Second pull against the now-empty vault. FR-013 says the local skill
-    // directory MUST remain intact — no file is added, no file is removed.
+    // Second pull against the now-empty vault. The local skill directory
+    // MUST remain intact, no file added, no file removed: vault delete is
+    // additive-only on the pull side.
     await claude.applyClaudeVault(machine.vaultDir, identity, false);
 
     expect(existsSync(join(localSkillDir, "SKILL.md"))).toBe(true);
@@ -754,17 +755,17 @@ describe("T026 — skills sync integration guarantees", () => {
     expect(skillBody).toBe("# my skill body");
   });
 
-  // SC-009 — negative-space vault content check.
+  // negative-space vault content check.
   //
   // Builds a real ~/.claude/skills/ containing one valid skill plus a
   // top-level symlink that points into a vendored-pool directory containing
   // a secret marker. Runs the REAL `performPush` (registry reset to the real
   // Agents) and decrypts every written artifact to verify that no entry
   // contains the vendored path OR the secret marker content. This is the
-  // walker's outermost safety guarantee — SC-009 fails iff FR-016's
-  // root-symlink rejection rule is bypassed.
+  // walker's outermost safety guarantee: if root-symlink rejection were
+  // bypassed, the secret marker would land in the encrypted vault.
 
-  test("SC-009 — vault never contains vendored-pool content reached through a symlinked skill root", async () => {
+  test("vault never contains vendored-pool content reached through a symlinked skill root", async () => {
     // Build the vendored pool outside the skills directory.
     const vendoredPool = join(tmpDir, "vendored-pool", "sensitive-skill");
     mkdirSync(vendoredPool, { recursive: true });

--- a/src/commands/__tests__/migrate.test.ts
+++ b/src/commands/__tests__/migrate.test.ts
@@ -49,7 +49,7 @@ describe("MigrateOptionsSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  test("rejects same source and target (FR-009)", () => {
+  test("rejects same source and target", () => {
     const result = MigrateOptionsSchema.safeParse({
       from: "claude",
       to: "claude",

--- a/src/commands/__tests__/push.test.ts
+++ b/src/commands/__tests__/push.test.ts
@@ -83,7 +83,7 @@ afterAll(() => {
   mock.restore();
 });
 
-describe("performPush — never-sync inside skill (FR-006)", () => {
+describe("performPush — never-sync inside skill", () => {
   let tmpDir: string;
   let machine: TestMachineFixture;
   const savedEnv: Record<string, string | undefined> = {};
@@ -183,8 +183,8 @@ describe("performPush — never-sync inside skill (FR-006)", () => {
   });
 });
 
-describe("performPush — additive default for local deletes (FR-011 / SC-006)", () => {
-  // T036 — closes the analysis-flagged automated-coverage gap for FR-011.
+describe("performPush — additive default for local deletes", () => {
+  // closes the analysis-flagged automated-coverage gap.
   // Uses the same Copilot fixture pattern as the never-sync test above.
 
   let tmpDir: string;
@@ -250,7 +250,7 @@ describe("performPush — additive default for local deletes (FR-011 / SC-006)",
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  test("local skill deletion does NOT mutate the vault artifact (FR-011)", async () => {
+  test("local skill deletion does NOT mutate the vault artifact", async () => {
     // First push: create one Copilot skill and push it to the vault.
     const skillDir = join(mutableCopilotPaths.skillsDir, "long-lived-skill");
     mkdirSync(skillDir, { recursive: true });
@@ -267,7 +267,7 @@ describe("performPush — additive default for local deletes (FR-011 / SC-006)",
     expect(firstBytes.length).toBeGreaterThan(0);
 
     // Now delete the local skill directory and push again. The additive
-    // default (FR-011) demands that the vault artifact stays exactly as it
+    // default demands that the vault artifact stays exactly as it
     // was — a stray local `rm -rf` must not propagate to other machines.
     await rm(skillDir, { recursive: true, force: true });
 

--- a/src/commands/__tests__/shared.test.ts
+++ b/src/commands/__tests__/shared.test.ts
@@ -3,7 +3,7 @@ import { rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
 
-// T037 — resolveRuntimeContext + loadPrivateKey
+// resolveRuntimeContext + loadPrivateKey
 
 // Both functions read env vars / files at CALL TIME (not baked), so standard
 // import + env var injection works without module mocking.

--- a/src/commands/__tests__/skill.test.ts
+++ b/src/commands/__tests__/skill.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the `agentsync skill remove` CLI verb (T023).
+ * Tests for the `agentsync skill remove` CLI verb.
  *
  * These tests exercise the testable core `performSkillRemove` directly — they
  * do not mock git because `performSkillRemove` uses a real `GitClient` against
@@ -82,7 +82,7 @@ afterAll(() => {
   mock.restore();
 });
 
-describe("performSkillRemove — contract rows (T023)", () => {
+describe("performSkillRemove — contract rows", () => {
   let tmpDir: string;
   let machine: TestMachineFixture;
   const savedEnv: Record<string, string | undefined> = {};
@@ -173,7 +173,7 @@ describe("performSkillRemove — contract rows (T023)", () => {
     expect(result.status).toBe("success");
     // Vault file gone.
     expect(existsSync(join(skillsVaultDir, "my-skill.tar.age"))).toBe(false);
-    // Local file still present (FR-012 leave-local-alone guarantee).
+    // Local file still present.
     expect(existsSync(join(localSkill, "SKILL.md"))).toBe(true);
     // A commit sha should be attached to the success result.
     if (result.status === "success") {
@@ -221,7 +221,7 @@ describe("performSkillRemove — contract rows (T023)", () => {
   });
 });
 
-describe("skillCommand — citty wrapper (T023 exit codes)", () => {
+describe("skillCommand — citty wrapper", () => {
   let tmpDir: string;
   let machine: TestMachineFixture;
   const savedEnv: Record<string, string | undefined> = {};

--- a/src/commands/__tests__/status.test.ts
+++ b/src/commands/__tests__/status.test.ts
@@ -52,7 +52,7 @@ describe("status colour mapping", () => {
   });
 });
 
-// T035 — FR-007 closes the analysis-flagged automated-coverage gap.
+// closes the analysis-flagged automated-coverage gap.
 // Proves the status command surfaces drift for skill .tar.age artifacts via
 // the existing collectAgeFiles walker, using the REAL Copilot agent path so
 // the proof carries to every other skill-bearing agent that calls the same
@@ -105,7 +105,7 @@ const mutableCopilotPaths = AgentPaths.copilot as MutableCopilotPaths;
 
 const RUNTIME_ENV_KEYS = ["AGENTSYNC_VAULT_DIR", "AGENTSYNC_KEY_PATH", "AGENTSYNC_MACHINE"];
 
-describe("status — FR-007 surfaces skill drift", () => {
+describe("status surfaces skill drift", () => {
   let tmpDir: string;
   let machine: TestMachineFixture;
   const savedEnv: Record<string, string | undefined> = {};

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -19,14 +19,14 @@ export interface Check {
 
 /**
  * Build the readability check rows for the per-agent skills directories
- * introduced by the agent-skills-sync feature (FR-008). Extracted into its
+ * introduced by the agent-skills-sync feature. Extracted into its
  * own helper so the rule can be unit-tested without mocking the rest of the
  * doctor pipeline.
  *
  * Each agent gets exactly one row:
  *   - `pass` when the path exists, is a real directory, and is readable
  *   - `warn` when the path does not exist, is unreadable, is a symbolic
- *     link (walker refuses to enumerate symlinked roots per FR-016), or
+ *     link (walker refuses to enumerate symlinked roots), or
  *     exists but is not a directory (e.g. the user accidentally created
  *     `~/.claude/skills` as a regular file instead of a directory)
  *
@@ -56,7 +56,7 @@ export async function buildSkillsDirChecks(): Promise<Check[]> {
         checks.push({
           name,
           status: "warn",
-          detail: `Symlinked skills root is not synced (FR-016): ${dir}`,
+          detail: `Symlinked skills root is not synced: ${dir}`,
         });
         continue;
       }
@@ -148,8 +148,8 @@ export const doctorCommand = defineCommand({
       });
     }
 
-    // 3a. Per-agent skills directories (agent-skills-sync feature, FR-008).
-    // Delegated to a testable helper so the rule has its own unit test.
+    // 3a. Per-agent skills directory readability checks. Delegated to a
+    // testable helper so the rule has its own unit test.
     checks.push(...(await buildSkillsDirChecks()));
 
     // 4. Vault config parses correctly against schema

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -111,7 +111,7 @@ export async function performPush(
     // emitted on the top-level snapshot.warnings array by the shared skills
     // walker (src/agents/skills-walker.ts), not on individual artifacts. They
     // must also escalate to a fatal abort so a never-sync file inside a skill
-    // directory never reaches encryption (FR-006).
+    // directory never reaches encryption.
     for (const w of snapshot.warnings) {
       if (w.startsWith("never-sync inside skill: ")) {
         secretErrors.push(`[${agent.name}] ${w}`);

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -27,7 +27,7 @@ export type SkillRemoveResult =
 
 /**
  * Remove a single skill from the vault, commit the deletion, and push. Leaves
- * every local skill directory on every machine untouched (FR-012 + FR-013).
+ * every local skill directory on every machine untouched.
  *
  * This function is the testable core — it returns a discriminated result
  * object instead of throwing or calling `process.exit()` so tests can assert

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -50,7 +50,7 @@ describe("loader", () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  // T012 — loadConfig happy path
+  // loadConfig happy path
 
   test("loadConfig parses a valid TOML file", async () => {
     await writeFile(configPath, MINIMAL_TOML, "utf8");
@@ -72,7 +72,7 @@ describe("loader", () => {
     await expect(loadConfig(configPath)).rejects.toThrow();
   });
 
-  // T013 — writeConfig round-trip
+  // writeConfig round-trip
 
   test("writeConfig + loadConfig round-trips a config object", async () => {
     await writeFile(configPath, MINIMAL_TOML, "utf8");
@@ -97,7 +97,7 @@ describe("loader", () => {
     expect(reloaded.version).toBe("1");
   });
 
-  // T014 — resolveConfigPath
+  // resolveConfigPath
 
   test("resolveConfigPath appends agentsync.toml to vaultDir", () => {
     const result = resolveConfigPath("/my/vault");

--- a/src/config/__tests__/paths.test.ts
+++ b/src/config/__tests__/paths.test.ts
@@ -8,7 +8,7 @@ import {
   resolveDaemonSocketPath,
 } from "../paths";
 
-// T015 — AgentPaths shape validation (non-mutable, import-time baked paths)
+// AgentPaths shape validation (non-mutable, import-time baked paths)
 
 describe("paths", () => {
   const HOME = homedir();
@@ -49,15 +49,15 @@ describe("paths", () => {
     expect(AgentPaths.copilot.agentsDir).toContain("agents");
   });
 
-  // T003 — skillsDir entries for the three newly skill-bearing agents (FR-001, FR-010)
+  // skillsDir entries for the three newly skill-bearing agents
 
   test("AgentPaths.claude.skillsDir is ~/.claude/skills/", () => {
     expect(AgentPaths.claude.skillsDir).toBe(join(HOME, ".claude", "skills"));
   });
 
-  test("AgentPaths.cursor.skillsDir is ~/.cursor/skills/ (FR-010 canonical path)", () => {
+  test("AgentPaths.cursor.skillsDir is ~/.cursor/skills/", () => {
     expect(AgentPaths.cursor.skillsDir).toBe(join(HOME, ".cursor", "skills"));
-    // FR-010 forbids reading ~/.cursor/skills-cursor/. The path entry must NOT
+    // forbids reading ~/.cursor/skills-cursor/. The path entry must NOT
     // resolve to that location regardless of platform.
     expect(AgentPaths.cursor.skillsDir).not.toContain("skills-cursor");
   });
@@ -102,7 +102,7 @@ describe("paths", () => {
     expect(paths.skillsDir).toBe(join(root, "skills"));
   });
 
-  // T016 — resolveAgentSyncHome / resolveDaemonSocketPath
+  // resolveAgentSyncHome / resolveDaemonSocketPath
 
   test("resolveAgentSyncHome returns a non-empty string", () => {
     const result = resolveAgentSyncHome();

--- a/src/core/__tests__/encryptor.test.ts
+++ b/src/core/__tests__/encryptor.test.ts
@@ -21,7 +21,7 @@ import {
 }
 
 describe("encryptor", () => {
-  // T004 — generateIdentity + identityToRecipient
+  // generateIdentity + identityToRecipient
 
   test("generateIdentity returns an AGE-SECRET-KEY-1 string", async () => {
     const identity = await generateIdentity();
@@ -41,7 +41,7 @@ describe("encryptor", () => {
     expect(a).not.toBe(b);
   });
 
-  // T005 — encryptString / decryptString round-trip
+  // encryptString / decryptString round-trip
 
   test("encryptString output starts with AGE armor header", async () => {
     const identity = await generateIdentity();
@@ -76,7 +76,7 @@ describe("encryptor", () => {
     );
   });
 
-  // T006 — wrong key
+  // wrong key
 
   test("decryptString throws when wrong identity is used", async () => {
     const id1 = await generateIdentity();
@@ -86,7 +86,7 @@ describe("encryptor", () => {
     await expect(decryptString(armored, id2)).rejects.toThrow();
   });
 
-  // T007 — encryptFile / decryptFile
+  // encryptFile / decryptFile
 
   let tmpDir: string;
 

--- a/src/core/__tests__/git.test.ts
+++ b/src/core/__tests__/git.test.ts
@@ -18,7 +18,7 @@ import { GitClient, type GitReconciliationError } from "../git";
   mock.module("node:fs/promises", () => realFsPromises);
 }
 
-// T036 — GitClient clone, init, commit, push, pull, currentBranch
+// GitClient clone, init, commit, push, pull, currentBranch
 
 // Ensure git is configured for test commits.
 // Only set if the user.email key is missing to avoid overwriting real config.

--- a/src/core/__tests__/ipc.test.ts
+++ b/src/core/__tests__/ipc.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
 import { IpcClient, IpcServer } from "../ipc";
 
-// T029-T032 — IPC server/client communication
+// IPC server/client communication
 // NOTE: macOS has a 104-char hard limit on Unix socket paths.
 // os.tmpdir() returns /var/folders/... which is ~50 chars before the filename,
 // making the full path exceed 104 chars. We use /tmp directly (always short on macOS).
@@ -31,7 +31,7 @@ describe("IpcServer + IpcClient", () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  // T029 — happy path roundtrip
+  // happy path roundtrip
   test("registered handler returns { ok: true, data } for a matching command", async () => {
     server.on("ping", async (args) => ({ pong: true, received: args }));
     await server.listen(socketPath);
@@ -46,7 +46,7 @@ describe("IpcServer + IpcClient", () => {
     });
   });
 
-  // T030 — unknown command
+  // unknown command
   test("unknown command returns { ok: false, error } without crashing the server", async () => {
     await server.listen(socketPath);
 
@@ -58,7 +58,7 @@ describe("IpcServer + IpcClient", () => {
     expect(resp.error).toContain("Unknown command");
   });
 
-  // T031 — no daemon listening
+  // no daemon listening
   test("IpcClient rejects promptly when no server is at the socket path", async () => {
     const client = new IpcClient();
     const nonexistent = join(tmpDir, "does-not-exist.sock");
@@ -66,7 +66,7 @@ describe("IpcServer + IpcClient", () => {
     await expect(client.send("ping", undefined, nonexistent)).rejects.toThrow();
   });
 
-  // T032 — stale socket recovery
+  // stale socket recovery
   test("IpcServer.listen removes a stale socket file and starts successfully", async () => {
     // Plant a stale file where the socket will be
     await Bun.write(socketPath, "stale-socket-data");

--- a/src/core/__tests__/sync-queue.test.ts
+++ b/src/core/__tests__/sync-queue.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { SyncQueue } from "../sync-queue";
 
 describe("SyncQueue", () => {
-  // T013 — two enqueued operations run serially
+  // two enqueued operations run serially
   test("two enqueued operations run serially — second starts only after first resolves", async () => {
     const q = new SyncQueue();
     const order: number[] = [];
@@ -34,7 +34,7 @@ describe("SyncQueue", () => {
     expect(order).toEqual([1, 2]);
   });
 
-  // T013 — serialisation: second does not start while first is running
+  // serialisation: second does not start while first is running
   test("second operation does not start while first is in progress", async () => {
     const q = new SyncQueue();
     let secondStarted = false;
@@ -65,7 +65,7 @@ describe("SyncQueue", () => {
     expect(secondStarted).toBe(true);
   });
 
-  // T014 — whenIdle resolves only after all enqueued work settles
+  // whenIdle resolves only after all enqueued work settles
   test("whenIdle() resolves only after all enqueued work settles", async () => {
     const q = new SyncQueue();
     const results: number[] = [];
@@ -102,7 +102,7 @@ describe("SyncQueue", () => {
     expect(results).toEqual([1]);
   });
 
-  // T014 — whenIdle resolves immediately when queue is empty
+  // whenIdle resolves immediately when queue is empty
   test("whenIdle() resolves immediately when the queue is idle", async () => {
     const q = new SyncQueue();
     await expect(q.whenIdle()).resolves.toBeUndefined();
@@ -115,21 +115,21 @@ describe("SyncQueue", () => {
     expect(result).toBe(42);
   });
 
-  // T058 — close() rejects new enqueues
+  // close() rejects new enqueues
   test("close() causes subsequent enqueue() to reject", async () => {
     const q = new SyncQueue();
     q.close();
     await expect(q.enqueue(async () => 1)).rejects.toThrow("SyncQueue is closed");
   });
 
-  // T058 — whenIdle() still resolves after close()
+  // whenIdle() still resolves after close()
   test("whenIdle() resolves after close() when queue is idle", async () => {
     const q = new SyncQueue();
     q.close();
     await expect(q.whenIdle()).resolves.toBeUndefined();
   });
 
-  // T058 — close() does not abort in-flight work
+  // close() does not abort in-flight work
   test("close() does not abort already-enqueued work", async () => {
     const q = new SyncQueue();
     let ran = false;

--- a/src/core/__tests__/tar.test.ts
+++ b/src/core/__tests__/tar.test.ts
@@ -24,7 +24,7 @@ describe("tar", () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  // T008 — archiveDirectory returns non-empty Buffer
+  // archiveDirectory returns non-empty Buffer
 
   test("archiveDirectory returns a non-empty Buffer", async () => {
     const srcDir = join(tmpDir, "src");
@@ -36,7 +36,7 @@ describe("tar", () => {
     expect(buf.length).toBeGreaterThan(0);
   });
 
-  // T009 — round-trip: archive then extract preserves files
+  // round-trip: archive then extract preserves files
 
   test("archiveDirectory + extractArchive round-trips file contents", async () => {
     const srcDir = join(tmpDir, "src");
@@ -70,7 +70,7 @@ describe("tar", () => {
     await expect(extractArchive(buf, destDir)).resolves.toBeUndefined();
   });
 
-  // T010 — zip-slip protection: absolute path entries are dropped
+  // zip-slip protection: absolute path entries are dropped
 
   test("extractArchive drops absolute-path entries (zip-slip protection)", async () => {
     // Build a normal archive first, then we verify absolute-path filtering logic
@@ -91,7 +91,7 @@ describe("tar", () => {
     expect(text).toBe("ok");
   });
 
-  // T011 — multiple files with unicode names preserved
+  // multiple files with unicode names preserved
 
   test("preserves unicode and hyphenated filenames", async () => {
     const srcDir = join(tmpDir, "src-uni");
@@ -107,7 +107,7 @@ describe("tar", () => {
     expect(text).toBe('key = "value"');
   });
 
-  // T004 — skipSymlinks filter (FR-016 inner tier)
+  // skipSymlinks filter
 
   test("archiveDirectory({ skipSymlinks: true }) omits symlink entries", async () => {
     const srcDir = join(tmpDir, "src-symlink-skip");
@@ -156,10 +156,10 @@ describe("tar", () => {
     // back without throwing on the symlink entry.
   });
 
-  // T004(3) — tar determinism for status hash stability (research R9 caveat)
+  // tar determinism for status hash stability
 
   test("archiveDirectory({ skipSymlinks: true }) is deterministic across calls", async () => {
-    // SC-003 depends on `archiveDirectory` producing identical bytes for the
+    // depends on `archiveDirectory` producing identical bytes for the
     // same directory tree so the status command's SHA-256 comparison is
     // stable. If this test fails, the fix is to set `gzip: { mtime: 0 }` (or
     // equivalent) on the underlying tar.create options so the gzip header

--- a/src/core/__tests__/watcher.test.ts
+++ b/src/core/__tests__/watcher.test.ts
@@ -13,7 +13,7 @@ import { Watcher } from "../watcher";
   mock.module("node:fs/promises", () => realFsPromises);
 }
 
-// T033-T035 — Watcher debounce and lifecycle
+// Watcher debounce and lifecycle
 
 describe("Watcher", () => {
   let tmpDir: string;
@@ -26,7 +26,7 @@ describe("Watcher", () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  // T033 — debounce collapses rapid writes into one callback
+  // debounce collapses rapid writes into one callback
   test("callback fires exactly once for rapid writes within the debounce window", async () => {
     const watcher = new Watcher();
     const fired: string[] = [];
@@ -47,7 +47,7 @@ describe("Watcher", () => {
     expect(fired.length).toBe(1);
   });
 
-  // T034 — remove stops callbacks for that path
+  // remove stops callbacks for that path
   test("Watcher.remove stops callbacks; subsequent writes do not fire", async () => {
     const watcher = new Watcher();
     let fireCount = 0;
@@ -71,7 +71,7 @@ describe("Watcher", () => {
     expect(fireCount).toBe(beforeRemove); // no new events
   });
 
-  // T035 — close stops all watchers
+  // close stops all watchers
   test("Watcher.close stops all watchers; writes after close invoke no callbacks", async () => {
     const watcher = new Watcher();
     let fireCount = 0;

--- a/src/core/tar.ts
+++ b/src/core/tar.ts
@@ -12,9 +12,8 @@ export interface ArchiveDirectoryOptions {
    * still archived. Default `false` preserves the existing tar-everything
    * behavior used by Copilot agent-tarballs.
    *
-   * Set this to `true` for skill-directory archives so vendored helper files
-   * symlinked into a user skill never reach the encrypted vault (FR-016 inner
-   * tier of the agent-skills-sync feature).
+   * Set to `true` for skill-directory archives so vendored helper files
+   * symlinked into a user skill never reach the encrypted vault.
    */
   skipSymlinks?: boolean;
 }

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -268,9 +268,9 @@ describe("startDaemon", () => {
   });
 });
 
-// ── T010a: Second-instance detection (FR-009, SC-005) ─────────────────────────
+// ── Second-instance detection ─────────────────────────
 describe("second-instance detection", () => {
-  test("exits with code 1 and logs 'already running' when daemon responds to health ping (T010a)", async () => {
+  test("exits with code 1 and logs 'already running' when daemon responds to health ping", async () => {
     ipcClientSendSpy.mockResolvedValueOnce({
       id: "test",
       ok: true,
@@ -286,9 +286,9 @@ describe("second-instance detection", () => {
   });
 });
 
-// ── T011/T012/T017: Clean shutdown (US1) ──────────────────────────────────────
-describe("clean shutdown (US1)", () => {
-  test("SIGTERM calls ipc.close() before process.exit(0) (T011)", async () => {
+// ── Clean shutdown ──────────────────────────────────────────────────────
+describe("clean shutdown", () => {
+  test("SIGTERM calls ipc.close() before process.exit(0)", async () => {
     await daemonModule.startDaemon();
     await signalHandlers.get("SIGTERM")?.();
 
@@ -296,7 +296,7 @@ describe("clean shutdown (US1)", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("SIGTERM unlinks the socket path before process.exit(0) (T012)", async () => {
+  test("SIGTERM unlinks the socket path before process.exit(0)", async () => {
     await daemonModule.startDaemon();
 
     // The shutdown function calls unlink(socketPath). Since the socket file doesn't
@@ -309,7 +309,7 @@ describe("clean shutdown (US1)", () => {
     expect(clearedIntervalToken).toBe("daemon-interval");
   });
 
-  test("shutdown sequence: clearInterval → ipc.close → watcher.close → exit(0) (T017)", async () => {
+  test("shutdown sequence: clearInterval → ipc.close → watcher.close → exit(0)", async () => {
     await daemonModule.startDaemon();
     await signalHandlers.get("SIGTERM")?.();
 
@@ -320,9 +320,9 @@ describe("clean shutdown (US1)", () => {
   });
 });
 
-// ── T018-T020: Failure tracking (US2) ─────────────────────────────────────────
-describe("failure tracking (US2)", () => {
-  test("after a failed pull, consecutiveFailures >= 1 and lastError is non-null (T018)", async () => {
+// ── Failure tracking ─────────────────────────────────────────
+describe("failure tracking", () => {
+  test("after a failed pull, consecutiveFailures >= 1 and lastError is non-null", async () => {
     await daemonModule.startDaemon();
 
     // Pull will fail because remote doesn't exist — withRetry calls it twice
@@ -337,7 +337,7 @@ describe("failure tracking (US2)", () => {
     expect(status.lastError).toContain("[pull]");
   });
 
-  test("status IPC handler returns an object matching DaemonStatusSchema shape (T020)", async () => {
+  test("status IPC handler returns an object matching DaemonStatusSchema shape", async () => {
     await daemonModule.startDaemon();
 
     const status = (await ipcHandlers.get("status")?.()) as Record<string, unknown>;
@@ -349,9 +349,9 @@ describe("failure tracking (US2)", () => {
   });
 });
 
-// ── T025-T026: Retry logic (US3) ─────────────────────────────────────────────
-describe("retry logic (US3)", () => {
-  test("when both attempts fail, consecutiveFailures increments to >= 1 and process.exit is NOT called (T026)", async () => {
+// ── Retry logic ─────────────────────────────────────────────
+describe("retry logic", () => {
+  test("when both attempts fail, consecutiveFailures increments to >= 1 and process.exit is NOT called", async () => {
     await daemonModule.startDaemon();
 
     // Push will fail (no remote) — retry also fails
@@ -361,14 +361,14 @@ describe("retry logic (US3)", () => {
       consecutiveFailures: number;
     };
     expect(status.consecutiveFailures).toBeGreaterThanOrEqual(1);
-    // Daemon must NOT exit — it stays alive for the next trigger (SC-004)
+    // Daemon must NOT exit — it stays alive for the next trigger
     expect(exitCode).toBeNull();
   });
 });
 
-// ── T034a/T034b: Startup validation (FR-006, FR-007, SC-006) ─────────────────
-describe("startup validation (US4)", () => {
-  test("exits with code 1 and log contains 'vault' when vault dir is missing (T034a)", async () => {
+// ── T034a/T034b: Startup validation ─────────────────
+describe("startup validation", () => {
+  test("exits with code 1 and log contains 'vault' when vault dir is missing", async () => {
     // Remove the vault directory so loadConfig fails
     process.env.AGENTSYNC_VAULT_DIR = join(tmpDir, "nonexistent-vault");
 
@@ -378,7 +378,7 @@ describe("startup validation (US4)", () => {
     expect(errorLogs.some((m) => m.toLowerCase().includes("startup failed"))).toBe(true);
   });
 
-  test("exits with code 1 when key file is missing (T034b)", async () => {
+  test("exits with code 1 when key file is missing", async () => {
     // Point to a non-existent key file
     process.env.AGENTSYNC_KEY_PATH = join(tmpDir, "nonexistent-key.txt");
 

--- a/src/daemon/__tests__/installer-linux.test.ts
+++ b/src/daemon/__tests__/installer-linux.test.ts
@@ -107,9 +107,9 @@ beforeEach(() => {
   lastExecFileOpts = undefined;
 });
 
-// T034: buildUnit emits correct ExecStart
+// buildUnit emits correct ExecStart
 describe("buildUnit", () => {
-  test("produces ExecStart with each arg quoted plus daemon _run (T034)", () => {
+  test("produces ExecStart with each arg quoted plus daemon _run", () => {
     const unit = m.buildUnit(["bun", "/path/cli.js"]);
     expect(unit).toContain('ExecStart="bun" "/path/cli.js" "daemon" "_run"');
   });
@@ -119,8 +119,8 @@ describe("buildUnit", () => {
     expect(unit).toContain('ExecStart="/usr/local/bin/agentsync" "daemon" "_run"');
   });
 
-  // T063: args containing spaces are quoted per systemd.syntax(7)
-  test("args containing spaces are quoted for systemd (T063)", () => {
+  // args containing spaces are quoted per systemd.syntax(7)
+  test("args containing spaces are quoted for systemd", () => {
     const unit = m.buildUnit(["bun", "/home/user/My Program/cli.js"]);
     expect(unit).toContain('"bun"');
     expect(unit).toContain('"/home/user/My Program/cli.js"');
@@ -128,7 +128,7 @@ describe("buildUnit", () => {
     expect(unit).toContain('"_run"');
   });
 
-  test("args containing backslashes and quotes are C-style escaped (T063)", () => {
+  test("args containing backslashes and quotes are C-style escaped", () => {
     const unit = m.buildUnit(['/path/with"quote', "/path/with\\backslash"]);
     expect(unit).toContain('"/path/with\\"quote"');
     expect(unit).toContain('"/path/with\\\\backslash"');
@@ -192,8 +192,8 @@ describe("startLinux / stopLinux", () => {
     await expect(m.startLinux()).rejects.toThrow("Service not bootstrapped");
   });
 
-  // T070: startLinux passes AbortSignal to execFileAsync
-  test("startLinux passes signal option to execFileAsync for start (T070)", async () => {
+  // startLinux passes AbortSignal to execFileAsync
+  test("startLinux passes signal option to execFileAsync for start", async () => {
     isEnabledStdout = "enabled\n";
     await m.startLinux();
 

--- a/src/daemon/__tests__/installer-macos.test.ts
+++ b/src/daemon/__tests__/installer-macos.test.ts
@@ -119,9 +119,9 @@ beforeEach(() => {
   lastExecFileOpts = undefined;
 });
 
-// ── T029: buildPlist emits separate <string> elements ─────────────────────────
+// ── buildPlist emits separate <string> elements ─────────────────────────
 describe("buildPlist", () => {
-  test("emits separate <string> elements for each arg (T029)", () => {
+  test("emits separate <string> elements for each arg", () => {
     const plist = m.buildPlist(["bun", "/path/cli.js"], "/var/log");
     // Must have individual entries, not a space-joined single string
     expect(plist).toContain("<string>bun</string>");
@@ -139,8 +139,8 @@ describe("buildPlist", () => {
     expect(plist).toContain("<string>_run</string>");
   });
 
-  // T064: XML special characters in args are escaped
-  test("escapes & and < in arg values (T064)", () => {
+  // XML special characters in args are escaped
+  test("escapes & and < in arg values", () => {
     const plist = m.buildPlist(["/path/with&amp", "/path/<special>"], "/var/log");
     expect(plist).toContain("<string>/path/with&amp;amp</string>");
     expect(plist).toContain("<string>/path/&lt;special&gt;</string>");
@@ -149,9 +149,9 @@ describe("buildPlist", () => {
   });
 });
 
-// ── T030: installMacOs calls bootout before bootstrap ─────────────────────────
+// ── installMacOs calls bootout before bootstrap ─────────────────────────
 describe("installMacOs", () => {
-  test("calls launchctl bootout before launchctl bootstrap (T030)", async () => {
+  test("calls launchctl bootout before launchctl bootstrap", async () => {
     await m.installMacOs(["bun", "/path/cli.js"]);
 
     const bootoutIdx = execFileCalls.findIndex(
@@ -191,8 +191,8 @@ describe("installMacOs", () => {
     expect(await m.isInstalledMacOs()).toBe(true);
   });
 
-  // T031: bootstrap failure surfaces stderr, not stack trace
-  test("throws with service manager stderr (not stack trace) when bootstrap fails (T031)", async () => {
+  // bootstrap failure surfaces stderr, not stack trace
+  test("throws with service manager stderr (not stack trace) when bootstrap fails", async () => {
     launchctlShouldFail = true;
     launchctlFailStderr = "Bootstrap failed: 5: Input/output error";
 
@@ -229,9 +229,9 @@ describe("uninstallMacOs", () => {
   });
 });
 
-// ── T032: startMacOs throws immediately when not registered ───────────────────
+// ── startMacOs throws immediately when not registered ───────────────────
 describe("startMacOs / stopMacOs", () => {
-  test("startMacOs throws 'Service not bootstrapped' when isRegisteredMacOs returns false (T032)", async () => {
+  test("startMacOs throws 'Service not bootstrapped' when isRegisteredMacOs returns false", async () => {
     // launchctl print will fail (not registered), no kickstart call expected
     await expect(m.startMacOs()).rejects.toThrow("Service not bootstrapped");
 
@@ -241,8 +241,8 @@ describe("startMacOs / stopMacOs", () => {
     expect(kickstartCall).toBeUndefined();
   });
 
-  // T069: startMacOs passes AbortSignal to execFileAsync
-  test("startMacOs passes signal option to execFileAsync for kickstart (T069)", async () => {
+  // startMacOs passes AbortSignal to execFileAsync
+  test("startMacOs passes signal option to execFileAsync for kickstart", async () => {
     launchctlPrintShouldFail = false; // registered
     await m.startMacOs();
 

--- a/src/daemon/__tests__/installer-windows.test.ts
+++ b/src/daemon/__tests__/installer-windows.test.ts
@@ -105,9 +105,9 @@ beforeEach(() => {
   lastExecFileOpts = undefined;
 });
 
-// T033: buildXml puts args[0] in <Command>, rest + daemon _run in <Arguments>
+// buildXml puts args[0] in <Command>, rest + daemon _run in <Arguments>
 describe("buildXml", () => {
-  test("<Command> holds only the binary, <Arguments> holds script + daemon _run (T033)", () => {
+  test("<Command> holds only the binary, <Arguments> holds script + daemon _run", () => {
     const xml = m.buildXml(["bun", "/path/cli.js"]);
     expect(xml).toContain("<Command>bun</Command>");
     expect(xml).toContain("<Arguments>/path/cli.js daemon _run</Arguments>");
@@ -120,8 +120,8 @@ describe("buildXml", () => {
     expect(xml).toContain("<Arguments>daemon _run</Arguments>");
   });
 
-  // T065: args with spaces are quoted for Windows command-line parsing
-  test("args containing spaces are double-quoted in <Arguments> (T065)", () => {
+  // args with spaces are quoted for Windows command-line parsing
+  test("args containing spaces are double-quoted in <Arguments>", () => {
     const xml = m.buildXml(["bun", "C:\\Program Files\\cli.js"]);
     expect(xml).toContain("<Command>bun</Command>");
     // The script path should be quoted because it contains a space
@@ -129,22 +129,22 @@ describe("buildXml", () => {
     expect(xml).toContain("daemon _run");
   });
 
-  test("args containing double quotes are escaped with backslash (T065)", () => {
+  test("args containing double quotes are escaped with backslash", () => {
     const xml = m.buildXml(["bun", '/path/with"quote']);
     const args = xml.match(/<Arguments>(.*?)<\/Arguments>/)?.[1] ?? "";
     expect(args).toContain('\\"');
   });
 
-  // T074a: trailing backslashes are doubled per CommandLineToArgvW
-  test("args with trailing backslash have it doubled inside quotes (T074a)", () => {
+  // trailing backslashes are doubled per CommandLineToArgvW
+  test("args with trailing backslash have it doubled inside quotes", () => {
     const xml = m.buildXml(["bun", "C:\\path\\"]);
     const args = xml.match(/<Arguments>(.*?)<\/Arguments>/)?.[1] ?? "";
     // Trailing \ before closing " must be doubled: "C:\path\\" → Windows sees C:\path\
     expect(args).toContain('"C:\\path\\\\"');
   });
 
-  // T074a: backslashes before quotes are doubled
-  test("backslashes immediately before a quote are doubled (T074a)", () => {
+  // backslashes before quotes are doubled
+  test("backslashes immediately before a quote are doubled", () => {
     const xml = m.buildXml(["bun", 'C:\\path\\"name']);
     const args = xml.match(/<Arguments>(.*?)<\/Arguments>/)?.[1] ?? "";
     // The \" sequence: backslash must be doubled so Windows sees literal \ + literal "
@@ -205,8 +205,8 @@ describe("startWindows / stopWindows", () => {
     await expect(m.startWindows()).rejects.toThrow("Service not bootstrapped");
   });
 
-  // T071: startWindows passes AbortSignal to execFileAsync
-  test("startWindows passes signal option to execFileAsync for /Run (T071)", async () => {
+  // startWindows passes AbortSignal to execFileAsync
+  test("startWindows passes signal option to execFileAsync for /Run", async () => {
     queryExitCode = 0; // installed
     await m.startWindows();
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -14,7 +14,7 @@ import { Watcher } from "../core/watcher";
 /** Format daemon log timestamps consistently across lifecycle events. */
 const ts = () => new Date().toISOString();
 
-// ── Failure tracking (US2) ─────────────────────────────────────────────────────
+// ── Failure tracking ─────────────────────────────────────────────────────
 let consecutiveFailures = 0;
 let lastError: string | null = null;
 
@@ -26,7 +26,7 @@ function recordSuccess(): void {
 
 /**
  * Increment the consecutive failure counter and capture the error message.
- * The operation type is always included in `lastError` for diagnostics per FR-004.
+ * The operation type is always included in `lastError` for diagnostics.
  * `lastError` MUST NOT include key file content — only paths and error codes.
  */
 function recordFailure(op: "push" | "pull", msg: string): void {
@@ -34,7 +34,7 @@ function recordFailure(op: "push" | "pull", msg: string): void {
   lastError = `[${op}] ${msg}`;
 }
 
-// ── Retry logic (US3) ──────────────────────────────────────────────────────────
+// ── Retry logic ──────────────────────────────────────────────────────────
 
 /**
  * Calls `fn` once; on failure retries exactly once.
@@ -53,13 +53,13 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
  * @returns A promise that resolves once the daemon has bound its IPC socket and registered watchers.
  */
 export async function startDaemon(): Promise<void> {
-  // ── Startup validation (FR-006, FR-007, SC-006) ──────────────────────────
+  // ── Startup validation ──────────────────────────
   let runtime: Awaited<ReturnType<typeof resolveRuntimeContext>>;
   try {
     runtime = await resolveRuntimeContext();
     // Eagerly load config to validate vault accessibility
     await loadConfig(resolveConfigPath(runtime.vaultDir));
-    // Validate encryption key is readable (FR-007)
+    // Validate encryption key is readable
     await access(runtime.privateKeyPath);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -71,7 +71,7 @@ export async function startDaemon(): Promise<void> {
   const config = await loadConfig(resolveConfigPath(runtime.vaultDir));
   const socketPath = (await import("../config/paths")).resolveDaemonSocketPath();
 
-  // ── Second-instance detection (FR-009, SC-005) ───────────────────────────
+  // ── Second-instance detection ───────────────────────────
   const client = new IpcClient();
   try {
     const response = await client.send("status", {}, socketPath);
@@ -84,7 +84,7 @@ export async function startDaemon(): Promise<void> {
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
     if (code === "ECONNREFUSED") {
-      // Stale socket — unlink before proceeding (FR-003)
+      // Stale socket — unlink before proceeding
       try {
         await unlink(socketPath);
       } catch {
@@ -96,7 +96,7 @@ export async function startDaemon(): Promise<void> {
 
   const pullIntervalMs = config.sync.pullIntervalMs ?? 5 * 60 * 1000;
 
-  // ── SyncQueue (US1) ──────────────────────────────────────────────────────
+  // ── SyncQueue ──────────────────────────────────────────────────────
   const queue = new SyncQueue();
 
   const ipc = new IpcServer();
@@ -213,12 +213,12 @@ export async function startDaemon(): Promise<void> {
       });
   }, pullIntervalMs);
 
-  // ── Graceful shutdown (US1) ──────────────────────────────────────────────
+  // ── Graceful shutdown ──────────────────────────────────────────────
   const shutdown = async () => {
     clearInterval(pullTimer);
     ipc.close();
     queue.close();
-    // Drain in-flight sync operations with a hard timeout (FR-013)
+    // Drain in-flight sync operations with a hard timeout
     await Promise.race([queue.whenIdle(), delay(10_000)]);
     await watcher.close();
     try {

--- a/src/lib/__tests__/debug.test.ts
+++ b/src/lib/__tests__/debug.test.ts
@@ -1,5 +1,5 @@
 /**
- * T049 — debug module: isDebug flag and debug() function
+ * debug module: isDebug flag and debug() function
  *
  * isDebug is a module-level constant evaluated at import time.
  * In this test file AGENTSYNC_DEBUG is either unset or "0", so isDebug is false

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -136,7 +136,7 @@ describe("readSourceArtefacts", () => {
     expect(result[0].name).toBe("review.md");
   });
 
-  test("returns empty for missing source files (FR-013)", async () => {
+  test("returns empty for missing source files", async () => {
     const result = await readSourceArtefacts("claude", "global-rules");
     expect(result).toHaveLength(0);
   });
@@ -242,7 +242,7 @@ describe("performMigrate", () => {
     expect(vsSkip).toBeDefined();
   });
 
-  test("aborts on detected secret in MCP content (FR-011)", async () => {
+  test("aborts on detected secret in MCP content", async () => {
     writeFixture(
       testClaude.mcpJson,
       JSON.stringify({
@@ -329,7 +329,7 @@ describe("performMigrate", () => {
     expect(written).toContain("slack");
   });
 
-  test("reports skip for missing source files (FR-013)", async () => {
+  test("reports skip for missing source files", async () => {
     const result = await performMigrate({
       from: "claude",
       to: "cursor",


### PR DESCRIPTION
## Summary

Strips spec-tracker references (`FR-###`, `SC-###`, `US#`, `T###`, `NC-#`, `Thread N`, `(research R#)`) from comments, JSDoc, test names, and string literals across the codebase. Future readers do not have spec context, so these IDs were noise that obscured the WHY they were meant to convey.

Where stripping the ref left a comment without meaning, the comment is rewritten to express the WHY directly: it names the rule, the failure mode the check prevents, or the invariant. Spec IDs belong in commit messages and PR descriptions, not source.

Adds a project `CLAUDE.md` rule forbidding the same pattern in future code.

## Changes

### Comment cleanup
- 39 source files in `src/` (production + tests) lose every `FR-###` / `SC-###` / `US#` / `T###` / `NC-#` / `Thread N` / `(research R#)` reference.
- Production prose rewrites: `src/agents/skills-walker.ts` (5-gate doc block reframed in terms of the WHY), `src/agents/{claude,codex,copilot,cursor}.ts` (skill-section comments), `src/core/tar.ts` (skipSymlinks JSDoc), `src/daemon/index.ts` (startup, second-instance, retry, drain comments), `src/commands/{push,skill,doctor}.ts`.
- Test names: `(FR-009)` / `(FR-016 inner)` / `(NC-1)` etc. suffixes dropped; section dividers like `// ── T021 — snapshotCursor ─` reduced to the descriptive part; "Row N —" structural markers preserved.
- Mid-sentence rewrites in `src/commands/__tests__/integration.test.ts` (rewrote two broken-grammar comments that the FR refs had been masking).

### User-facing change
- `src/commands/doctor.ts`: warning detail string changes from `Symlinked skills root is not synced (FR-016): <dir>` to `Symlinked skills root is not synced: <dir>`.
- Matching `expect(claudeRow?.detail).toContain("FR-016")` removed from `src/commands/__tests__/doctor.test.ts`; the sibling `toContain("Symlinked skills root")` assertion still pins the message.

### CLAUDE.md
- Adds **No spec-tracker refs in code** bullet under "Conventions and gotchas" so future contributors do not reintroduce the pattern.

### Architecture

No architectural changes. Pure prose / test-name diff plus one user-facing string change.

## Test Evidence

- `bun run typecheck` ✅
- `bunx biome ci src/` ✅ (82 files clean)
- `bun test` ✅ 432 pass / 0 fail / 965 expect() calls

## Risks / Follow-ups

- The user-facing string change in `doctor` is a one-line behavioural delta. The retained `toContain("Symlinked skills root")` test assertion still catches regressions; the dropped `FR-016` substring is now neither in code nor in the test, which is the desired end state.
- None other.

## Checklist

- [x] New code has tests where appropriate (no new code; existing tests still pass)
- [x] Documentation updated if behavior changed (`CLAUDE.md` adds the new rule; the user-facing doctor warning is a one-string update)