### PR TITLE
test(watcher): use polling waitFor for positive assertions

### DIFF
--- a/src/core/__tests__/watcher.test.ts
+++ b/src/core/__tests__/watcher.test.ts
@@ -55,8 +55,11 @@ describe("Watcher", () => {
     // Await the actual callback rather than a fixed sleep — FSEvents latency
     // can exceed any fixed budget under full-suite I/O contention.
     await waitFor(() => fired.length >= 1);
-    // Give any spurious extras a chance to land before snapshotting.
-    await Bun.sleep(150);
+    // Watch for a spurious extra. Inverting the poll makes the "no extras
+    // within window" intent explicit and matches the 300 ms margin used by
+    // the other negative branches — a fixed sleep here would be silently
+    // masked by close() cancelling any still-pending debounce timer.
+    await waitFor(() => fired.length > 1, 300).catch(() => {});
     watcher.close();
 
     // Debounce must collapse all writes into exactly one callback

--- a/src/core/__tests__/watcher.test.ts
+++ b/src/core/__tests__/watcher.test.ts
@@ -13,6 +13,19 @@ import { Watcher } from "../watcher";
   mock.module("node:fs/promises", () => realFsPromises);
 }
 
+// Poll for an event-driven condition instead of a fixed sleep — fs.watch on
+// macOS (FSEvents) batches with non-deterministic latency, so positive
+// assertions need to await callback arrival rather than assume a budget.
+async function waitFor(condition: () => boolean, maxMs = 2000, stepMs = 25): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > maxMs) {
+      throw new Error(`waitFor: condition not met within ${maxMs}ms`);
+    }
+    await Bun.sleep(stepMs);
+  }
+}
+
 // Watcher debounce and lifecycle
 
 describe("Watcher", () => {
@@ -39,8 +52,11 @@ describe("Watcher", () => {
       await writeFile(filePath, `write-${i}`, "utf8");
     }
 
-    // Wait debounce window + generous buffer
-    await Bun.sleep(250);
+    // Await the actual callback rather than a fixed sleep — FSEvents latency
+    // can exceed any fixed budget under full-suite I/O contention.
+    await waitFor(() => fired.length >= 1);
+    // Give any spurious extras a chance to land before snapshotting.
+    await Bun.sleep(150);
     watcher.close();
 
     // Debounce must collapse all writes into exactly one callback
@@ -57,16 +73,18 @@ describe("Watcher", () => {
       fireCount++;
     });
 
-    // First write — should trigger
+    // First write — must observe the callback before snapshotting, otherwise
+    // the negative assertion can pass for the wrong reason on slow event delivery.
     await writeFile(filePath, "initial", "utf8");
-    await Bun.sleep(150);
+    await waitFor(() => fireCount >= 1);
     const beforeRemove = fireCount;
 
     watcher.remove(tmpDir);
 
-    // Write after remove — must NOT trigger
+    // Write after remove — must NOT trigger. Use a wider margin than the
+    // original 150 ms so FSEvents latency can't masquerade as a quiet watcher.
     await writeFile(filePath, "after-remove", "utf8");
-    await Bun.sleep(150);
+    await Bun.sleep(300);
 
     expect(fireCount).toBe(beforeRemove); // no new events
   });
@@ -75,18 +93,24 @@ describe("Watcher", () => {
   test("Watcher.close stops all watchers; writes after close invoke no callbacks", async () => {
     const watcher = new Watcher();
     let fireCount = 0;
+    const warmupPath = join(tmpDir, "warmup.txt");
     const filePath = join(tmpDir, "post-close.txt");
 
     watcher.add(tmpDir, 50, () => {
       fireCount++;
     });
-    await Bun.sleep(50); // let the watcher initialise
+
+    // Warm-up write proves the watcher is live before we close it; without
+    // this, a slow FSEvents subscribe could let a pre-close event leak past.
+    await writeFile(warmupPath, "warmup", "utf8");
+    await waitFor(() => fireCount >= 1);
+    const beforeClose = fireCount;
 
     watcher.close();
 
     await writeFile(filePath, "after-close", "utf8");
-    await Bun.sleep(150);
+    await Bun.sleep(300);
 
-    expect(fireCount).toBe(0);
+    expect(fireCount).toBe(beforeClose);
   });
 });


### PR DESCRIPTION
## Summary

Watcher tests on macOS (FSEvents) fail intermittently under full-suite I/O contention because the previous tests awaited the debounce window with a fixed `Bun.sleep` before positive equality assertions — the FS event can land later than the sleep budget, and the assertion fires while `fired.length === 0`. This PR replaces fixed-sleep-before-positive-assert with a local polling helper, keeps a (widened) fixed sleep before the two negative assertions, and adds a warm-up handshake to the close test so the watcher is provably live before close.

The fix is test-only; `src/core/watcher.ts` is unchanged.

## Changes

- Added a local `waitFor(condition, maxMs=2000, stepMs=25)` poll helper to `src/core/__tests__/watcher.test.ts` that throws a descriptive timeout error so failures surface as `waitFor: condition not met` rather than `Expected 1, Received 0`.
- Rewrote the debounce test to `waitFor(() => fired.length >= 1)`, then sleep 150 ms for spurious extras, then close and assert exactly one callback.
- Rewrote `Watcher.remove` to await the first callback via `waitFor` before snapshotting `beforeRemove`. Negative assertion keeps a fixed sleep but widens it from 150 ms to 300 ms.
- Rewrote `Watcher.close` to replace the 50 ms warm-up sleep with a warm-up write + `waitFor` so the watcher is provably live before close. Negative-assertion sleep widened to 300 ms; the post-close baseline is now `beforeClose` rather than a hard-coded `0`, so any warm-up event counts as part of the pre-close baseline.

### Architecture

Test-only change; no production behaviour or flow shift.

## Test Evidence

- `for i in 1 2 3 4 5; do bun test src/core/__tests__/watcher.test.ts; done` — 5/5 runs pass, `3 pass / 0 fail / 3 expect() calls` each.
- `bun test` (full suite, ×2) — `239 pass / 20 fail / 16 errors`, identical to baseline on `main` (the 20 failures and 16 errors are pre-existing test bleed unrelated to this change; confirmed by checking out main and re-running).
- `bun run typecheck` — clean.
- `bun run lint` — only pre-existing CSS warnings on `docs/...` (mkdocs site); no new findings from this change.

## Files changed

- `src/core/__tests__/watcher.test.ts` — added `waitFor` helper; rewrote three tests to await callback arrival (positive) or sleep + widened margin (negative).

## Commits

- `39c28ce` — test(watcher): use polling waitFor for positive assertions

## Tests run

- `bun test src/core/__tests__/watcher.test.ts` (×5) · 3/3 pass per run
- `bun test` (×2) · 239 pass / 20 fail / 16 errors (baseline-matching pre-existing failures)
- `bun run typecheck` · pass
- `bun run lint` · 8 pre-existing CSS warnings, no errors

## Verification

1. Watcher suite passes deterministically in isolation (5+ consecutive `bun test src/core/__tests__/watcher.test.ts`).
2. Full `bun test` runs show no Watcher failures across two consecutive runs.
3. Diff inspection:
   - No `Bun.sleep(...)` immediately precedes a positive `toBe(1)`-style assertion in `watcher.test.ts`.
   - Both negative assertions (`Watcher.remove`, `Watcher.close`) retain a fixed sleep but with a wider margin (300 ms vs original 150 ms).
   - No production code in `src/core/watcher.ts` was modified.

## Risks / Follow-ups

- The fix targets macOS FSEvents latency, which cannot be reproduced on the Linux CI host. CI cannot exercise the failure mode directly; the fix is structural (await the event vs assume a budget) and the worst-case effect on Linux is a per-test slowdown bounded by `maxMs = 2000`.
- The 20 pre-existing full-suite failures (mock.module bleed of `node:fs/promises`) are out of scope and not addressed here.

Closes #45


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved file system watcher test reliability and stability across platforms by replacing fixed timing waits with event-driven polling conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/61)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->