### PR TITLE
refactor(init): remove dead readFile after writeConfig

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
@@ -191,7 +191,6 @@ export const initCommand = defineCommand({
 
       const gitignorePath = join(runtime.vaultDir, ".gitignore");
       await writeFile(gitignorePath, "*.tmp\n", "utf8");
-      await readFile(configPath, "utf8");
 
       const committed = await git.commit({ message: `init: ${runtime.machineName}` });
       if (committed) {


### PR DESCRIPTION
## Summary

Removes a dead `await readFile(configPath, "utf8")` in `src/commands/init.ts` whose return value was discarded — a leftover from a verify-after-write that was never wired up. `writeConfig` already round-trips through TOML and `loadConfig` validates via Zod, so file existence/validity is implied by `writeConfig` resolving without error; no replacement check is needed. Also drops the now-unused `readFile` import.

Closes #48

## Changes

- Remove the dead `await readFile(configPath, "utf8")` call that sat between the `.gitignore` write and `git.commit` in the init flow.
- Trim `readFile` from the `node:fs/promises` import; nothing else in `init.ts` references it.

## Files changed

- `src/commands/init.ts` · remove discarded `await readFile(configPath, "utf8")` and drop the now-unused `readFile` import.

## Commits

- `c502093` · refactor(init): remove dead readFile after writeConfig

## Tests run

- `bun run typecheck` · pass (no errors).
- `bun run lint` · pass (8 pre-existing CSS warnings + 1 info on unrelated files; no errors).
- `bun test src/commands/__tests__/integration.test.ts` · pass (27 pass, 0 fail) — covers fresh init, join-existing-vault, and error-rollback paths through `initMod.initCommand.run`.
- `bun test` (full) · 239 pass / 20 fail / 16 errors — same totals on `main` at `c5642a6` (pre-existing test infra failures in `daemon.test.ts`, `doctor.test.ts`, `status.test.ts` related to `node:fs/promises` mocking, unrelated to this change).

## Verification

1. `git diff main -- src/commands/init.ts` shows exactly two lines removed: the discarded `readFile` call and the `readFile` symbol in the import. No other behaviour changed.
2. The `writeConfig` → `.gitignore` write → `git.commit` sequence is intact, with `await writeFile(gitignorePath, "*.tmp\n", "utf8")` now flowing directly into `await git.commit(...)`.
3. Init integration tests (`src/commands/__tests__/integration.test.ts`) continue to pass — the fresh-init, join-existing-vault, and rollback paths all observe the same on-disk state as before.

<!-- Pure refactor: no new code paths, no new state, no external calls, no flow change. Mermaid diagram omitted per template guidance for refactor-only PRs. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized the initialization process by removing a redundant file operation, improving overall performance during setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->