### PR TITLE
fix(init): probe remote before writing keypair; roll back orphan key on failure

### DIFF
--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -441,10 +441,12 @@ describe("integration", () => {
     const root = join(tmpDir, "init-unreachable-remote");
     mkdirSync(root, { recursive: true });
     const machine = await createMachineFixture(root, "init-unreachable-machine");
-    // createMachineFixture pre-seeds a key.txt so that other tests can model
-    // "machine that has already run init once". For this test we want the
-    // first-init case, so remove the seeded key before invoking init.
+    // createMachineFixture pre-seeds a key.txt and a vaultDir so that other
+    // tests can model "machine that has already run init once". For this test
+    // we want the first-init case, so remove both before invoking init — and
+    // then assert that init's failure path does NOT recreate the vault dir.
     await rm(machine.keyPath, { force: true });
+    await rm(machine.vaultDir, { recursive: true, force: true });
 
     const bogusRemote = join(root, "nonexistent-remote.git");
 
@@ -457,10 +459,12 @@ describe("integration", () => {
     });
 
     expect(process.exitCode).toBe(1);
-    // An unreachable remote must abort BEFORE any key material is written.
-    // Otherwise a retry against a different URL silently inherits an orphan
-    // key bound to no completed init.
+    // An unreachable remote must abort BEFORE any local artifact is written.
+    // No key.txt, no agentsync.toml, AND no vault dir on disk — otherwise a
+    // retry against a different URL silently inherits an orphan key or an
+    // empty vault dir bound to no completed init.
     expect(existsSync(machine.keyPath)).toBe(false);
+    expect(existsSync(machine.vaultDir)).toBe(false);
     expect(existsSync(join(machine.vaultDir, "agentsync.toml"))).toBe(false);
     expect(fakeLogs.error.length).toBeGreaterThan(0);
     expect(fakeLogs.success.some((message) => message.includes("Initialized vault"))).toBe(false);

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -437,6 +437,125 @@ describe("integration", () => {
     expect(fakeLogs.success.some((message) => message.includes("Initialized vault"))).toBe(false);
   });
 
+  test("init against an unreachable remote leaves no key.txt and no vault artifacts", async () => {
+    const root = join(tmpDir, "init-unreachable-remote");
+    mkdirSync(root, { recursive: true });
+    const machine = await createMachineFixture(root, "init-unreachable-machine");
+    // createMachineFixture pre-seeds a key.txt so that other tests can model
+    // "machine that has already run init once". For this test we want the
+    // first-init case, so remove the seeded key before invoking init.
+    await rm(machine.keyPath, { force: true });
+
+    const bogusRemote = join(root, "nonexistent-remote.git");
+
+    await withMachineEnv(machine, async () => {
+      await initMod.initCommand.run?.({
+        args: { remote: bogusRemote, branch: "main" },
+        rawArgs: [],
+        cmd: {} as never,
+      } as never);
+    });
+
+    expect(process.exitCode).toBe(1);
+    // An unreachable remote must abort BEFORE any key material is written.
+    // Otherwise a retry against a different URL silently inherits an orphan
+    // key bound to no completed init.
+    expect(existsSync(machine.keyPath)).toBe(false);
+    expect(existsSync(join(machine.vaultDir, "agentsync.toml"))).toBe(false);
+    expect(fakeLogs.error.length).toBeGreaterThan(0);
+    expect(fakeLogs.success.some((message) => message.includes("Initialized vault"))).toBe(false);
+  });
+
+  test("init failure against an unreachable remote preserves a pre-existing keypair", async () => {
+    const root = join(tmpDir, "init-preserves-existing-key");
+    mkdirSync(root, { recursive: true });
+    // createMachineFixture writes a key.txt with a fresh identity. That key
+    // stands in for one a previous successful init committed to.
+    const machine = await createMachineFixture(root, "init-preserve-machine");
+    const bogusRemote = join(root, "nonexistent-remote.git");
+
+    const originalKeyContents = await readFile(machine.keyPath, "utf8");
+
+    await withMachineEnv(machine, async () => {
+      await initMod.initCommand.run?.({
+        args: { remote: bogusRemote, branch: "main" },
+        rawArgs: [],
+        cmd: {} as never,
+      } as never);
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(machine.keyPath)).toBe(true);
+    // A pre-existing key must be byte-for-byte unchanged. Rolling it back
+    // would destroy the only copy of the user's age private key.
+    const afterKeyContents = await readFile(machine.keyPath, "utf8");
+    expect(afterKeyContents).toBe(originalKeyContents);
+  });
+
+  test("init failure after a successful remote probe cleans up a freshly generated key.txt", async () => {
+    const root = join(tmpDir, "init-divergence-rollback");
+    mkdirSync(root, { recursive: true });
+    const bareRepoPath = await createBareRepo(root);
+    const machineA = await createMachineFixture(root, "machine-a");
+    const machineB = await createMachineFixture(root, "machine-b");
+    // Remove machineB's pre-seeded key so init must generate a fresh one
+    // during this run. That makes this run the "isNew = true" path and lets
+    // the assertion below distinguish "rolled back" from "never written".
+    await rm(machineB.keyPath, { force: true });
+
+    seedVaultRepo({ machine: machineA, bareRepoPath });
+
+    await writeConfig(resolveConfigPath(machineB.vaultDir), {
+      version: "1",
+      recipients: { [machineB.machineName]: machineB.recipient },
+      agents: {
+        cursor: false,
+        claude: true,
+        codex: false,
+        copilot: false,
+        vscode: false,
+      },
+      remote: {
+        url: bareRepoPath,
+        branch: "main",
+      },
+      sync: {
+        debounceMs: 300,
+        autoPush: true,
+        autoPull: true,
+        pullIntervalMs: 300_000,
+      },
+      claudePlugins: { syncMarketplace: false },
+    });
+    writeFileSync(join(machineB.vaultDir, ".gitignore"), "*.tmp\n", "utf8");
+    runGit(["init"], machineB.vaultDir);
+    runGit(["symbolic-ref", "HEAD", "refs/heads/main"], machineB.vaultDir);
+    runGit(["config", "user.name", "Agent Sync Test"], machineB.vaultDir);
+    runGit(["config", "user.email", "test@agentsync.local"], machineB.vaultDir);
+    runGit(["remote", "add", "origin", bareRepoPath], machineB.vaultDir);
+    runGit(["add", "."], machineB.vaultDir);
+    runGit(["commit", "-m", "local-only bootstrap"], machineB.vaultDir);
+
+    await withMachineEnv(machineB, async () => {
+      await initMod.initCommand.run?.({
+        args: { remote: bareRepoPath, branch: "main" },
+        rawArgs: [],
+        cmd: {} as never,
+      } as never);
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(
+      fakeLogs.error.some((message) =>
+        message.includes("AgentSync only supports fast-forward sync"),
+      ),
+    ).toBe(true);
+    // The remote probe succeeded (so a key was generated), but the
+    // post-probe reconcile step failed. The key must be cleaned up so a
+    // retry does not silently reuse material from a never-completed init.
+    expect(existsSync(machineB.keyPath)).toBe(false);
+  });
+
   test("performPush encrypts artifact and writes .age file to vault", async () => {
     fakeArtifacts.push({
       vaultPath: "claude/CLAUDE.age",

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -492,6 +492,36 @@ describe("integration", () => {
     expect(afterKeyContents).toBe(originalKeyContents);
   });
 
+  test("init preserves an unreadable key.txt instead of overwriting it", async () => {
+    const root = join(tmpDir, "init-preserves-unreadable-key");
+    mkdirSync(root, { recursive: true });
+    const bareRepoPath = await createBareRepo(root);
+    const machine = await createMachineFixture(root, "init-unreadable-key");
+    // Replace the seeded key.txt with a directory at the same path. readFile
+    // throws EISDIR (not ENOENT), which previously fell through the bare catch
+    // and silently overwrote the path with a freshly generated key — a
+    // destructive outcome for any non-missing key file (locked permissions,
+    // corrupt prior write, mount issue).
+    await rm(machine.keyPath, { force: true });
+    mkdirSync(machine.keyPath);
+
+    await withMachineEnv(machine, async () => {
+      await initMod.initCommand.run?.({
+        args: { remote: bareRepoPath, branch: "main" },
+        rawArgs: [],
+        cmd: {} as never,
+      } as never);
+    });
+
+    expect(process.exitCode).toBe(1);
+    // The directory at key.txt must still be a directory — never replaced
+    // with a regenerated identity file. This is the invariant the fix exists
+    // to protect: only ENOENT means "no key", everything else must surface.
+    expect(existsSync(machine.keyPath)).toBe(true);
+    const { statSync } = createRequire(import.meta.url)("fs") as typeof import("node:fs");
+    expect(statSync(machine.keyPath).isDirectory()).toBe(true);
+  });
+
   test("init failure after a successful remote probe cleans up a freshly generated key.txt", async () => {
     const root = join(tmpDir, "init-divergence-rollback");
     mkdirSync(root, { recursive: true });

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -522,6 +522,44 @@ describe("integration", () => {
     expect(statSync(machine.keyPath).isDirectory()).toBe(true);
   });
 
+  test("init failure inside ensureKeypair writeFile leaves no orphan key.txt", async () => {
+    const root = join(tmpDir, "init-writefile-failure");
+    mkdirSync(root, { recursive: true });
+    const bareRepoPath = await createBareRepo(root);
+    const machine = await createMachineFixture(root, "init-writefile-machine");
+    // Remove the seeded key.txt so init takes the generate-and-write path.
+    await rm(machine.keyPath, { force: true });
+
+    // Point the key path under a parent directory that does not exist. init's
+    // mkdir creates `vaultDir` (recursive: true) but not the key.txt parent,
+    // so writeFile inside ensureKeypair will reject AFTER the remote probe
+    // succeeds. The cleanup contract is that any failure mid-generate-and-
+    // write must leave no orphan key.txt at the target path — otherwise a
+    // retry could silently inherit a partial-written key as "existing".
+    const orphanKeyPath = join(root, "missing-parent-dir", "key.txt");
+
+    await withMachineEnv({ ...machine, keyPath: orphanKeyPath }, async () => {
+      await initMod.initCommand.run?.({
+        args: { remote: bareRepoPath, branch: "main" },
+        rawArgs: [],
+        cmd: {} as never,
+      } as never);
+    });
+
+    expect(process.exitCode).toBe(1);
+    // No orphan key at the target. force: true in the cleanup catches
+    // ENOENT for the case where writeFile failed before any bytes hit disk,
+    // and removes partial bytes when writeFile rejected mid-write.
+    expect(existsSync(orphanKeyPath)).toBe(false);
+    // The "back up your private key now" warn must NOT fire when init
+    // never actually committed to the key — otherwise the user would copy
+    // a key that is about to be (or has just been) cleaned up.
+    expect(fakeLogs.warn.some((message) => message.includes("New age keypair generated"))).toBe(
+      false,
+    );
+    expect(fakeLogs.error.length).toBeGreaterThan(0);
+  });
+
   test("init failure after a successful remote probe cleans up a freshly generated key.txt", async () => {
     const root = join(tmpDir, "init-divergence-rollback");
     mkdirSync(root, { recursive: true });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -87,17 +87,25 @@ export const initCommand = defineCommand({
       return;
     }
 
-    const { recipient, isNew: keyIsNew } = await ensureKeypair(runtime.privateKeyPath);
-
-    if (keyIsNew) {
-      log.warn(
-        `New age keypair generated.\n  Public key : ${recipient}\n  Private key: ${runtime.privateKeyPath}\n  ⚠  Back up your private key in a password manager now. It cannot be recovered.`,
-      );
-    } else {
-      log.info(`Loaded existing keypair — public key: ${recipient}`);
-    }
-
+    // `keyIsNew` is declared outside the try so the catch can tell whether
+    // this invocation generated the key (and is allowed to delete it) or
+    // inherited one from a previous successful init (which must be preserved).
+    let keyIsNew = false;
     try {
+      // `ensureKeypair` is inside the guarded block so a mid-call failure
+      // (writeFile partial-write, identityToRecipient throw) still triggers
+      // the rollback below instead of leaving a half-written key on disk.
+      const { recipient, isNew } = await ensureKeypair(runtime.privateKeyPath);
+      keyIsNew = isNew;
+
+      if (keyIsNew) {
+        log.warn(
+          `New age keypair generated.\n  Public key : ${recipient}\n  Private key: ${runtime.privateKeyPath}\n  ⚠  Back up your private key in a password manager now. It cannot be recovered.`,
+        );
+      } else {
+        log.info(`Loaded existing keypair — public key: ${recipient}`);
+      }
+
       const repoInitialized = await git.isInitialized();
 
       if (!repoInitialized) {
@@ -173,13 +181,25 @@ export const initCommand = defineCommand({
         );
       }
     } catch (err) {
-      // The remote probe above passed, so the failure here is in clone/init,
-      // reconcile, config write, commit, or push. If we generated the key on
-      // this invocation, delete it so a retry is not bound to material that
-      // never made it into a successful init. A pre-existing key (one a
-      // previous successful init committed to) is preserved untouched.
+      // The remote probe above passed, so the failure here is in keypair
+      // generation, clone/init, reconcile, config write, commit, or push. If
+      // we generated the key on this invocation, delete it so a retry is not
+      // bound to material that never made it into a successful init. A
+      // pre-existing key (one a previous successful init committed to) is
+      // preserved untouched.
       if (keyIsNew) {
-        await rm(runtime.privateKeyPath, { force: true });
+        try {
+          await rm(runtime.privateKeyPath, { force: true });
+        } catch (rmErr) {
+          // Surface rm failures (EBUSY/EACCES/EROFS) as a warning instead of
+          // letting them propagate and mask the real init error below. The
+          // hint tells the user that an orphan key.txt may still be on disk
+          // and a naive retry would silently inherit it.
+          const rmMessage = rmErr instanceof Error ? rmErr.message : String(rmErr);
+          log.warn(
+            `Failed to roll back freshly generated key at ${runtime.privateKeyPath}: ${rmMessage}.\nRemove key.txt manually before retrying.`,
+          );
+        }
       }
       log.error(err instanceof Error ? err.message : String(err));
       process.exitCode = 1;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
@@ -22,8 +22,16 @@ const DEFAULT_SYNC = {
   pullIntervalMs: 300_000,
 };
 
-/** Load or create the local age keypair so init can register this machine as a recipient. */
-async function ensureKeypair(path: string): Promise<{ identity: string; recipient: string }> {
+/**
+ * Load or create the local age keypair so init can register this machine as a
+ * recipient. Returns `isNew` so the caller can (a) defer the "generated" /
+ * "loaded" log line until after init has actually committed to keeping the key
+ * and (b) roll back a freshly written `key.txt` without touching a pre-existing
+ * one if a later step fails.
+ */
+async function ensureKeypair(
+  path: string,
+): Promise<{ identity: string; recipient: string; isNew: boolean }> {
   let identity: string;
   let isNew = false;
 
@@ -37,15 +45,7 @@ async function ensureKeypair(path: string): Promise<{ identity: string; recipien
 
   const recipient = await identityToRecipient(identity);
 
-  if (isNew) {
-    log.warn(
-      `New age keypair generated.\n  Public key : ${recipient}\n  Private key: ${path}\n  ⚠  Back up your private key in a password manager now. It cannot be recovered.`,
-    );
-  } else {
-    log.info(`Loaded existing keypair — public key: ${recipient}`);
-  }
-
-  return { identity, recipient };
+  return { identity, recipient, isNew };
 }
 
 /** Bootstrap a vault, local key material, and the initial git remote wiring. */
@@ -72,13 +72,33 @@ export const initCommand = defineCommand({
     const runtime = await resolveRuntimeContext();
     await mkdir(runtime.vaultDir, { recursive: true });
 
-    const { recipient } = await ensureKeypair(runtime.privateKeyPath);
-
     let git = new GitClient(runtime.vaultDir);
+
+    // Probe the remote BEFORE writing any key material. An unreachable or
+    // auth-blocked remote here must abort with no `key.txt` on disk so a
+    // retry against a different URL does not silently inherit an orphan key
+    // that was generated for a never-completed init.
+    let remoteState: Awaited<ReturnType<GitClient["inspectRemoteBranch"]>>;
+    try {
+      remoteState = await git.inspectRemoteBranch(args.remote, args.branch);
+    } catch (err) {
+      log.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 1;
+      return;
+    }
+
+    const { recipient, isNew: keyIsNew } = await ensureKeypair(runtime.privateKeyPath);
+
+    if (keyIsNew) {
+      log.warn(
+        `New age keypair generated.\n  Public key : ${recipient}\n  Private key: ${runtime.privateKeyPath}\n  ⚠  Back up your private key in a password manager now. It cannot be recovered.`,
+      );
+    } else {
+      log.info(`Loaded existing keypair — public key: ${recipient}`);
+    }
 
     try {
       const repoInitialized = await git.isInitialized();
-      const remoteState = await git.inspectRemoteBranch(args.remote, args.branch);
 
       if (!repoInitialized) {
         if (remoteState.exists) {
@@ -153,6 +173,14 @@ export const initCommand = defineCommand({
         );
       }
     } catch (err) {
+      // The remote probe above passed, so the failure here is in clone/init,
+      // reconcile, config write, commit, or push. If we generated the key on
+      // this invocation, delete it so a retry is not bound to material that
+      // never made it into a successful init. A pre-existing key (one a
+      // previous successful init committed to) is preserved untouched.
+      if (keyIsNew) {
+        await rm(runtime.privateKeyPath, { force: true });
+      }
       log.error(err instanceof Error ? err.message : String(err));
       process.exitCode = 1;
     }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,7 +5,7 @@ import { defineCommand } from "citty";
 import { loadConfig, resolveConfigPath, writeConfig } from "../config/loader";
 import { generateIdentity, identityToRecipient } from "../core/encryptor";
 import { GitClient } from "../core/git";
-import { loadPrivateKey, resolveRuntimeContext } from "./shared";
+import { isFileNotFoundError, loadPrivateKey, resolveRuntimeContext } from "./shared";
 
 const DEFAULT_AGENTS = {
   cursor: true,
@@ -37,7 +37,14 @@ async function ensureKeypair(
 
   try {
     identity = await loadPrivateKey(path);
-  } catch {
+  } catch (err) {
+    // Only auto-generate when key.txt is genuinely absent. Other read errors
+    // (EACCES on a locked-down key, a malformed file from a previous corrupt
+    // write, an unreadable mount) must surface as failures — silently
+    // overwriting them would destroy a key the user may still be able to
+    // recover and rebind every recipient to fresh material the user did not
+    // consent to.
+    if (!isFileNotFoundError(err)) throw err;
     identity = await generateIdentity();
     await writeFile(path, `${identity}\n`, { mode: 0o600 });
     isNew = true;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -98,14 +98,6 @@ export const initCommand = defineCommand({
       const { recipient, isNew } = await ensureKeypair(runtime.privateKeyPath);
       keyIsNew = isNew;
 
-      if (keyIsNew) {
-        log.warn(
-          `New age keypair generated.\n  Public key : ${recipient}\n  Private key: ${runtime.privateKeyPath}\n  ⚠  Back up your private key in a password manager now. It cannot be recovered.`,
-        );
-      } else {
-        log.info(`Loaded existing keypair — public key: ${recipient}`);
-      }
-
       const repoInitialized = await git.isInitialized();
 
       if (!repoInitialized) {
@@ -165,6 +157,19 @@ export const initCommand = defineCommand({
         log.info("Vault pushed to remote.");
       }
 
+      // Defer the keypair status log until every fallible step above has
+      // succeeded. Reporting "New age keypair generated, back it up now"
+      // earlier risks the user copying a key into a password manager seconds
+      // before the catch block rolls it back, leaving them with a backup
+      // that no longer matches anything on disk.
+      if (keyIsNew) {
+        log.warn(
+          `New age keypair generated.\n  Public key : ${recipient}\n  Private key: ${runtime.privateKeyPath}\n  ⚠  Back up your private key in a password manager now. It cannot be recovered.`,
+        );
+      } else {
+        log.info(`Loaded existing keypair — public key: ${recipient}`);
+      }
+
       log.success(`Initialized vault at ${runtime.vaultDir}`);
 
       if (joinedExistingVault) {
@@ -190,6 +195,7 @@ export const initCommand = defineCommand({
       if (keyIsNew) {
         try {
           await rm(runtime.privateKeyPath, { force: true });
+          log.info(`Rolled back freshly generated keypair at ${runtime.privateKeyPath}.`);
         } catch (rmErr) {
           // Surface rm failures (EBUSY/EACCES/EROFS) as a warning instead of
           // letting them propagate and mask the real init error below. The

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -28,15 +28,20 @@ const DEFAULT_SYNC = {
  * "loaded" log line until after init has actually committed to keeping the key
  * and (b) roll back a freshly written `key.txt` without touching a pre-existing
  * one if a later step fails.
+ *
+ * Contract on failure: if this function throws, the on-disk state of `path` is
+ * either unchanged (pre-existing key preserved, or no key ever written) or
+ * has been best-effort cleaned up. The caller's `isNew` rollback only fires
+ * after a successful return, so any failure mid-generate-and-write must be
+ * handled locally or the orphan key.txt is invisible to the outer recovery.
  */
 async function ensureKeypair(
   path: string,
 ): Promise<{ identity: string; recipient: string; isNew: boolean }> {
-  let identity: string;
-  let isNew = false;
-
   try {
-    identity = await loadPrivateKey(path);
+    const identity = await loadPrivateKey(path);
+    const recipient = await identityToRecipient(identity);
+    return { identity, recipient, isNew: false };
   } catch (err) {
     // Only auto-generate when key.txt is genuinely absent. Other read errors
     // (EACCES on a locked-down key, a malformed file from a previous corrupt
@@ -45,14 +50,26 @@ async function ensureKeypair(
     // recover and rebind every recipient to fresh material the user did not
     // consent to.
     if (!isFileNotFoundError(err)) throw err;
-    identity = await generateIdentity();
-    await writeFile(path, `${identity}\n`, { mode: 0o600 });
-    isNew = true;
   }
 
-  const recipient = await identityToRecipient(identity);
-
-  return { identity, recipient, isNew };
+  const identity = await generateIdentity();
+  try {
+    await writeFile(path, `${identity}\n`, { mode: 0o600 });
+    const recipient = await identityToRecipient(identity);
+    return { identity, recipient, isNew: true };
+  } catch (err) {
+    // writeFile may have written partial data before rejecting (per Node docs,
+    // the call performs multiple internal writes and is best-effort on abort),
+    // and identityToRecipient can throw on a freshly written key. Either way,
+    // the file we just created — full, partial, or empty — must not survive
+    // as an "existing key" that the next init silently loads. `force: true`
+    // swallows ENOENT for the case where writeFile failed before opening the
+    // file. A real rm failure (EBUSY/EACCES/EROFS) is swallowed too: the
+    // original write/recipient error is the actionable root cause, and the
+    // user will see it via the outer init catch.
+    await rm(path, { force: true }).catch(() => {});
+    throw err;
+  }
 }
 
 /** Bootstrap a vault, local key material, and the initial git remote wiring. */
@@ -97,11 +114,12 @@ export const initCommand = defineCommand({
     // `keyIsNew` is declared outside the try so the catch can tell whether
     // this invocation generated the key (and is allowed to delete it) or
     // inherited one from a previous successful init (which must be preserved).
+    // It is only set to true after `ensureKeypair` returns successfully —
+    // partial-write and post-write failures inside `ensureKeypair` clean up
+    // their own orphan file locally (see its contract above), since this
+    // catch cannot observe `isNew` for a call that threw.
     let keyIsNew = false;
     try {
-      // `ensureKeypair` is inside the guarded block so a mid-call failure
-      // (writeFile partial-write, identityToRecipient throw) still triggers
-      // the rollback below instead of leaving a half-written key on disk.
       const { recipient, isNew } = await ensureKeypair(runtime.privateKeyPath);
       keyIsNew = isNew;
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
 import { loadConfig, resolveConfigPath, writeConfig } from "../config/loader";
+import { resolveAgentSyncHome } from "../config/paths";
 import { generateIdentity, identityToRecipient } from "../core/encryptor";
 import { GitClient } from "../core/git";
 import { isFileNotFoundError, loadPrivateKey, resolveRuntimeContext } from "./shared";
@@ -64,10 +65,18 @@ async function ensureKeypair(
     // the file we just created — full, partial, or empty — must not survive
     // as an "existing key" that the next init silently loads. `force: true`
     // swallows ENOENT for the case where writeFile failed before opening the
-    // file. A real rm failure (EBUSY/EACCES/EROFS) is swallowed too: the
-    // original write/recipient error is the actionable root cause, and the
-    // user will see it via the outer init catch.
-    await rm(path, { force: true }).catch(() => {});
+    // file. A real rm failure (EBUSY/EACCES/EROFS) is surfaced as a warn:
+    // the original write/recipient error is still the root cause, but the
+    // user needs to know an orphan key.txt may remain on disk so a naive
+    // retry does not silently inherit it.
+    try {
+      await rm(path, { force: true });
+    } catch (rmErr) {
+      const rmMessage = rmErr instanceof Error ? rmErr.message : String(rmErr);
+      log.warn(
+        `Failed to remove newly generated key at ${path}: ${rmMessage}.\nRemove it manually before retrying.`,
+      );
+    }
     throw err;
   }
 }
@@ -94,22 +103,30 @@ export const initCommand = defineCommand({
     log.info("Initializing AgentSync");
 
     const runtime = await resolveRuntimeContext();
-    await mkdir(runtime.vaultDir, { recursive: true });
 
-    let git = new GitClient(runtime.vaultDir);
-
-    // Probe the remote BEFORE writing any key material. An unreachable or
-    // auth-blocked remote here must abort with no `key.txt` on disk so a
-    // retry against a different URL does not silently inherit an orphan key
-    // that was generated for a never-completed init.
+    // Probe the remote BEFORE writing any local artifacts (key.txt or even
+    // the vault directory itself). An unreachable or auth-blocked remote
+    // must abort with no on-disk state inside `runtime.vaultDir` so a retry
+    // against a different URL does not silently inherit an orphan key or
+    // an empty vault dir that was created for a never-completed init.
+    //
+    // The probe needs a cwd to run `git -C <cwd> ls-remote` against, but
+    // does not need a git repo. `resolveRuntimeContext` has already created
+    // the agentsync home (the parent of the default vault dir), which is
+    // always a valid cwd regardless of whether `AGENTSYNC_VAULT_DIR`
+    // overrides the vault location.
+    const probeClient = new GitClient(resolveAgentSyncHome());
     let remoteState: Awaited<ReturnType<GitClient["inspectRemoteBranch"]>>;
     try {
-      remoteState = await git.inspectRemoteBranch(args.remote, args.branch);
+      remoteState = await probeClient.inspectRemoteBranch(args.remote, args.branch);
     } catch (err) {
       log.error(err instanceof Error ? err.message : String(err));
       process.exitCode = 1;
       return;
     }
+
+    await mkdir(runtime.vaultDir, { recursive: true });
+    let git = new GitClient(runtime.vaultDir);
 
     // `keyIsNew` is declared outside the try so the catch can tell whether
     // this invocation generated the key (and is allowed to delete it) or

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -54,7 +54,7 @@ export async function loadVaultConfigOrExit(vaultDir: string): Promise<AgentSync
   }
 }
 
-function isFileNotFoundError(err: unknown): boolean {
+export function isFileNotFoundError(err: unknown): boolean {
   return (
     typeof err === "object" &&
     err !== null &&


### PR DESCRIPTION
## Summary

`agentsync init` wrote the new age private key to `key.txt` before any git
or network step, so an unreachable / auth-blocked remote left the user with
an orphan `key.txt` and no `agentsync.toml`. A retry then silently picked up
that orphan key as "Loaded existing keypair" and bound a new remote vault to
material from a never-completed init.

This PR

- probes the remote with `inspectRemoteBranch` **before** generating any
  keypair, so unreachable remotes abort cleanly with no key on disk;
- has `ensureKeypair` return `isNew` and defers the "generated" / "loaded"
  log line to the caller so it only fires once init has committed to
  keeping the key;
- wraps the post-probe init work in a try/catch that deletes a freshly
  generated `key.txt` (and only a freshly generated one) on failure, while
  preserving any pre-existing key byte-for-byte.

Closes #46

## Diagram

```mermaid
flowchart TD
    A[init start] --> B[mkdir vaultDir]
    B --> C[probe remote: inspectRemoteBranch]
    C -- network/auth fail --> X[log.error + exit 1<br/>NO key.txt written]
    C -- ok --> D[ensureKeypair returns identity, recipient, isNew]
    D --> E{isNew?}
    E -- yes --> F[log.warn New keypair generated]
    E -- no --> G[log.info Loaded existing keypair]
    F --> H[try: clone/init, reconcile, write config, commit, push]
    G --> H
    H -- success --> I[log.success Initialized vault]
    H -- failure --> J{isNew?}
    J -- yes --> K[fs.rm key.txt<br/>roll back fresh key]
    J -- no --> L[preserve existing key]
    K --> M[log.error + exit 1]
    L --> M
```

## Changes

- `src/commands/init.ts`: reorder init to probe the remote before key
  generation; refactor `ensureKeypair` to return `isNew` and move the
  user-facing log lines to the caller; wrap the post-probe work in a
  try/catch that cleans up a freshly written `key.txt` on failure.
- `src/commands/__tests__/integration.test.ts`: three new tests covering
  (a) unreachable remote leaves no key.txt and no vault artifacts,
  (b) failure preserves a pre-existing keypair byte-for-byte,
  (c) post-probe divergence cleans up the freshly generated key.txt.

## Files changed (path · one-line rationale)

- `src/commands/init.ts` · move remote probe before keypair generation,
  add `isNew` plumbing, and roll back freshly written `key.txt` on
  post-probe failure.
- `src/commands/__tests__/integration.test.ts` · cover the early-abort,
  preserve-existing-key, and post-probe-cleanup paths.

## Commits (sha · subject)

- `13679e7` · fix(init): probe remote before writing keypair; roll back orphan key on later failures

## Tests run (command · result)

- `bun test src/commands/__tests__/integration.test.ts` · **25 pass / 0 fail**
  (the 3 new tests pass; all existing init / push / pull / key tests still
  pass).
- `bun run typecheck` (`tsc --noEmit`) · **exit 0**, no errors.
- `bun run lint` (`biome ci .`) · **exit 0**; only the pre-existing 8 CSS
  warnings in `docs/stylesheets/extra.css` and the biome.json schema-version
  info (same on `main`, unrelated to this change).
- `bun run check` test step fails with the same pre-existing 20 failures /
  16 module-mock errors that occur on `main`
  (`SyntaxError: Export named 'unlink' / 'stat' not found in module
  'node:fs/promises'`). Confirmed identical `239 pass / 20 fail / 16 errors`
  baseline by re-running on `main` via `git stash`. These failures are not
  introduced by this PR.

## Verification

Manual repro of the issue scenarios on this branch:

1. Unreachable remote, no pre-existing key:

   ```
   rm -rf /tmp/repro46 && mkdir -p /tmp/repro46 && \
     AGENTSYNC_HOME=/tmp/repro46 AGENTSYNC_VAULT_DIR=/tmp/repro46/vault \
     AGENTSYNC_KEY_PATH=/tmp/repro46/key.txt \
     bun run src/cli.ts init --remote /tmp/nonexistent/repo.git
   ```

   Result: exit 1; error names the unreachable remote;
   `/tmp/repro46/key.txt` does NOT exist; `/tmp/repro46/vault` is empty
   (no `agentsync.toml`). Confirmed via `ls -la`.

2. Unreachable remote, pre-existing key:

   ```
   echo "AGE-SECRET-KEY-1FAKE..." > /tmp/repro46b/key.txt && chmod 600 …
   AGENTSYNC_HOME=/tmp/repro46b AGENTSYNC_KEY_PATH=/tmp/repro46b/key.txt \
     bun run src/cli.ts init --remote /tmp/nonexistent/repo.git
   ```

   Result: exit 1; `sha256sum /tmp/repro46b/key.txt` is byte-identical
   before and after (`336053ed…`). Pre-existing key preserved.

3. Post-probe failure (covered by the new divergence-rollback test):
   reachable remote but local history already diverged. Init fails with
   `AgentSync only supports fast-forward sync`, exit 1, and the freshly
   generated `key.txt` is removed.

4. All acceptance criteria from the issue are met:
   - [x] `init` against an unreachable remote leaves no `key.txt` and no
         `vault/` artifacts on disk.
   - [x] `init` against a reachable but auth-blocked remote behaves the
         same (same code path: the probe throws on either non-zero
         `ls-remote` exit).
   - [x] Existing keypair (from a previous successful init) is never
         deleted on failure.
   - [x] Test coverage for both new-key and existing-key failure paths,
         plus the post-probe failure path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Init now probes the remote first and aborts before writing key material if the remote is unreachable.
  * Existing private keys are preserved unchanged when the remote is unreachable or the key path is unreadable.
  * If init generates a new key but a later step fails, the newly created key is cleaned up automatically.

* **Tests**
  * Added five end-to-end integration tests covering unreachable remotes, unreadable key paths, preservation of existing keys, and cleanup after failures.

* **Chores**
  * Made a file-not-found helper available for broader use.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/62)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->