### PR TITLE
feat(migrate): transport-aware MCP model with VS Code servers/inputs schema

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -77,9 +77,29 @@ flowchart TD
 ## Key Behaviours
 
 - **Overwrite on collision**: If the target already has a matching entry, the source value wins.
-- **MCP per-server merge**: Only colliding server names are overwritten; target-only servers are preserved.
-- **Secret detection**: If API keys or tokens are found in MCP `env` fields, migration aborts with a clear error. Remove literal secrets and retry.
+- **MCP per-server merge**: Only colliding server names are overwritten; target-only servers are preserved. The merge key is target-specific: VS Code uses top-level `servers` + `inputs`, Claude/Cursor use `mcpServers`, Codex uses `[mcp.servers.*]` TOML tables.
+- **Secret detection**: If API keys or tokens are found in MCP content (including HTTP-transport `headers.Authorization`), migration aborts with a clear error. Remove literal secrets and retry.
 - **Graceful skipping**: Missing source files and unsupported pairs produce skip messages, not errors.
+
+## MCP Transport Support
+
+AgentSync parses each source MCP config into a transport-aware intermediate
+model before writing the target. The model represents a discriminated union
+over `stdio`, `http`, and `sse` transports plus VS Code-specific metadata
+(`inputs`, `sandbox`, `sandboxEnabled`, `dev`, `envFile`).
+
+| Target | Schema | Supported transports | Lossy fields |
+|--------|--------|----------------------|--------------|
+| **VS Code** | top-level `servers` + `inputs` ([docs](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration)) | stdio, http, sse | — |
+| **Claude** | top-level `mcpServers` (stdio-only) | stdio | non-stdio servers dropped with warning; `inputs` dropped with warning |
+| **Cursor** | top-level `mcpServers` (stdio-only) | stdio | non-stdio servers dropped with warning; `inputs` dropped with warning |
+| **Codex** | TOML `[mcp.servers.<name>]` | stdio, plus structured `type`/`url`/`headers`/`auth` for future HTTP/SSE clients | `inputs` dropped with warning |
+
+When a target cannot represent a transport, AgentSync emits an **explicit
+translator warning** that names the dropped server and the unsupported
+transport (e.g. `vscode → claude (mcp): Dropped server "remote": transport
+"http" is not representable…`). Warnings flow into `MigrateResult.warnings`
+so the CLI surfaces them — they are never dropped silently.
 
 ## Examples
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -91,8 +91,8 @@ over `stdio`, `http`, and `sse` transports plus VS Code-specific metadata
 | Target | Schema | Supported transports | Lossy fields |
 |--------|--------|----------------------|--------------|
 | **VS Code** | top-level `servers` + `inputs` ([docs](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration)) | stdio, http, sse | — |
-| **Claude** | top-level `mcpServers` (stdio-only) | stdio | non-stdio servers dropped with warning; `inputs` dropped with warning |
-| **Cursor** | top-level `mcpServers` (stdio-only) | stdio | non-stdio servers dropped with warning; `inputs` dropped with warning |
+| **Claude** | top-level `mcpServers` (stdio-only) | stdio | non-stdio servers dropped with warning; `inputs` dropped with warning; stdio-only `envFile`/`sandbox`/`sandboxEnabled`/`dev` named per-server in a warning |
+| **Cursor** | top-level `mcpServers` (stdio-only) | stdio | same as Claude |
 | **Codex** | TOML `[mcp.servers.<name>]` | stdio, plus structured `type`/`url`/`headers`/`auth` for future HTTP/SSE clients | `inputs` dropped with warning |
 
 When a target cannot represent a transport, AgentSync emits an **explicit
@@ -100,6 +100,12 @@ translator warning** that names the dropped server and the unsupported
 transport (e.g. `vscode → claude (mcp): Dropped server "remote": transport
 "http" is not representable…`). Warnings flow into `MigrateResult.warnings`
 so the CLI surfaces them — they are never dropped silently.
+
+If a source migrates to a stdio-only target where **every** server is
+unrepresentable (e.g. an all-HTTP VS Code config → Claude), the translator
+skips the write rather than creating a brand-new file containing only
+`{"mcpServers":{}}`. The warning still surfaces in `MigrateResult.warnings`
+so the operator hears about the dropped servers.
 
 ## Examples
 

--- a/src/agents/__tests__/vscode.test.ts
+++ b/src/agents/__tests__/vscode.test.ts
@@ -64,6 +64,36 @@ describe("snapshotVsCode", () => {
     );
   });
 
+  test("redacts HTTP transport Authorization header value in vscode-shape mcp.json", async () => {
+    const { snapshotVsCode } = vsCodeModule;
+    // VS Code official shape: top-level `servers` with `type: "http"` and
+    // `headers.Authorization`. The header value carries a github-style PAT
+    // so the redaction pattern fires deterministically.
+    const mcp = {
+      servers: {
+        remote: {
+          type: "http",
+          url: "https://example.com/mcp",
+          headers: { Authorization: "ghp_abcdefghijklmnopqrstuvwxyz1234567890" },
+        },
+      },
+    };
+    await writeFile(testVsCodePaths.mcpJson, JSON.stringify(mcp), "utf8");
+
+    const result = await snapshotVsCode();
+    const artifact = result.artifacts[0];
+    const parsed = JSON.parse(artifact.plaintext.trim()) as {
+      servers: { remote: { headers: Record<string, string> } };
+    };
+    const authVal = parsed.servers.remote.headers.Authorization;
+    // The literal secret must be replaced by the redaction placeholder
+    expect(authVal).not.toContain("ghp_abcdefghij");
+    expect(authVal).toContain("REDACTED");
+    expect(result.warnings.some((w) => w.includes("Redacted"))).toBe(true);
+    // Shape is preserved (top-level servers, not re-shaped to mcpServers)
+    expect((parsed as Record<string, unknown>).mcpServers).toBeUndefined();
+  });
+
   test("redacts embedded API key in mcp.json and emits warning", async () => {
     const { snapshotVsCode } = vsCodeModule;
     const mcp = {

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -11,7 +11,7 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { AgentPaths } from "../../config/paths";
-import { performMigrate, readSourceArtefacts } from "../migrate";
+import { applyMigrated, performMigrate, readSourceArtefacts } from "../migrate";
 
 // Re-install the real node:fs/promises in bun's module cache. The daemon
 // installer test files (installer-linux/macos/windows) stub fs/promises at
@@ -480,6 +480,71 @@ describe("performMigrate", () => {
     // Existing inputs preserved
     expect(Array.isArray(parsed.inputs)).toBe(true);
     expect((parsed.inputs as Array<{ id: string }>)[0].id).toBe("existing_token");
+  });
+
+  test("applyMigrated vscode inputs collision: source value wins on shared id", async () => {
+    // Exercises the inputs-dedup branch in applyMigrated. No registered
+    // translator pair currently produces inputs into a vscode target that
+    // already has inputs, but the dedup contract is still load-bearing
+    // defensive code — pin "source wins on collision" so it matches the
+    // sibling servers merge and docs/migrate.md.
+    writeFixture(
+      testVscode.mcpJson,
+      JSON.stringify({
+        servers: { existing: { type: "stdio", command: "old" } },
+        inputs: [{ id: "tok", type: "promptString", description: "OLD" }],
+      }),
+    );
+    const incoming = `${JSON.stringify(
+      {
+        servers: { gh: { type: "stdio", command: "gh-mcp" } },
+        inputs: [{ id: "tok", type: "promptString", description: "NEW" }],
+      },
+      null,
+      2,
+    )}\n`;
+
+    const artifact = await applyMigrated("vscode", "mcp", "mcp.json", incoming, false);
+    expect(artifact).not.toBeNull();
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = await readIfExists(testVscode.mcpJson);
+    const parsed = JSON.parse(written as string) as {
+      servers: Record<string, unknown>;
+      inputs?: Array<{ id: string; description?: string }>;
+    };
+    // Source wins for the collision
+    expect(parsed.inputs?.find((i) => i.id === "tok")?.description).toBe("NEW");
+    // No duplicate entries — dedup still works
+    expect((parsed.inputs ?? []).filter((i) => i.id === "tok")).toHaveLength(1);
+    // Both servers present after merge
+    expect(parsed.servers.existing).toBeDefined();
+    expect(parsed.servers.gh).toBeDefined();
+  });
+
+  test("vscode → claude with only http servers does not create empty mcpServers file", async () => {
+    writeFixture(
+      testVscode.mcpJson,
+      JSON.stringify({
+        servers: {
+          remote: { type: "http", url: "https://example.com/mcp" },
+        },
+      }),
+    );
+
+    const result = await performMigrate({
+      from: "vscode",
+      to: "claude",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    // Translator warned, but no file was written.
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.migrated).toHaveLength(0);
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = await readIfExists(testClaude.mcpJson);
+    expect(written).toBeNull();
   });
 
   test("partial write failure continues remaining artefacts", async () => {

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -359,6 +359,129 @@ describe("performMigrate", () => {
     expect(result.migrated[0].targetPath).toContain("review.md");
   });
 
+  test("vscode → claude writes under mcpServers (not servers)", async () => {
+    writeFixture(
+      testVscode.mcpJson,
+      JSON.stringify({
+        servers: {
+          gh: { type: "stdio", command: "gh-mcp", args: [], env: {} },
+        },
+      }),
+    );
+
+    const result = await performMigrate({
+      from: "vscode",
+      to: "claude",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.migrated).toHaveLength(1);
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = await readIfExists(testClaude.mcpJson);
+    expect(written).not.toBeNull();
+    const parsed = JSON.parse(written as string) as Record<string, unknown>;
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.servers).toBeUndefined();
+    expect((parsed.mcpServers as Record<string, unknown>).gh).toBeDefined();
+  });
+
+  test("claude → vscode writes under top-level servers (no nested mcpServers.servers)", async () => {
+    writeFixture(
+      testClaude.mcpJson,
+      JSON.stringify({
+        mcpServers: { gh: { command: "gh-mcp", args: [], env: {} } },
+      }),
+    );
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "vscode",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.migrated).toHaveLength(1);
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = await readIfExists(testVscode.mcpJson);
+    expect(written).not.toBeNull();
+    const parsed = JSON.parse(written as string) as Record<string, unknown>;
+    expect(parsed.servers).toBeDefined();
+    // Critically, the legacy mcpServers key must NOT appear on the VS Code target.
+    expect(parsed.mcpServers).toBeUndefined();
+    const servers = parsed.servers as Record<string, Record<string, unknown>>;
+    expect(servers.gh.type).toBe("stdio");
+    expect(servers.gh.command).toBe("gh-mcp");
+    // And there must be no double-nesting like servers.gh.servers or
+    // mcpServers.servers anywhere.
+    expect((servers.gh as { servers?: unknown }).servers).toBeUndefined();
+  });
+
+  test("vscode → claude HTTP transport produces translator warnings on result", async () => {
+    writeFixture(
+      testVscode.mcpJson,
+      JSON.stringify({
+        servers: {
+          remote: {
+            type: "http",
+            url: "https://example.com/mcp",
+            headers: { "X-Trace": "on" },
+          },
+          gh: { type: "stdio", command: "gh-mcp" },
+        },
+      }),
+    );
+
+    const result = await performMigrate({
+      from: "vscode",
+      to: "claude",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    // Translator warnings about dropped HTTP transport should surface
+    expect(result.warnings.length).toBeGreaterThan(0);
+    const joined = result.warnings.join("\n");
+    expect(joined).toContain("remote");
+    expect(joined).toContain("http");
+  });
+
+  test("vscode existing inputs preserved during vscode-target merge", async () => {
+    // Existing VS Code file with both servers and inputs
+    writeFixture(
+      testVscode.mcpJson,
+      JSON.stringify({
+        servers: { existing: { type: "stdio", command: "old" } },
+        inputs: [{ id: "existing_token", type: "promptString", password: true }],
+      }),
+    );
+    writeFixture(testClaude.mcpJson, JSON.stringify({ mcpServers: { gh: { command: "gh-mcp" } } }));
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "vscode",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = await readIfExists(testVscode.mcpJson);
+    const parsed = JSON.parse(written as string) as {
+      servers: Record<string, unknown>;
+      inputs?: unknown[];
+    };
+    // Incoming server merged, existing server preserved
+    expect(parsed.servers.gh).toBeDefined();
+    expect(parsed.servers.existing).toBeDefined();
+    // Existing inputs preserved
+    expect(Array.isArray(parsed.inputs)).toBe(true);
+    expect((parsed.inputs as Array<{ id: string }>)[0].id).toBe("existing_token");
+  });
+
   test("partial write failure continues remaining artefacts", async () => {
     mkdirSync(testClaude.commandsDir, { recursive: true });
     writeFileSync(join(testClaude.commandsDir, "review.md"), "# Review");

--- a/src/migrate/__tests__/translators/mcp.test.ts
+++ b/src/migrate/__tests__/translators/mcp.test.ts
@@ -26,6 +26,46 @@ args = []
 [mcp.servers.slack.env]
 `;
 
+const FIXTURE_VSCODE_OFFICIAL = JSON.stringify(
+  {
+    inputs: [{ id: "gh_token", type: "promptString", description: "GitHub token", password: true }],
+    servers: {
+      github: {
+        type: "stdio",
+        command: "gh-mcp",
+        args: ["serve"],
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: VS Code input variable syntax
+        env: { GITHUB_TOKEN: "${input:gh_token}" },
+        envFile: ".env.local",
+        sandboxEnabled: true,
+        sandbox: { networking: false },
+        dev: { watch: ["**/*.ts"] },
+      },
+      remote: {
+        type: "http",
+        url: "https://example.com/mcp",
+        headers: { Authorization: "Bearer test", "X-Trace": "on" },
+      },
+      sse: {
+        type: "sse",
+        url: "https://example.com/sse",
+      },
+    },
+  },
+  null,
+  2,
+);
+
+const FIXTURE_VSCODE_LEGACY = JSON.stringify(
+  {
+    mcpServers: {
+      github: { command: "gh-mcp", args: ["serve"], env: { GITHUB_TOKEN: "test" } },
+    },
+  },
+  null,
+  2,
+);
+
 describe("MCP translators", () => {
   test("empty mcpServers returns null", () => {
     expect(translateMcp.claudeToCursor('{"mcpServers":{}}')).toBeNull();
@@ -74,5 +114,122 @@ describe("MCP translators", () => {
     const parsed = JSON.parse(result?.content as string);
     expect(parsed.mcpServers.github.env.GITHUB_TOKEN).toBe("test");
     expect(parsed.mcpServers.github.args).toEqual(["serve"]);
+  });
+});
+
+// ── VS Code official-shape fixtures ─────────────────────────────────────────
+
+describe("VS Code MCP translators (official servers/inputs schema)", () => {
+  test("vscode → vscode round-trip preserves all transport fields", () => {
+    // Run through claude as an intermediate to prove parse+serialize work
+    // without losing transport metadata.
+    const result = translateMcp.codexToVsCode(
+      // First convert vscode → codex → vscode through the model
+      (translateMcp.vsCodeToCodex(FIXTURE_VSCODE_OFFICIAL) as { content: string }).content,
+    );
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result?.content as string) as {
+      servers: Record<string, Record<string, unknown>>;
+    };
+    expect(parsed.servers.github.type).toBe("stdio");
+    expect(parsed.servers.github.command).toBe("gh-mcp");
+    expect(parsed.servers.remote.type).toBe("http");
+    expect(parsed.servers.remote.url).toBe("https://example.com/mcp");
+    expect((parsed.servers.remote.headers as Record<string, string>).Authorization).toBe(
+      "Bearer test",
+    );
+    expect(parsed.servers.sse.type).toBe("sse");
+    expect(parsed.servers.sse.url).toBe("https://example.com/sse");
+  });
+
+  test("claude → vscode emits top-level servers (not mcpServers)", () => {
+    const result = translateMcp.claudeToVsCode(FIXTURE_JSON);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result?.content as string) as Record<string, unknown>;
+    expect(parsed.servers).toBeDefined();
+    expect((parsed.servers as Record<string, unknown>).github).toBeDefined();
+    expect(parsed.mcpServers).toBeUndefined();
+  });
+
+  test("cursor → vscode emits top-level servers", () => {
+    const result = translateMcp.cursorToVsCode(FIXTURE_JSON);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result?.content as string) as Record<string, unknown>;
+    expect(parsed.servers).toBeDefined();
+    expect(parsed.mcpServers).toBeUndefined();
+  });
+
+  test("vscode → claude emits mcpServers (not servers) and warns about HTTP/SSE", () => {
+    const result = translateMcp.vsCodeToClaude(FIXTURE_VSCODE_OFFICIAL);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result?.content as string) as Record<string, unknown>;
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.servers).toBeUndefined();
+    // Only stdio survives — github
+    const servers = parsed.mcpServers as Record<string, unknown>;
+    expect(servers.github).toBeDefined();
+    expect(servers.remote).toBeUndefined();
+    expect(servers.sse).toBeUndefined();
+    // Warnings name the dropped servers and the inputs placeholder
+    const w = (result?.warnings ?? []).join("\n");
+    expect(w).toContain("remote");
+    expect(w).toContain("http");
+    expect(w).toContain("sse");
+    expect(w).toContain("inputs");
+  });
+
+  test("vscode → cursor emits mcpServers and warns about HTTP/SSE", () => {
+    const result = translateMcp.vsCodeToCursor(FIXTURE_VSCODE_OFFICIAL);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result?.content as string) as Record<string, unknown>;
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.servers).toBeUndefined();
+    expect((result?.warnings ?? []).length).toBeGreaterThan(0);
+  });
+
+  test("vscode → codex preserves HTTP transport fields under [mcp.servers]", () => {
+    const result = translateMcp.vsCodeToCodex(FIXTURE_VSCODE_OFFICIAL);
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain("[mcp.servers.remote]");
+    expect(result?.content).toContain('type = "http"');
+    expect(result?.content).toContain('url = "https://example.com/mcp"');
+    expect(result?.content).toContain("[mcp.servers.remote.headers]");
+    expect(result?.content).toContain('Authorization = "Bearer test"');
+  });
+
+  test("vscode → codex warns about top-level inputs being dropped", () => {
+    const result = translateMcp.vsCodeToCodex(FIXTURE_VSCODE_OFFICIAL);
+    expect(result?.warnings ?? []).toHaveLength(1);
+    expect((result?.warnings ?? [])[0]).toContain("inputs");
+  });
+
+  test("vscode (legacy mcpServers shape) still parses for round-trip", () => {
+    const result = translateMcp.vsCodeToClaude(FIXTURE_VSCODE_LEGACY);
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result?.content as string) as Record<string, unknown>;
+    const servers = parsed.mcpServers as Record<string, { command: string }>;
+    expect(servers.github.command).toBe("gh-mcp");
+  });
+
+  test("vscode → vscode preserves inputs at top level", () => {
+    // Self-pair isn't registered, but we exercise the serializer via the
+    // codex round-trip to confirm inputs survive the model.
+    const vsToCodex = translateMcp.vsCodeToCodex(FIXTURE_VSCODE_OFFICIAL);
+    const back = translateMcp.codexToVsCode((vsToCodex as { content: string }).content);
+    expect(back).not.toBeNull();
+    // codex doesn't carry inputs, so the round-trip drops them on this path —
+    // and that's exactly why vs-code-to-codex emits a warning above.
+    const parsed = JSON.parse(back?.content as string) as Record<string, unknown>;
+    expect(parsed.servers).toBeDefined();
+  });
+
+  test("claude → vscode preserves env via stdio shape", () => {
+    const result = translateMcp.claudeToVsCode(FIXTURE_JSON);
+    const parsed = JSON.parse(result?.content as string) as {
+      servers: Record<string, Record<string, unknown>>;
+    };
+    expect(parsed.servers.github.type).toBe("stdio");
+    expect(parsed.servers.github.command).toBe("gh-mcp");
+    expect((parsed.servers.github.env as Record<string, string>).GITHUB_TOKEN).toBe("test");
   });
 });

--- a/src/migrate/__tests__/translators/mcp.test.ts
+++ b/src/migrate/__tests__/translators/mcp.test.ts
@@ -121,10 +121,9 @@ describe("MCP translators", () => {
 
 describe("VS Code MCP translators (official servers/inputs schema)", () => {
   test("vscode → vscode round-trip preserves all transport fields", () => {
-    // Run through claude as an intermediate to prove parse+serialize work
-    // without losing transport metadata.
+    // Round-trip vscode → codex → vscode to prove parse+serialize work
+    // without losing transport metadata across the model.
     const result = translateMcp.codexToVsCode(
-      // First convert vscode → codex → vscode through the model
       (translateMcp.vsCodeToCodex(FIXTURE_VSCODE_OFFICIAL) as { content: string }).content,
     );
     expect(result).not.toBeNull();
@@ -231,5 +230,65 @@ describe("VS Code MCP translators (official servers/inputs schema)", () => {
     expect(parsed.servers.github.type).toBe("stdio");
     expect(parsed.servers.github.command).toBe("gh-mcp");
     expect((parsed.servers.github.env as Record<string, string>).GITHUB_TOKEN).toBe("test");
+  });
+
+  test("vscode → codex → vscode does not re-nest extras over repeated cycles", () => {
+    // Regression: the codex serializer used to write extras as a nested
+    // `entry.extras` subtable, which the parser then re-captured under
+    // `extras` again, wrapping one level deeper on every round-trip.
+    const withCustom = JSON.stringify({
+      servers: {
+        github: { type: "stdio", command: "gh-mcp", customMeta: { tier: "gold" } },
+      },
+    });
+    let current = withCustom;
+    for (let i = 0; i < 3; i++) {
+      const toCodex = translateMcp.vsCodeToCodex(current) as { content: string };
+      current = (translateMcp.codexToVsCode(toCodex.content) as { content: string }).content;
+    }
+    const parsed = JSON.parse(current) as {
+      servers: Record<string, Record<string, unknown>>;
+    };
+    // Custom field is preserved at the top level of the server entry, not
+    // nested under any number of `extras` keys.
+    expect(parsed.servers.github.customMeta).toEqual({ tier: "gold" });
+    expect((parsed.servers.github as { extras?: unknown }).extras).toBeUndefined();
+  });
+
+  test("vscode → claude with only http servers returns skipWrite + warnings", () => {
+    // No stdio survives the projection, so the translator should surface
+    // the warning without writing `{"mcpServers":{}}` over a fresh target.
+    const allHttp = JSON.stringify({
+      servers: {
+        remote: { type: "http", url: "https://example.com/mcp" },
+      },
+    });
+    const result = translateMcp.vsCodeToClaude(allHttp);
+    expect(result).not.toBeNull();
+    expect(result?.skipWrite).toBe(true);
+    expect((result?.warnings ?? []).join("\n")).toContain("remote");
+  });
+
+  test("vscode → codex with only inputs returns skipWrite + warnings", () => {
+    const inputsOnly = JSON.stringify({
+      servers: {},
+      inputs: [{ id: "tok", type: "promptString" }],
+    });
+    const result = translateMcp.vsCodeToCodex(inputsOnly);
+    // Either `null` (no servers AND no inputs in model — but inputs survive
+    // parsing here) or a skipWrite envelope. Either way no file is written.
+    if (result !== null) {
+      expect(result.skipWrite).toBe(true);
+      expect(result.warnings ?? []).toHaveLength(1);
+    }
+  });
+
+  test("vscode → claude warns about dropped stdio-only metadata fields", () => {
+    const result = translateMcp.vsCodeToClaude(FIXTURE_VSCODE_OFFICIAL);
+    expect(result).not.toBeNull();
+    const w = (result?.warnings ?? []).join("\n");
+    // FIXTURE_VSCODE_OFFICIAL.servers.github sets envFile/sandbox/sandboxEnabled/dev
+    expect(w).toContain('Server "github"');
+    expect(w).toMatch(/envFile|sandbox|sandboxEnabled|dev/);
   });
 });

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -201,9 +201,13 @@ export async function applyMigrated(
               ? incomingParsed.inputs
               : [];
             if (incomingInputs.length > 0) {
+              // Source wins on collision (mirrors the spread-based servers
+              // merge above and the documented "source value wins" rule in
+              // docs/migrate.md). Iterate incoming first so its entry is
+              // recorded under the dedupe key before the existing one.
               const seen = new Set<string>();
               const merged: unknown[] = [];
-              for (const list of [existingInputs, incomingInputs]) {
+              for (const list of [incomingInputs, existingInputs]) {
                 for (const entry of list) {
                   const id =
                     entry && typeof entry === "object"
@@ -321,6 +325,13 @@ export async function performMigrate(options: MigrateOptions): Promise<MigrateRe
           for (const w of translated.warnings) {
             result.warnings.push(`${options.from} → ${target} (${type}): ${w}`);
           }
+        }
+
+        // Translator opted out of writing (e.g. every server in the source
+        // was dropped by the target's schema). Warnings have already been
+        // captured above, so just move on without creating an empty stub.
+        if (translated.skipWrite) {
+          continue;
         }
 
         // Secret detection for MCP content — abort if secrets found

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -170,12 +170,15 @@ export async function applyMigrated(
     if (!targetPath) return null;
 
     if (!dryRun) {
-      // Per-server merge: read existing target, merge source servers in
+      // Per-server merge: read existing target, merge source servers in.
+      // The merge key is target-specific because each target uses a different
+      // top-level layout (Codex: TOML `[mcp.servers.*]`; VS Code: `servers` +
+      // `inputs`; Claude/Cursor: `mcpServers`). Using the wrong key would
+      // either write to a section the target ignores or duplicate state.
       const existing = await readIfExists(targetPath);
       if (existing) {
         try {
           if (to === "codex") {
-            // TOML merge: preserve non-MCP sections in config.toml
             const existingParsed = TOML.parse(existing);
             const incomingParsed = TOML.parse(content);
             const existingMcp = (existingParsed.mcp ?? {}) as TOML.JsonMap;
@@ -185,8 +188,38 @@ export async function applyMigrated(
             existingMcp.servers = { ...existingServers, ...incomingServers };
             existingParsed.mcp = existingMcp;
             content = TOML.stringify(existingParsed);
+          } else if (to === "vscode") {
+            const existingParsed = JSON.parse(existing) as Record<string, unknown>;
+            const incomingParsed = JSON.parse(content) as Record<string, unknown>;
+            const existingServers = (existingParsed.servers ?? {}) as Record<string, unknown>;
+            const incomingServers = (incomingParsed.servers ?? {}) as Record<string, unknown>;
+            existingParsed.servers = { ...existingServers, ...incomingServers };
+            const existingInputs = Array.isArray(existingParsed.inputs)
+              ? existingParsed.inputs
+              : [];
+            const incomingInputs = Array.isArray(incomingParsed.inputs)
+              ? incomingParsed.inputs
+              : [];
+            if (incomingInputs.length > 0) {
+              const seen = new Set<string>();
+              const merged: unknown[] = [];
+              for (const list of [existingInputs, incomingInputs]) {
+                for (const entry of list) {
+                  const id =
+                    entry && typeof entry === "object"
+                      ? ((entry as { id?: unknown }).id as string | undefined)
+                      : undefined;
+                  const dedupeKey = typeof id === "string" ? id : JSON.stringify(entry);
+                  if (seen.has(dedupeKey)) continue;
+                  seen.add(dedupeKey);
+                  merged.push(entry);
+                }
+              }
+              existingParsed.inputs = merged;
+            }
+            content = `${JSON.stringify(existingParsed, null, 2)}\n`;
           } else {
-            // JSON merge: Claude, Cursor, VS Code
+            // Claude and Cursor: mcpServers merge
             const existingParsed = JSON.parse(existing) as Record<string, unknown>;
             const incomingParsed = JSON.parse(content) as Record<string, unknown>;
             const existingServers = (existingParsed.mcpServers ?? {}) as Record<string, unknown>;
@@ -282,6 +315,12 @@ export async function performMigrate(options: MigrateOptions): Promise<MigrateRe
             pair: { from: options.from, to: target, type },
           });
           continue;
+        }
+
+        if (translated.warnings && translated.warnings.length > 0) {
+          for (const w of translated.warnings) {
+            result.warnings.push(`${options.from} → ${target} (${type}): ${w}`);
+          }
         }
 
         // Secret detection for MCP content — abort if secrets found

--- a/src/migrate/translators/mcp.ts
+++ b/src/migrate/translators/mcp.ts
@@ -332,6 +332,9 @@ function serializeVsCodeMcp(model: McpModel): string {
 /**
  * Serialise to Claude/Cursor `mcp.json` shape. These clients only support
  * stdio today, so any HTTP/SSE server is dropped and named in a warning.
+ * Stdio-only metadata that the schema does not represent (envFile, sandbox,
+ * sandboxEnabled, dev, preserved extras) is also named per-server so the
+ * operator hears about it instead of silently losing it on round-trip.
  */
 function serializeMcpServersJson(model: McpModel): { content: string; warnings: string[] } {
   const mcpServers: Record<string, unknown> = {};
@@ -342,6 +345,17 @@ function serializeMcpServersJson(model: McpModel): { content: string; warnings: 
         `Dropped server "${s.name}": transport "${s.transport}" is not representable in the target's stdio-only mcpServers schema (url/headers/auth dropped).`,
       );
       continue;
+    }
+    const dropped: string[] = [];
+    if (s.envFile !== undefined) dropped.push("envFile");
+    if (s.sandbox !== undefined) dropped.push("sandbox");
+    if (s.sandboxEnabled !== undefined) dropped.push("sandboxEnabled");
+    if (s.dev !== undefined) dropped.push("dev");
+    if (s.extras && Object.keys(s.extras).length > 0) dropped.push(...Object.keys(s.extras));
+    if (dropped.length > 0) {
+      warnings.push(
+        `Server "${s.name}": dropped fields not supported by mcpServers schema: ${dropped.join(", ")}.`,
+      );
     }
     mcpServers[s.name] = stripUndefined({
       command: s.command,
@@ -361,18 +375,18 @@ function serializeMcpServersJson(model: McpModel): { content: string; warnings: 
  * Serialise to Codex TOML. Codex supports the legacy stdio shape directly;
  * non-stdio metadata is written under the same `[mcp.servers.<name>]`
  * tables as structured TOML so a future Codex with Streamable HTTP support
- * can pick it up. Unknown extras are stashed under `[mcp.servers.<name>.extras]`.
+ * can pick it up. Cross-server merge with any existing config is performed
+ * by the orchestrator (`applyMigrated`), so this function always starts from
+ * an empty TOML root.
+ *
+ * Unknown extras are spread inline at the same level as the typed fields
+ * (mirroring the VS Code serializer). Stuffing them into a nested `extras`
+ * subtable would re-capture the literal key "extras" on the next parse via
+ * `pickExtras`, nesting one level deeper on every round-trip.
  */
-function serializeCodexMcp(model: McpModel, existingToml?: string): string {
-  let base: TOML.JsonMap = {};
-  if (existingToml) {
-    try {
-      base = TOML.parse(existingToml);
-    } catch {
-      /* corrupt existing TOML — start fresh */
-    }
-  }
-  const mcp = (base.mcp ?? {}) as TOML.JsonMap;
+function serializeCodexMcp(model: McpModel): string {
+  const base: TOML.JsonMap = {};
+  const mcp: TOML.JsonMap = {};
   const serverMap: TOML.JsonMap = {};
   for (const s of model.servers) {
     const entry: TOML.JsonMap = {};
@@ -390,7 +404,11 @@ function serializeCodexMcp(model: McpModel, existingToml?: string): string {
     if (s.sandboxEnabled !== undefined) entry.sandboxEnabled = s.sandboxEnabled;
     if (s.sandbox !== undefined && s.sandbox !== null) entry.sandbox = s.sandbox as TOML.AnyJson;
     if (s.dev !== undefined && s.dev !== null) entry.dev = s.dev as TOML.AnyJson;
-    if (s.extras && Object.keys(s.extras).length > 0) entry.extras = s.extras as TOML.AnyJson;
+    if (s.extras) {
+      for (const [k, v] of Object.entries(s.extras)) {
+        if (!(k in entry) && v !== undefined && v !== null) entry[k] = v as TOML.AnyJson;
+      }
+    }
     serverMap[s.name] = entry;
   }
   mcp.servers = serverMap;
@@ -420,12 +438,12 @@ function mcpToMcpServers(parse: ParseFn): Translator {
       const model = parse(raw);
       if (model.servers.length === 0 && model.inputs.length === 0) return null;
       const { content, warnings } = serializeMcpServersJson(model);
-      // Even if every server was dropped, surface the warnings so the
-      // operator hears about it — but skip writing an empty mcpServers file.
-      const parsed = JSON.parse(content) as { mcpServers: Record<string, unknown> };
-      if (Object.keys(parsed.mcpServers).length === 0) {
+      const wouldWriteAnyServer = model.servers.some((s) => s.transport === "stdio");
+      if (!wouldWriteAnyServer) {
+        // Surface warnings about dropped non-stdio servers / inputs without
+        // creating a brand-new file containing only `{"mcpServers":{}}`.
         if (warnings.length === 0) return null;
-        return { content, targetName: "mcp.json", warnings };
+        return { content, targetName: "mcp.json", warnings, skipWrite: true };
       }
       return { content, targetName: "mcp.json", warnings };
     } catch {
@@ -445,8 +463,14 @@ function mcpToCodex(parse: ParseFn): Translator {
           `Dropped ${model.inputs.length} top-level "inputs" placeholder(s): Codex MCP TOML has no equivalent.`,
         );
       }
+      const content = serializeCodexMcp(model);
+      // Inputs-only sources would write an empty `[mcp]\nservers = { }` stub;
+      // surface the warning instead and let the orchestrator skip the write.
+      if (model.servers.length === 0) {
+        return { content, targetName: "config.toml", warnings, skipWrite: true };
+      }
       return {
-        content: serializeCodexMcp(model),
+        content,
         targetName: "config.toml",
         ...(warnings.length > 0 ? { warnings } : {}),
       };

--- a/src/migrate/translators/mcp.ts
+++ b/src/migrate/translators/mcp.ts
@@ -2,9 +2,20 @@
  * src/migrate/translators/mcp.ts
  *
  * Pairwise translators for MCP server configurations.
- * Claude/Cursor/VS Code use JSON { mcpServers: { name: { command, args, env } } }.
- * Codex uses TOML [mcp.servers.name] with the same logical fields.
- * The McpServer[] intermediate representation bridges the two formats.
+ *
+ * The MCP ecosystem is no longer stdio-only: VS Code, the MCP spec, and the
+ * authorization spec now describe both stdio and Streamable HTTP transports
+ * with auth/discovery metadata. AgentSync therefore parses each source
+ * format into a transport-aware intermediate model (`McpModel`) before
+ * serialising to the target shape. Where a target cannot represent a
+ * transport (e.g. Claude/Cursor JSON is stdio-only today), the translator
+ * emits an explicit warning naming the dropped server rather than silently
+ * losing the field.
+ *
+ * VS Code reads top-level `servers` + `inputs` per its current docs.
+ * Claude/Cursor read top-level `mcpServers` (stdio-only).
+ * Codex reads TOML `[mcp.servers.*]` tables; non-stdio metadata is preserved
+ * as structured TOML so HTTP/SSE configs survive a round-trip.
  *
  * Secret detection is handled by the orchestrator, NOT the translators.
  * Translators are pure format converters.
@@ -14,135 +25,460 @@ import * as TOML from "@iarna/toml";
 import { z } from "zod";
 import type { Translator } from "../types";
 
-interface McpServer {
+// ── Intermediate model (transport-aware) ─────────────────────────────────────
+
+export type McpTransport = "stdio" | "http" | "sse";
+
+interface McpServerCommon {
   name: string;
+  /** Shared optional metadata that several transports/agents may preserve. */
+  envFile?: string;
+  sandboxEnabled?: boolean;
+  sandbox?: unknown;
+  dev?: unknown;
+  /** Unknown-but-known fields preserved verbatim for round-tripping. */
+  extras?: Record<string, unknown>;
+}
+
+export interface McpStdioServer extends McpServerCommon {
+  transport: "stdio";
   command: string;
   args?: string[];
   env?: Record<string, string>;
 }
 
-const McpServerSchema = z.object({
+export interface McpRemoteServer extends McpServerCommon {
+  transport: "http" | "sse";
+  url: string;
+  headers?: Record<string, string>;
+  /** Transport-level auth (OAuth-style discovery, bearer token shape, etc.). */
+  auth?: unknown;
+}
+
+export type McpServer = McpStdioServer | McpRemoteServer;
+
+/**
+ * VS Code-style top-level `inputs` placeholders. Other agents do not consume
+ * these today; they are preserved when the target is VS Code and dropped
+ * (with a warning) otherwise.
+ */
+export interface McpInput {
+  id: string;
+  type?: string;
+  description?: string;
+  password?: boolean;
+  /** Any additional VS Code-specific keys we preserve verbatim. */
+  extras?: Record<string, unknown>;
+}
+
+interface McpModel {
+  servers: McpServer[];
+  inputs: McpInput[];
+}
+
+// ── Zod helpers (single-server validation) ───────────────────────────────────
+
+const ZRecordString = z.record(z.string(), z.string());
+
+const ZStdioServer = z.object({
+  type: z.literal("stdio").optional(),
   command: z.string().min(1),
-  args: z.array(z.string()).optional().default([]),
-  env: z.record(z.string(), z.string()).optional().default({}),
+  args: z.array(z.string()).optional(),
+  env: ZRecordString.optional(),
+  envFile: z.string().optional(),
+  sandbox: z.unknown().optional(),
+  sandboxEnabled: z.boolean().optional(),
+  dev: z.unknown().optional(),
 });
 
-const JsonMcpSchema = z.object({
-  mcpServers: z.record(z.string(), McpServerSchema).default({}),
+const ZHttpServer = z.object({
+  type: z.union([z.literal("http"), z.literal("sse")]),
+  url: z.string().min(1),
+  headers: ZRecordString.optional(),
+  auth: z.unknown().optional(),
+  envFile: z.string().optional(),
+  sandbox: z.unknown().optional(),
+  sandboxEnabled: z.boolean().optional(),
+  dev: z.unknown().optional(),
 });
 
-const TomlMcpSchema = z.object({
-  mcp: z
-    .object({
-      servers: z.record(z.string(), McpServerSchema).default({}),
-    })
-    .default({ servers: {} }),
-});
+// Reserved keys that we map into the typed McpServer fields. Anything else
+// goes into `extras` so we can round-trip it.
+const STDIO_KNOWN_KEYS = new Set([
+  "type",
+  "command",
+  "args",
+  "env",
+  "envFile",
+  "sandbox",
+  "sandboxEnabled",
+  "dev",
+]);
 
-// ── JSON parsing (Claude, Cursor, VS Code) ───────────────────────────────────
+const HTTP_KNOWN_KEYS = new Set([
+  "type",
+  "url",
+  "headers",
+  "auth",
+  "envFile",
+  "sandbox",
+  "sandboxEnabled",
+  "dev",
+]);
 
-function parseJsonMcp(raw: string): McpServer[] {
-  const parsed = JsonMcpSchema.parse(JSON.parse(raw));
-  return Object.entries(parsed.mcpServers).map(([name, cfg]) => ({
-    name,
-    command: cfg.command,
-    args: cfg.args,
-    env: cfg.env,
-  }));
-}
-
-function serializeJsonMcp(servers: McpServer[]): string {
-  const mcpServers: Record<string, unknown> = {};
-  for (const s of servers) {
-    mcpServers[s.name] = { command: s.command, args: s.args, env: s.env };
+function pickExtras(
+  raw: Record<string, unknown>,
+  known: Set<string>,
+): Record<string, unknown> | undefined {
+  const extras: Record<string, unknown> = {};
+  let any = false;
+  for (const [k, v] of Object.entries(raw)) {
+    if (!known.has(k)) {
+      extras[k] = v;
+      any = true;
+    }
   }
-  return `${JSON.stringify({ mcpServers }, null, 2)}\n`;
+  return any ? extras : undefined;
 }
 
-// ── TOML parsing (Codex) ─────────────────────────────────────────────────────
+function parseSingleServer(name: string, raw: unknown): McpServer | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const declared = obj.type;
+  const isHttpish = declared === "http" || declared === "sse";
 
-function parseTomlMcp(raw: string): McpServer[] {
-  // Round-trip through JSON to convert TOML's special array/integer types to plain JS objects
-  const parsed = TomlMcpSchema.parse(JSON.parse(JSON.stringify(TOML.parse(raw))));
-  return Object.entries(parsed.mcp.servers).map(([name, cfg]) => ({
+  if (isHttpish) {
+    const parsed = ZHttpServer.safeParse(obj);
+    if (!parsed.success) return null;
+    const server: McpRemoteServer = {
+      name,
+      transport: parsed.data.type,
+      url: parsed.data.url,
+      headers: parsed.data.headers,
+      auth: parsed.data.auth,
+      envFile: parsed.data.envFile,
+      sandbox: parsed.data.sandbox,
+      sandboxEnabled: parsed.data.sandboxEnabled,
+      dev: parsed.data.dev,
+      extras: pickExtras(obj, HTTP_KNOWN_KEYS),
+    };
+    return server;
+  }
+
+  const parsed = ZStdioServer.safeParse(obj);
+  if (!parsed.success) return null;
+  const server: McpStdioServer = {
     name,
-    command: cfg.command,
-    args: cfg.args,
-    env: cfg.env,
-  }));
+    transport: "stdio",
+    command: parsed.data.command,
+    args: parsed.data.args,
+    env: parsed.data.env,
+    envFile: parsed.data.envFile,
+    sandbox: parsed.data.sandbox,
+    sandboxEnabled: parsed.data.sandboxEnabled,
+    dev: parsed.data.dev,
+    extras: pickExtras(obj, STDIO_KNOWN_KEYS),
+  };
+  return server;
 }
 
-function serializeTomlMcp(servers: McpServer[], existingToml?: string): string {
+function parseInputs(raw: unknown): McpInput[] {
+  if (!Array.isArray(raw)) return [];
+  const out: McpInput[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry as Record<string, unknown>;
+    if (typeof obj.id !== "string" || obj.id.length === 0) continue;
+    const knownInputKeys = new Set(["id", "type", "description", "password"]);
+    const extras: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (!knownInputKeys.has(k)) extras[k] = v;
+    }
+    out.push({
+      id: obj.id,
+      type: typeof obj.type === "string" ? obj.type : undefined,
+      description: typeof obj.description === "string" ? obj.description : undefined,
+      password: typeof obj.password === "boolean" ? obj.password : undefined,
+      extras: Object.keys(extras).length > 0 ? extras : undefined,
+    });
+  }
+  return out;
+}
+
+// ── Source parsers ───────────────────────────────────────────────────────────
+
+/**
+ * Parse VS Code's documented `mcp.json` shape: top-level `servers` + optional
+ * `inputs`. Falls back to the legacy `{ mcpServers: ... }` JSON shape so
+ * vault-round-trip fixtures continue to load.
+ */
+function parseVsCodeMcp(raw: string): McpModel {
+  const root = JSON.parse(raw) as Record<string, unknown>;
+  const out: McpModel = { servers: [], inputs: [] };
+
+  if (root.servers && typeof root.servers === "object") {
+    for (const [name, cfg] of Object.entries(root.servers as Record<string, unknown>)) {
+      const server = parseSingleServer(name, cfg);
+      if (server) out.servers.push(server);
+    }
+    out.inputs = parseInputs(root.inputs);
+    return out;
+  }
+
+  if (root.mcpServers && typeof root.mcpServers === "object") {
+    for (const [name, cfg] of Object.entries(root.mcpServers as Record<string, unknown>)) {
+      const server = parseSingleServer(name, cfg);
+      if (server) out.servers.push(server);
+    }
+  }
+  return out;
+}
+
+/** Parse Claude/Cursor `mcp.json`: top-level `mcpServers`. */
+function parseMcpServersJson(raw: string): McpModel {
+  const root = JSON.parse(raw) as Record<string, unknown>;
+  const out: McpModel = { servers: [], inputs: [] };
+  if (root.mcpServers && typeof root.mcpServers === "object") {
+    for (const [name, cfg] of Object.entries(root.mcpServers as Record<string, unknown>)) {
+      const server = parseSingleServer(name, cfg);
+      if (server) out.servers.push(server);
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse Codex `config.toml` MCP tables. Tables under `[mcp.servers.<name>]`
+ * may carry stdio-only fields (the historical shape) or transport-aware
+ * fields (`type`, `url`, `headers`, `auth`) populated by AgentSync writes.
+ */
+function parseCodexMcp(raw: string): McpModel {
+  const root = JSON.parse(JSON.stringify(TOML.parse(raw))) as Record<string, unknown>;
+  const out: McpModel = { servers: [], inputs: [] };
+  const mcp = (root.mcp ?? {}) as Record<string, unknown>;
+  const servers = (mcp.servers ?? {}) as Record<string, unknown>;
+  for (const [name, cfg] of Object.entries(servers)) {
+    const server = parseSingleServer(name, cfg);
+    if (server) out.servers.push(server);
+  }
+  return out;
+}
+
+// ── Target serialisers ───────────────────────────────────────────────────────
+
+function stripUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Serialise the model to VS Code's `mcp.json` shape: top-level `servers`
+ * + `inputs`. Each server is written with the transport-specific fields it
+ * carries; unknown-but-preserved keys are merged back from `extras`.
+ */
+function serializeVsCodeMcp(model: McpModel): string {
+  const servers: Record<string, unknown> = {};
+  for (const s of model.servers) {
+    let entry: Record<string, unknown>;
+    if (s.transport === "stdio") {
+      entry = {
+        type: "stdio",
+        command: s.command,
+        args: s.args,
+        env: s.env,
+        envFile: s.envFile,
+        sandbox: s.sandbox,
+        sandboxEnabled: s.sandboxEnabled,
+        dev: s.dev,
+      };
+    } else {
+      entry = {
+        type: s.transport,
+        url: s.url,
+        headers: s.headers,
+        auth: s.auth,
+        envFile: s.envFile,
+        sandbox: s.sandbox,
+        sandboxEnabled: s.sandboxEnabled,
+        dev: s.dev,
+      };
+    }
+    entry = stripUndefined(entry);
+    if (s.extras) {
+      for (const [k, v] of Object.entries(s.extras)) {
+        if (!(k in entry)) entry[k] = v;
+      }
+    }
+    servers[s.name] = entry;
+  }
+  const root: Record<string, unknown> = { servers };
+  if (model.inputs.length > 0) {
+    root.inputs = model.inputs.map((i) =>
+      stripUndefined({
+        id: i.id,
+        type: i.type,
+        description: i.description,
+        password: i.password,
+        ...(i.extras ?? {}),
+      }),
+    );
+  }
+  return `${JSON.stringify(root, null, 2)}\n`;
+}
+
+/**
+ * Serialise to Claude/Cursor `mcp.json` shape. These clients only support
+ * stdio today, so any HTTP/SSE server is dropped and named in a warning.
+ */
+function serializeMcpServersJson(model: McpModel): { content: string; warnings: string[] } {
+  const mcpServers: Record<string, unknown> = {};
+  const warnings: string[] = [];
+  for (const s of model.servers) {
+    if (s.transport !== "stdio") {
+      warnings.push(
+        `Dropped server "${s.name}": transport "${s.transport}" is not representable in the target's stdio-only mcpServers schema (url/headers/auth dropped).`,
+      );
+      continue;
+    }
+    mcpServers[s.name] = stripUndefined({
+      command: s.command,
+      args: s.args,
+      env: s.env,
+    });
+  }
+  if (model.inputs.length > 0) {
+    warnings.push(
+      `Dropped ${model.inputs.length} top-level "inputs" placeholder(s): not supported by the target's mcpServers schema.`,
+    );
+  }
+  return { content: `${JSON.stringify({ mcpServers }, null, 2)}\n`, warnings };
+}
+
+/**
+ * Serialise to Codex TOML. Codex supports the legacy stdio shape directly;
+ * non-stdio metadata is written under the same `[mcp.servers.<name>]`
+ * tables as structured TOML so a future Codex with Streamable HTTP support
+ * can pick it up. Unknown extras are stashed under `[mcp.servers.<name>.extras]`.
+ */
+function serializeCodexMcp(model: McpModel, existingToml?: string): string {
   let base: TOML.JsonMap = {};
   if (existingToml) {
     try {
       base = TOML.parse(existingToml);
     } catch {
-      /* ignore corrupt TOML — start fresh */
+      /* corrupt existing TOML — start fresh */
     }
   }
   const mcp = (base.mcp ?? {}) as TOML.JsonMap;
   const serverMap: TOML.JsonMap = {};
-  for (const s of servers) {
-    serverMap[s.name] = {
-      command: s.command,
-      args: s.args ?? [],
-      env: s.env ?? {},
-    };
+  for (const s of model.servers) {
+    const entry: TOML.JsonMap = {};
+    if (s.transport === "stdio") {
+      entry.command = s.command;
+      entry.args = (s.args ?? []) as TOML.AnyJson;
+      entry.env = (s.env ?? {}) as TOML.AnyJson;
+    } else {
+      entry.type = s.transport;
+      entry.url = s.url;
+      if (s.headers) entry.headers = s.headers as TOML.AnyJson;
+      if (s.auth !== undefined && s.auth !== null) entry.auth = s.auth as TOML.AnyJson;
+    }
+    if (s.envFile !== undefined) entry.envFile = s.envFile;
+    if (s.sandboxEnabled !== undefined) entry.sandboxEnabled = s.sandboxEnabled;
+    if (s.sandbox !== undefined && s.sandbox !== null) entry.sandbox = s.sandbox as TOML.AnyJson;
+    if (s.dev !== undefined && s.dev !== null) entry.dev = s.dev as TOML.AnyJson;
+    if (s.extras && Object.keys(s.extras).length > 0) entry.extras = s.extras as TOML.AnyJson;
+    serverMap[s.name] = entry;
   }
   mcp.servers = serverMap;
   base.mcp = mcp;
   return TOML.stringify(base);
 }
 
-// ── Translator functions ─────────────────────────────────────────────────────
+// ── Translators (registry-shaped wrappers) ───────────────────────────────────
 
-const jsonToJson: Translator = (raw) => {
-  try {
-    const servers = parseJsonMcp(raw);
-    if (servers.length === 0) return null;
-    return { content: serializeJsonMcp(servers), targetName: "mcp.json" };
-  } catch {
-    return null;
-  }
-};
+type ParseFn = (raw: string) => McpModel;
 
-const jsonToToml: Translator = (raw) => {
-  try {
-    const servers = parseJsonMcp(raw);
-    if (servers.length === 0) return null;
-    return { content: serializeTomlMcp(servers), targetName: "config.toml" };
-  } catch {
-    return null;
-  }
-};
+function mcpToVsCode(parse: ParseFn): Translator {
+  return (raw) => {
+    try {
+      const model = parse(raw);
+      if (model.servers.length === 0 && model.inputs.length === 0) return null;
+      return { content: serializeVsCodeMcp(model), targetName: "mcp.json" };
+    } catch {
+      return null;
+    }
+  };
+}
 
-const tomlToJson: Translator = (raw) => {
-  try {
-    const servers = parseTomlMcp(raw);
-    if (servers.length === 0) return null;
-    return { content: serializeJsonMcp(servers), targetName: "mcp.json" };
-  } catch {
-    return null;
-  }
-};
+function mcpToMcpServers(parse: ParseFn): Translator {
+  return (raw) => {
+    try {
+      const model = parse(raw);
+      if (model.servers.length === 0 && model.inputs.length === 0) return null;
+      const { content, warnings } = serializeMcpServersJson(model);
+      // Even if every server was dropped, surface the warnings so the
+      // operator hears about it — but skip writing an empty mcpServers file.
+      const parsed = JSON.parse(content) as { mcpServers: Record<string, unknown> };
+      if (Object.keys(parsed.mcpServers).length === 0) {
+        if (warnings.length === 0) return null;
+        return { content, targetName: "mcp.json", warnings };
+      }
+      return { content, targetName: "mcp.json", warnings };
+    } catch {
+      return null;
+    }
+  };
+}
+
+function mcpToCodex(parse: ParseFn): Translator {
+  return (raw) => {
+    try {
+      const model = parse(raw);
+      if (model.servers.length === 0 && model.inputs.length === 0) return null;
+      const warnings: string[] = [];
+      if (model.inputs.length > 0) {
+        warnings.push(
+          `Dropped ${model.inputs.length} top-level "inputs" placeholder(s): Codex MCP TOML has no equivalent.`,
+        );
+      }
+      return {
+        content: serializeCodexMcp(model),
+        targetName: "config.toml",
+        ...(warnings.length > 0 ? { warnings } : {}),
+      };
+    } catch {
+      return null;
+    }
+  };
+}
 
 /**
  * All MCP translators indexed by direction for registry registration.
- * Each function parses source MCP config (JSON or TOML), extracts McpServer[] intermediate
- * representation, and serialises to the target format.
+ *
+ * Each function picks the source parser based on the *source* agent (VS Code
+ * uses its top-level `servers`/`inputs` parser; Claude/Cursor use the
+ * legacy `mcpServers` parser; Codex parses TOML) and the target serialiser
+ * based on the *target* agent's documented schema.
  */
 export const translateMcp = {
-  claudeToCursor: jsonToJson,
-  claudeToVsCode: jsonToJson,
-  cursorToClaude: jsonToJson,
-  cursorToVsCode: jsonToJson,
-  vsCodeToClaude: jsonToJson,
-  vsCodeToCursor: jsonToJson,
-  claudeToCodex: jsonToToml,
-  cursorToCodex: jsonToToml,
-  vsCodeToCodex: jsonToToml,
-  codexToClaude: tomlToJson,
-  codexToCursor: tomlToJson,
-  codexToVsCode: tomlToJson,
+  // Claude as source ----------------------------------------------------------
+  claudeToCursor: mcpToMcpServers(parseMcpServersJson),
+  claudeToVsCode: mcpToVsCode(parseMcpServersJson),
+  claudeToCodex: mcpToCodex(parseMcpServersJson),
+  // Cursor as source ----------------------------------------------------------
+  cursorToClaude: mcpToMcpServers(parseMcpServersJson),
+  cursorToVsCode: mcpToVsCode(parseMcpServersJson),
+  cursorToCodex: mcpToCodex(parseMcpServersJson),
+  // VS Code as source ---------------------------------------------------------
+  vsCodeToClaude: mcpToMcpServers(parseVsCodeMcp),
+  vsCodeToCursor: mcpToMcpServers(parseVsCodeMcp),
+  vsCodeToCodex: mcpToCodex(parseVsCodeMcp),
+  // Codex as source -----------------------------------------------------------
+  codexToClaude: mcpToMcpServers(parseCodexMcp),
+  codexToCursor: mcpToMcpServers(parseCodexMcp),
+  codexToVsCode: mcpToVsCode(parseCodexMcp),
 };

--- a/src/migrate/types.ts
+++ b/src/migrate/types.ts
@@ -44,12 +44,14 @@ export interface MigrateResult {
  *
  * @param sourceContent - Raw content read from the source agent's config file.
  * @param sourceName - Filename of the source artefact (used for file-based types like commands).
- * @returns Translated content and target filename, or null if the input is empty/untranslatable.
+ * @returns Translated content, target filename, and optional warnings about lossy or
+ *   partial transformations (e.g., dropped HTTP/SSE transport fields). null when the
+ *   input is empty or untranslatable.
  */
 export type Translator = (
   sourceContent: string,
   sourceName?: string,
-) => { content: string; targetName: string } | null;
+) => { content: string; targetName: string; warnings?: string[] } | null;
 
 // MigrateOptions is defined by the Zod schema in src/config/schema.ts
 // and re-exported here for convenience.

--- a/src/migrate/types.ts
+++ b/src/migrate/types.ts
@@ -45,13 +45,20 @@ export interface MigrateResult {
  * @param sourceContent - Raw content read from the source agent's config file.
  * @param sourceName - Filename of the source artefact (used for file-based types like commands).
  * @returns Translated content, target filename, and optional warnings about lossy or
- *   partial transformations (e.g., dropped HTTP/SSE transport fields). null when the
- *   input is empty or untranslatable.
+ *   partial transformations (e.g., dropped HTTP/SSE transport fields). When `skipWrite`
+ *   is set the orchestrator surfaces `warnings` but does not write the file — used when
+ *   every server in the source was dropped by the target schema and writing an empty
+ *   stub would create misleading state. null when the input is empty or untranslatable.
  */
 export type Translator = (
   sourceContent: string,
   sourceName?: string,
-) => { content: string; targetName: string; warnings?: string[] } | null;
+) => {
+  content: string;
+  targetName: string;
+  warnings?: string[];
+  skipWrite?: boolean;
+} | null;
 
 // MigrateOptions is defined by the Zod schema in src/config/schema.ts
 // and re-exported here for convenience.


### PR DESCRIPTION
## Summary

Closes #41.

Models MCP server configuration as a transport-aware intermediate (`stdio` | `http` | `sse`) so VS Code's official top-level `servers` + `inputs` schema round-trips correctly through every translator pair. Previously the migrate pipeline assumed a flat `mcpServers` shape, which silently dropped HTTP/SSE transport metadata, `headers`, `envFile`, `sandbox`, and top-level `inputs` when targeting VS Code.

## Changes

**`src/migrate/translators/mcp.ts`** — rewritten around a discriminated-union `McpServer` model. New parsers (`parseVsCodeMcp` with legacy `mcpServers` fallback, `parseMcpServersJson`, `parseCodexMcp`) emit a shared `McpModel`; new serializers (`serializeVsCodeMcp`, `serializeMcpServersJson`, `serializeCodexMcp`) project it back into each agent's native shape. Non-stdio servers dropped while targeting stdio-only agents (Claude/Cursor) now emit explicit translator warnings naming the server and the unsupported transport. Top-level `inputs` are preserved into VS Code and warned about for all other targets.

**`src/migrate/types.ts`** — `Translator` return type extended with optional `warnings: string[]` so lossy translations can surface guidance instead of silently dropping fields.

**`src/migrate/migrate.ts`** — `applyMigrated()` now merges using a target-aware key: VS Code merges into top-level `servers` and dedupes `inputs`, Claude/Cursor keep their `mcpServers` merge, Codex keeps its `[mcp.servers.*]` TOML merge. Translator warnings are propagated into `MigrateResult.warnings` with a `${from} → ${target} (${type}): …` prefix so the CLI surfaces them.

**Tests** — `src/migrate/__tests__/translators/mcp.test.ts` adds an official-shape VS Code fixture plus the legacy fallback fixture and covers: vscode↔codex transport round-trip, claude/cursor → vscode emitting top-level `servers` (not double-nested), vscode → claude/cursor warning about dropped http/sse servers and dropped `inputs`, vscode → codex preserving `headers`/`url`/`type` under `[mcp.servers.*]`. `src/migrate/__tests__/migrate.test.ts` adds orchestrator-level tests for cross-shape merge keys and warning propagation. `src/agents/__tests__/vscode.test.ts` adds a regression test confirming `headers.Authorization` values in VS Code official-shape `mcp.json` are still redacted by the existing sanitizer (which walks any JSON shape).

**`docs/migrate.md`** — new "MCP Transport Support" section documents the per-target transport matrix and how warnings surface; "Key Behaviours" notes the target-specific MCP merge key.

### Architecture

```mermaid
flowchart LR
    classDef source fill:#1a5276,color:#ffffff
    classDef model fill:#1e8449,color:#ffffff
    classDef target fill:#b9770e,color:#ffffff
    classDef warn fill:#922b21,color:#ffffff

    VS["VS Code mcp.json<br/>servers + inputs"]:::source
    CL["Claude mcp.json<br/>mcpServers"]:::source
    CR["Cursor mcp.json<br/>mcpServers"]:::source
    CX["Codex config.toml<br/>[mcp.servers.*]"]:::source

    MODEL["McpModel<br/>discriminated union:<br/>stdio | http | sse<br/>+ inputs"]:::model

    OUTVS["VS Code: top-level servers + inputs"]:::target
    OUTCL["Claude: mcpServers (stdio-only)"]:::target
    OUTCR["Cursor: mcpServers (stdio-only)"]:::target
    OUTCX["Codex: [mcp.servers.*] TOML"]:::target

    WARN["MigrateResult.warnings<br/>names dropped server + transport"]:::warn

    VS --> MODEL
    CL --> MODEL
    CR --> MODEL
    CX --> MODEL

    MODEL --> OUTVS
    MODEL -->|"drop non-stdio"| OUTCL
    MODEL -->|"drop non-stdio"| OUTCR
    MODEL -->|"drop inputs"| OUTCX

    OUTCL -.-> WARN
    OUTCR -.-> WARN
    OUTCX -.-> WARN
```

## Test Evidence

| Command | Result |
|---------|--------|
| `bun run typecheck` | pass |
| `bun run lint` | pass (warnings only, no errors) |
| `bun test src/migrate src/agents/__tests__/vscode.test.ts` | **73 pass / 0 fail** |

Plan tasks T1–T11 all landed in the single commit on this branch. Full-suite `bun test` shows the 20 pre-existing `node:fs/promises` import failures from the daemon installer tests bleeding into unrelated suites; they are present on `main` at `72de7b1` without these changes and are not introduced by this PR (`migrate.test.ts` already carries a defensive workaround comment for that bleed).

## Risks / Follow-ups

- Codex serialization now emits structured `type` / `url` / `headers` / `auth` blocks under `[mcp.servers.<name>]` for http/sse transports. Existing Codex clients that only consume stdio fields will ignore them safely, but a future Codex release that itself defines a non-stdio schema may need a translator update.
- VS Code parser accepts both the official `servers` shape and the legacy `mcpServers` shape so existing vault snapshots continue to work; we should drop the legacy fallback once we're confident no vaults still carry the old shape.
- The 20 pre-existing test failures from the daemon installer `node:fs/promises` mock bleed remain — out of scope here but worth a dedicated cleanup.

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MCP HTTP and SSE transports with intelligent platform-aware migration handling.
  * Introduced warning system for unsupported transports when migrating between platforms.
  * Enhanced secret redaction for MCP authorization headers and sensitive content.

* **Documentation**
  * Updated migration guide with MCP transport support details and platform-specific merge behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->