### PR TITLE
fix(walker): scan skill/agent bundle bodies for literal secrets

### DIFF
--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -144,6 +144,43 @@ describe("snapshotCopilot", () => {
     expect(() => Buffer.from(art!.plaintext, "base64")).not.toThrow();
   });
 
+  // Per-file secret scan on the agents walk. The central scan in
+  // `commands/push.ts` skips `.tar.age` artifacts, so a key pasted into an
+  // agent's markdown body would slip through unless the walk-side scan
+  // catches it. The Copilot agents walk does NOT delegate to the shared
+  // skills walker, so this coverage is independent of the skill tests above.
+
+  test("agent dir with a literal Anthropic key in markdown body is rejected", async () => {
+    const agentDir = join(testCopilotPaths.agentsDir, "leaky-agent");
+    mkdirSync(agentDir, { recursive: true });
+    const fakeKey = `sk-ant-api03-${"C".repeat(48)}`;
+    const leak = join(agentDir, "agent.md");
+    writeFileSync(leak, `# leaky\n\ntoken: ${fakeKey}\n`, "utf8");
+
+    const result = await copilotModule.snapshotCopilot();
+    const art = result.artifacts.find((a) => a.vaultPath === "copilot/agents/leaky-agent.tar.age");
+    expect(art).toBeUndefined();
+
+    const offending = result.warnings.find((w) => w.startsWith("Detected literal secret"));
+    expect(offending).toBeDefined();
+    expect(offending).toContain("anthropic-api-key");
+    expect(offending).toContain(leak);
+  });
+
+  test("clean agent dir still produces a single .tar.age artifact", async () => {
+    const agentDir = join(testCopilotPaths.agentsDir, "clean-agent");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, "agent.md"), "# clean prose, no keys here\n", "utf8");
+    writeFileSync(join(agentDir, "notes.md"), "# also clean\n", "utf8");
+
+    const result = await copilotModule.snapshotCopilot();
+    const arts = result.artifacts.filter(
+      (a) => a.vaultPath === "copilot/agents/clean-agent.tar.age",
+    );
+    expect(arts).toHaveLength(1);
+    expect(result.warnings.filter((w) => w.startsWith("Detected literal secret"))).toHaveLength(0);
+  });
+
   // walker retrofit regression: snapshotCopilot must inherit the
   // symlink-rejection and dot-skip rules from the shared walker.
 

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -167,6 +167,32 @@ describe("snapshotCopilot", () => {
     expect(offending).toContain(leak);
   });
 
+  // Never-sync path hit inside an agent dir. The agents walk consumes the
+  // same collectInteriorViolations helper as the skills walker, so a file
+  // matching NEVER_SYNC_PATTERNS (auth.json, .credentials.json, history.jsonl,
+  // sessions/**, *.local.md, …) anywhere inside the agent must drop the
+  // artifact and emit the `never-sync inside skill: …` warning that
+  // performPush escalates to a fatal abort. Without this gate the agent
+  // would be archived with `archiveDirectory(agentDir)` and the credential
+  // would ship to the vault.
+  test("agent dir containing a never-sync file (auth.json) is rejected", async () => {
+    const agentDir = join(testCopilotPaths.agentsDir, "leaky-auth-agent");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, "agent.md"), "# agent\n", "utf8");
+    const authFile = join(agentDir, "auth.json");
+    writeFileSync(authFile, '{"token":"secret"}', "utf8");
+
+    const result = await copilotModule.snapshotCopilot();
+    const art = result.artifacts.find(
+      (a) => a.vaultPath === "copilot/agents/leaky-auth-agent.tar.age",
+    );
+    expect(art).toBeUndefined();
+
+    const neverSync = result.warnings.find((w) => w.startsWith("never-sync inside skill: "));
+    expect(neverSync).toBeDefined();
+    expect(neverSync).toContain(authFile);
+  });
+
   test("clean agent dir still produces a single .tar.age artifact", async () => {
     const agentDir = join(testCopilotPaths.agentsDir, "clean-agent");
     mkdirSync(agentDir, { recursive: true });

--- a/src/agents/__tests__/skills-walker.test.ts
+++ b/src/agents/__tests__/skills-walker.test.ts
@@ -199,6 +199,81 @@ describe("collectSkillArtifacts", () => {
     expect(result.warnings[0]?.startsWith("never-sync inside skill: ")).toBe(true);
   });
 
+  // Literal-secret coverage at the walker layer. The central scan in
+  // `commands/push.ts` skips `.tar.age` artifacts because base64 scrambles
+  // credential prefixes and statistically overlaps `AKIA…`/`AIza…` shapes —
+  // so a key pasted into `SKILL.md` would otherwise be encrypted and shipped.
+  // The walker now scans each readable interior file body before tarring.
+
+  test("rejects a skill whose SKILL.md contains a literal Claude API key", async () => {
+    const skillDir = join(tmpDir, "leaky-skill");
+    await mkdir(skillDir, { recursive: true });
+    const fakeKey = `sk-ant-api03-${"A".repeat(48)}`;
+    await writeFile(join(skillDir, "SKILL.md"), `# leaky\n\ntoken: ${fakeKey}\n`, "utf8");
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    const warn = result.warnings[0] ?? "";
+    expect(warn.startsWith("Detected literal secret")).toBe(true);
+    expect(warn).toContain("anthropic-api-key");
+    expect(warn).toContain(join(skillDir, "SKILL.md"));
+  });
+
+  test("rejects a skill with a nested markdown file containing an AWS key", async () => {
+    const skillDir = join(tmpDir, "nested-leak");
+    await mkdir(join(skillDir, "notes"), { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# clean sentinel", "utf8");
+    // Embedded AWS access-key-id prefix (16-char alphanumeric body).
+    const leak = join(skillDir, "notes", "leak.md");
+    await writeFile(leak, "deploy with AKIAIOSFODNN7EXAMPLE\n", "utf8");
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    const warn = result.warnings[0] ?? "";
+    expect(warn.startsWith("Detected literal secret")).toBe(true);
+    expect(warn).toContain("aws-access-key");
+    expect(warn).toContain(leak);
+  });
+
+  test("does NOT false-positive on a clean skill with AKIA-shaped prose", async () => {
+    const skillDir = join(tmpDir, "clean-prose");
+    await mkdir(skillDir, { recursive: true });
+    // `sha256:` digest is a long base64-ish run that the original
+    // anchored-only redactor would have flagged. Here we are exercising
+    // the unanchored EMBEDDED_SECRET_PATTERNS — none of which match a
+    // plain `AKIA` substring without the 16-char alphanumeric body.
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "# clean\n\nrelated word: AKIA-history-of-aviation\n\nsha256:abcdef0123456789abcdef0123456789abcdef0123456789\n",
+      "utf8",
+    );
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0]?.vaultPath).toBe("claude/skills/clean-prose.tar.age");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("collects clean skills even when another skill has a literal-secret hit", async () => {
+    const clean = join(tmpDir, "clean-skill");
+    await mkdir(clean, { recursive: true });
+    await writeFile(join(clean, "SKILL.md"), "# clean", "utf8");
+
+    const dirty = join(tmpDir, "dirty-skill");
+    await mkdir(dirty, { recursive: true });
+    const fakeKey = `sk-ant-api03-${"B".repeat(48)}`;
+    await writeFile(join(dirty, "SKILL.md"), `# dirty\n\ntoken: ${fakeKey}\n`, "utf8");
+
+    const result = await collectSkillArtifacts("claude", tmpDir);
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0]?.vaultPath).toBe("claude/skills/clean-skill.tar.age");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.startsWith("Detected literal secret")).toBe(true);
+    expect(result.warnings[0]).toContain(join(dirty, "SKILL.md"));
+  });
+
   // Row 13 — the skills root path itself is a symlink. Resolves the spec
   // ambiguity toward the conservative "skills I created" intent: if the
   // entire root is a symlink (e.g., a power user has done

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -83,13 +83,16 @@ export async function snapshotCopilot(): Promise<SnapshotResult> {
   warnings.push(...copilotSkills.warnings);
 
   // Agents directories (tar each one, similar to skills). Each agent's
-  // interior is scanned for literal credentials before the bytes head for
-  // encryption: the central scan in `commands/push.ts` skips `.tar.age`
-  // artifacts (base64 scrambles credential prefixes), so a per-file scan
-  // here is the only layer that can catch a key pasted into an agent's
-  // markdown body. Mirrors the shared walker's gate 4 contract: collect
-  // every offender, emit `Detected literal secret …` warnings (which
-  // performPush escalates to a fatal abort), and skip the artifact.
+  // interior is scanned for both never-sync path hits and literal
+  // credentials before the bytes head for encryption: the central scan
+  // in `commands/push.ts` skips `.tar.age` artifacts (base64 scrambles
+  // credential prefixes), so this per-file walk is the only layer that
+  // can catch a key pasted into an agent's markdown body or a never-sync
+  // file (auth.json, history.jsonl, sessions/**, …) nested under the
+  // agent dir. Mirrors the shared walker's gate 4 contract symmetrically:
+  // collect every offender, emit `never-sync inside skill: …` for path
+  // hits and `Detected literal secret …` for body hits — both prefixes
+  // are escalated to a fatal abort by performPush — and skip the artifact.
   try {
     const names = await readdir(AgentPaths.copilot.agentsDir);
     for (const name of names) {
@@ -98,7 +101,10 @@ export async function snapshotCopilot(): Promise<SnapshotResult> {
       if (!agentDirStat?.isDirectory()) continue;
 
       const violations = await collectInteriorViolations(agentDir);
-      if (violations.secretWarnings.length > 0) {
+      if (violations.neverSyncHits.length > 0 || violations.secretWarnings.length > 0) {
+        for (const hit of violations.neverSyncHits) {
+          warnings.push(`never-sync inside skill: ${hit}`);
+        }
         warnings.push(...violations.secretWarnings);
         continue;
       }

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -5,7 +5,12 @@ import { AgentPaths } from "../config/paths";
 import { shouldNeverSync } from "../core/sanitizer";
 import { archiveDirectory, extractArchive } from "../core/tar";
 import { atomicWrite, readIfExists, type SnapshotArtifact, type SnapshotResult } from "./_utils";
-import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "./skills-walker";
+import {
+  collectInteriorViolations,
+  collectSkillArtifacts,
+  InvalidSkillNameError,
+  validateSkillName,
+} from "./skills-walker";
 
 /** Snapshot payload for the Copilot adapter. */
 export type CopilotSnapshotResult = SnapshotResult;
@@ -77,13 +82,27 @@ export async function snapshotCopilot(): Promise<SnapshotResult> {
   artifacts.push(...copilotSkills.artifacts);
   warnings.push(...copilotSkills.warnings);
 
-  // Agents directories (tar each one, similar to skills)
+  // Agents directories (tar each one, similar to skills). Each agent's
+  // interior is scanned for literal credentials before the bytes head for
+  // encryption: the central scan in `commands/push.ts` skips `.tar.age`
+  // artifacts (base64 scrambles credential prefixes), so a per-file scan
+  // here is the only layer that can catch a key pasted into an agent's
+  // markdown body. Mirrors the shared walker's gate 4 contract: collect
+  // every offender, emit `Detected literal secret …` warnings (which
+  // performPush escalates to a fatal abort), and skip the artifact.
   try {
     const names = await readdir(AgentPaths.copilot.agentsDir);
     for (const name of names) {
       const agentDir = join(AgentPaths.copilot.agentsDir, name);
       const agentDirStat = await stat(agentDir).catch(() => null);
       if (!agentDirStat?.isDirectory()) continue;
+
+      const violations = await collectInteriorViolations(agentDir);
+      if (violations.secretWarnings.length > 0) {
+        warnings.push(...violations.secretWarnings);
+        continue;
+      }
+
       const tarBuffer = await archiveDirectory(agentDir);
       artifacts.push({
         vaultPath: `copilot/agents/${name}.tar.age`,

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -9,6 +9,7 @@ import {
   collectInteriorViolations,
   collectSkillArtifacts,
   InvalidSkillNameError,
+  NEVER_SYNC_WARNING_PREFIX,
   validateSkillName,
 } from "./skills-walker";
 
@@ -103,7 +104,10 @@ export async function snapshotCopilot(): Promise<SnapshotResult> {
       const violations = await collectInteriorViolations(agentDir);
       if (violations.neverSyncHits.length > 0 || violations.secretWarnings.length > 0) {
         for (const hit of violations.neverSyncHits) {
-          warnings.push(`never-sync inside skill: ${hit}`);
+          // Re-use the skills-walker prefix so the push gate's existing
+          // escalation rule covers agent-dir hits too — keeping the contract
+          // string in one exported constant prevents silent drift.
+          warnings.push(`${NEVER_SYNC_WARNING_PREFIX}${hit}`);
         }
         warnings.push(...violations.secretWarnings);
         continue;

--- a/src/agents/skills-walker.ts
+++ b/src/agents/skills-walker.ts
@@ -262,17 +262,27 @@ export async function collectSkillArtifacts(
  * One pass means each interior file is `lstat`-ed and read at most once,
  * and both gates share the same symlink-skipping rules.
  *
- * Symlinks (files OR sub-directories) are NOT followed and NOT inspected,
- * which is consistent with the archive step: vendored content reached via a
- * symlink is out of scope for this feature and will not be archived in gate
- * 5 either.
+ * Symlinks (files OR sub-directories) are NOT followed and NOT inspected.
+ * This matches the skills-walker caller, which then calls
+ * `archiveDirectory(skillDir, { skipSymlinks: true })`. The Copilot agents
+ * caller in `src/agents/copilot.ts` currently passes `archiveDirectory` its
+ * default (`skipSymlinks: false`) for backwards-compatibility with existing
+ * agent tarballs, so an interior symlink there is skipped by the body-scan
+ * but its target-path string is still archived. node-tar archives symlinks
+ * as `SymbolicLink` entries (target path only, not target content), so this
+ * does not exfiltrate credential bodies through a vendored helper — but
+ * callers that need full symmetry should pass `{ skipSymlinks: true }`.
  *
- * File-body reads use UTF-8. Read failures (binary files, permission errors,
- * transient I/O) silently skip the body scan for that file — the path-only
- * never-sync check still runs against the path. Binary files cannot be
- * scanned reliably with the embedded-secret regexes anyway; the goal is to
- * catch credentials pasted into text files like `SKILL.md`, READMEs, and
- * any other authored markdown or config.
+ * File-body reads use UTF-8. Permission errors and transient I/O silently
+ * skip the body scan for that file — the path-only never-sync check still
+ * runs against the path. Binary content does NOT throw under UTF-8: Node
+ * substitutes U+FFFD for invalid sequences and returns a string, so the
+ * regex still executes against the decoded bytes. This is intentional —
+ * `EMBEDDED_SECRET_PATTERNS` are anchored on real credential prefixes
+ * (`sk-ant-api03-`, `AKIA…`, `AIza…`, …) with realistic length floors, so
+ * random binary bytes virtually never match while a credential pasted into
+ * a binary blob is still caught. Do NOT add a binary-detection early-return
+ * here without a measured false-positive case; it would only weaken coverage.
  */
 export interface InteriorViolations {
   neverSyncHits: string[];
@@ -301,8 +311,12 @@ export async function collectInteriorViolations(rootDir: string): Promise<Interi
       }
 
       if (childStat.isSymbolicLink()) {
-        // Skip vendored content. The archive step filters interior symlinks
-        // out anyway, so inspecting them here would only produce noise.
+        // Skip vendored content. The skills-walker caller filters interior
+        // symlinks out of the tar archive via `skipSymlinks: true`; the
+        // Copilot agents caller currently does not, so a symlink there is
+        // archived as a `SymbolicLink` entry (path string only, not target
+        // content). See the symmetry note in `collectInteriorViolations`'s
+        // contract docstring above.
         continue;
       }
 

--- a/src/agents/skills-walker.ts
+++ b/src/agents/skills-walker.ts
@@ -45,8 +45,23 @@ export type SkillBearingAgent = "claude" | "cursor" | "codex" | "copilot";
  */
 export type SkillsWalkerResult = SnapshotResult;
 
-/** Warning prefix emitted when a never-sync rule matches inside a skill. */
-const NEVER_SYNC_WARNING_PREFIX = "never-sync inside skill: ";
+/**
+ * Warning prefix emitted when a never-sync rule matches inside a skill or
+ * agent bundle. Exported so every emitter (this file, `copilot.ts`) and the
+ * push gate (`commands/push.ts`) match the same literal — drift on this
+ * string would silently downgrade fatal aborts to soft warnings.
+ */
+export const NEVER_SYNC_WARNING_PREFIX = "never-sync inside skill: ";
+
+/**
+ * Warning prefix emitted by `scanForSecrets` when a literal credential is
+ * found inside a readable bundle interior file body. Note the trailing `(` —
+ * it disambiguates walker hits (`Detected literal secret (<name>) in …`)
+ * from redactor hits (`Detected literal secret for field <name>`), so the
+ * push gate can escalate the walker arm without re-catching the redactor
+ * warnings that the per-artifact loop already handles.
+ */
+export const WALKER_SECRET_WARNING_PREFIX = "Detected literal secret (";
 
 /** Warning prefix emitted when `archiveDirectory` fails on an otherwise-valid skill. */
 const ARCHIVE_FAILURE_WARNING_PREFIX = "skill archive failed: ";

--- a/src/agents/skills-walker.ts
+++ b/src/agents/skills-walker.ts
@@ -10,7 +10,14 @@
  *      silently so only authored skills sync.
  *   4. Interior paths matching `NEVER_SYNC_PATTERNS` emit a
  *      `never-sync inside skill: ` warning that the push pipeline escalates
- *      to a fatal abort, so secrets nested inside a skill cannot leak.
+ *      to a fatal abort, so secrets nested inside a skill cannot leak. The
+ *      same interior walk also runs `scanForSecrets` over each readable
+ *      file body and emits `Detected literal secret` warnings. The central
+ *      Phase-1 scan in `commands/push.ts` skips `.tar.age` artifacts (base64
+ *      scrambles credential prefixes and false-positives on the encoded
+ *      alphabet), so a per-file scan inside the bundle is the only layer
+ *      that can catch a literal credential pasted into `SKILL.md` or any
+ *      other interior file.
  *   5. Interior symlinks are filtered from the tar archive so vendored
  *      files cannot smuggle in through a symlinked child.
  *
@@ -18,9 +25,9 @@
  * travel back as warnings on the result so the caller decides how to surface.
  */
 
-import { lstat, readdir } from "node:fs/promises";
+import { lstat, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { shouldNeverSync } from "../core/sanitizer";
+import { scanForSecrets, shouldNeverSync } from "../core/sanitizer";
 import { archiveDirectory } from "../core/tar";
 import type { SnapshotArtifact, SnapshotResult } from "./_utils";
 
@@ -190,14 +197,20 @@ export async function collectSkillArtifacts(
     }
     if (!sentinelStat.isFile()) continue;
 
-    // Gate 4: never-sync interior walk. The walker collects every
-    // matching path in the skill — not just the first — so the user sees
-    // every offender in one push instead of fixing them one at a time.
-    const neverSyncHits = await collectNeverSyncHits(entryPath);
-    if (neverSyncHits.length > 0) {
-      for (const hit of neverSyncHits) {
+    // Gate 4: interior violation walk. A single pass collects both
+    // never-sync hits (path-pattern only) and literal secret hits
+    // (file-body scan). The walker collects every match in the skill —
+    // not just the first — so the user sees every offender in one push
+    // instead of fixing them one at a time. Literal-secret coverage at
+    // this layer closes the bundle-internals gap: the central scan in
+    // `commands/push.ts` skips `.tar.age` artifacts because base64 of a
+    // tar buffer is both scramble-prone and false-positive prone.
+    const violations = await collectInteriorViolations(entryPath);
+    if (violations.neverSyncHits.length > 0 || violations.secretWarnings.length > 0) {
+      for (const hit of violations.neverSyncHits) {
         warnings.push(`${NEVER_SYNC_WARNING_PREFIX}${hit}`);
       }
+      warnings.push(...violations.secretWarnings);
       // Skip the artifact entirely so encryption never sees the bad bytes,
       // even in the unlikely event that the push gate is later removed.
       continue;
@@ -234,15 +247,41 @@ export async function collectSkillArtifacts(
 }
 
 /**
- * Walk a real skill directory and return the absolute paths of every interior
- * file whose path matches a {@link shouldNeverSync} rule.
+ * Walk a real skill directory and surface every interior gate violation in
+ * one pass. Returned shape:
+ *
+ *   - `neverSyncHits`  — absolute paths of files whose path matches a
+ *                        {@link shouldNeverSync} rule (gate 4a, path-only).
+ *   - `secretWarnings` — `Detected literal secret …` warnings emitted by
+ *                        {@link scanForSecrets} over each readable file
+ *                        body (gate 4b, body-scan). The full warning
+ *                        string from `scanForSecrets` is preserved so the
+ *                        push pipeline's existing `Detected literal secret`
+ *                        prefix check fires unchanged.
+ *
+ * One pass means each interior file is `lstat`-ed and read at most once,
+ * and both gates share the same symlink-skipping rules.
  *
  * Symlinks (files OR sub-directories) are NOT followed and NOT inspected,
- * which is consistent with the archive step: vendored content reached via a symlink is
- * out of scope for this feature and will not be archived in gate 5 either.
+ * which is consistent with the archive step: vendored content reached via a
+ * symlink is out of scope for this feature and will not be archived in gate
+ * 5 either.
+ *
+ * File-body reads use UTF-8. Read failures (binary files, permission errors,
+ * transient I/O) silently skip the body scan for that file — the path-only
+ * never-sync check still runs against the path. Binary files cannot be
+ * scanned reliably with the embedded-secret regexes anyway; the goal is to
+ * catch credentials pasted into text files like `SKILL.md`, READMEs, and
+ * any other authored markdown or config.
  */
-async function collectNeverSyncHits(rootDir: string): Promise<string[]> {
-  const hits: string[] = [];
+export interface InteriorViolations {
+  neverSyncHits: string[];
+  secretWarnings: string[];
+}
+
+export async function collectInteriorViolations(rootDir: string): Promise<InteriorViolations> {
+  const neverSyncHits: string[] = [];
+  const secretWarnings: string[] = [];
 
   async function walk(dir: string): Promise<void> {
     let names: string[];
@@ -269,12 +308,29 @@ async function collectNeverSyncHits(rootDir: string): Promise<string[]> {
 
       if (childStat.isDirectory()) {
         await walk(childPath);
-      } else if (childStat.isFile() && shouldNeverSync(childPath)) {
-        hits.push(childPath);
+        continue;
       }
+      if (!childStat.isFile()) continue;
+
+      if (shouldNeverSync(childPath)) {
+        neverSyncHits.push(childPath);
+        // Do not also body-scan a never-sync file: it is rejected by path,
+        // and reading it would leak its contents into memory for no benefit.
+        continue;
+      }
+
+      let body: string;
+      try {
+        body = await readFile(childPath, "utf8");
+      } catch {
+        // Binary content, EACCES, or transient I/O — the path-only gate
+        // above is already best-effort for non-readable files. Skip silently.
+        continue;
+      }
+      secretWarnings.push(...scanForSecrets(body, childPath));
     }
   }
 
   await walk(rootDir);
-  return hits;
+  return { neverSyncHits, secretWarnings };
 }

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -713,7 +713,9 @@ describe("integration", () => {
       const literalSecretEntries = result.errors.filter((e) => e.includes(duplicatedWarning));
       expect(literalSecretEntries.length).toBe(1);
       // The banner's count must match the distinct-issue count, not 2× it.
-      expect(result.errors[0]).toMatch(/1 security issue/);
+      // Exact substring (not a loose regex): `/1 security issue/` would also
+      // pass for `11`, `21`, … if a future regression bumped the count.
+      expect(result.errors[0]).toContain("1 security issue(s)");
     } finally {
       pushMod.__setPushAgentsForTesting([
         {

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -675,6 +675,58 @@ describe("integration", () => {
     expect(result.errors.some((message) => message.includes("Detected literal secret"))).toBe(true);
   });
 
+  test("performPush does NOT double-report when a redactor warning lands on both artifact.warnings and snapshot.warnings", async () => {
+    // Real adapters (sanitizeClaudeHooks / sanitizeClaudeMcp / plugin manifest)
+    // push the `Detected literal secret for field X` warning onto BOTH the
+    // artifact (via collect()) AND the top-level snapshot.warnings (see
+    // src/agents/claude.ts:54). The Phase-1 artifact loop and the walker-
+    // warning loop must not both fire on the same warning, or one secret would
+    // produce two entries in the abort banner. Walker hits use the
+    // `Detected literal secret (<name>) in …` shape; redactor hits use
+    // `Detected literal secret for field <name>` — the snapshot-level prefix
+    // matches the walker shape only.
+    const duplicatedWarning = "Detected literal secret for field apiKey";
+    const dualSnapshotAgent = [
+      {
+        name: "claude" as const,
+        snapshot: async () => ({
+          artifacts: [
+            {
+              vaultPath: "claude/settings.age",
+              sourcePath: "/fake/.claude/settings.json",
+              plaintext: '{"apiKey":"[REDACTED]"}',
+              warnings: [duplicatedWarning],
+            },
+          ],
+          warnings: [duplicatedWarning],
+        }),
+        apply: async () => {},
+      },
+    ];
+
+    pushMod.__setPushAgentsForTesting(dualSnapshotAgent);
+    try {
+      const result = await pushMod.performPush({ agent: "claude" });
+
+      expect(result.fatal).toBe(true);
+      expect(result.pushed).toBe(0);
+      const literalSecretEntries = result.errors.filter((e) => e.includes(duplicatedWarning));
+      expect(literalSecretEntries.length).toBe(1);
+      // The banner's count must match the distinct-issue count, not 2× it.
+      expect(result.errors[0]).toMatch(/1 security issue/);
+    } finally {
+      pushMod.__setPushAgentsForTesting([
+        {
+          name: "claude" as const,
+          snapshot: async () => ({ artifacts: [...fakeArtifacts], warnings: [] }),
+          apply: async (vaultDir: string) => {
+            fakeApplyCalls.push(vaultDir);
+          },
+        },
+      ]);
+    }
+  });
+
   test("status command runs without throwing", async () => {
     const statusMod = await import("../../commands/status");
     await statusMod.statusCommand.run?.({

--- a/src/commands/__tests__/push.test.ts
+++ b/src/commands/__tests__/push.test.ts
@@ -378,3 +378,99 @@ describe("performPush — literal secret embedded in markdown body", () => {
     );
   });
 });
+
+describe("performPush — literal secret embedded inside a skill bundle body", () => {
+  // The Phase-1 central scan in performPush deliberately skips `.tar.age`
+  // artifacts (base64 of a tar buffer scrambles credential prefixes and
+  // overlaps `AKIA…`/`AIza…` shapes). Without per-file scanning at the
+  // walker layer, a literal key pasted into SKILL.md would be encrypted
+  // and shipped. This test proves the walker warning flows through the
+  // existing Phase-1 abort wiring end-to-end.
+
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  const savedEnv: Record<string, string | undefined> = {};
+  const savedCopilot = {
+    skillsDir: mutableCopilotPaths.skillsDir,
+    instructionsFile: mutableCopilotPaths.instructionsFile,
+    instructionsDir: mutableCopilotPaths.instructionsDir,
+    promptsDir: mutableCopilotPaths.promptsDir,
+    agentsDir: mutableCopilotPaths.agentsDir,
+    vscodeMcpInSettings: mutableCopilotPaths.vscodeMcpInSettings,
+  };
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    const bareRepoPath = await createBareRepo(tmpDir);
+    machine = await createMachineFixture(tmpDir, "bundle-secret-machine");
+
+    const copilotHome = join(tmpDir, "copilot-home-bundle-secret");
+    mutableCopilotPaths.skillsDir = join(copilotHome, "skills");
+    mutableCopilotPaths.instructionsFile = join(copilotHome, "instructions");
+    mutableCopilotPaths.instructionsDir = join(copilotHome, "instructions");
+    mutableCopilotPaths.promptsDir = join(copilotHome, "prompts");
+    mutableCopilotPaths.agentsDir = join(copilotHome, "agents");
+    mutableCopilotPaths.vscodeMcpInSettings = join(tmpDir, "vscode-settings.json");
+
+    for (const key of RUNTIME_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+    process.env.AGENTSYNC_MACHINE = machine.machineName;
+
+    seedVaultRepo({
+      machine,
+      bareRepoPath,
+      agents: { copilot: true, claude: false },
+    });
+
+    fakeLogs.success.length = 0;
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mutableCopilotPaths.skillsDir = savedCopilot.skillsDir;
+    mutableCopilotPaths.instructionsFile = savedCopilot.instructionsFile;
+    mutableCopilotPaths.instructionsDir = savedCopilot.instructionsDir;
+    mutableCopilotPaths.promptsDir = savedCopilot.promptsDir;
+    mutableCopilotPaths.agentsDir = savedCopilot.agentsDir;
+    mutableCopilotPaths.vscodeMcpInSettings = savedCopilot.vscodeMcpInSettings;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("aborts when a Copilot skill SKILL.md body contains a literal Claude API key", async () => {
+    const skillDir = join(mutableCopilotPaths.skillsDir, "leaky-bundle");
+    mkdirSync(skillDir, { recursive: true });
+    const fakeKey = `sk-ant-api03-${"D".repeat(48)}`;
+    const skillMd = join(skillDir, "SKILL.md");
+    writeFileSync(skillMd, `# leaky\n\ntoken: ${fakeKey}\n`, "utf8");
+
+    const result = await pushMod.performPush({ agent: "copilot" });
+
+    expect(result.fatal).toBe(true);
+    expect(result.pushed).toBe(0);
+    expect(result.errors.some((e) => e.startsWith("Push aborted"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("Detected literal secret"))).toBe(true);
+    // The offending file path must appear so the user can locate the leak
+    // without grepping their config tree.
+    expect(result.errors.some((e) => e.includes(skillMd))).toBe(true);
+
+    // No encrypted artifact written for the leaky skill — the walker drops
+    // the artifact before encryption.
+    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "leaky-bundle.tar.age"))).toBe(
+      false,
+    );
+  });
+});

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -4,6 +4,7 @@ import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
 import { applyClaudeVault, type ClaudeSyncOptions, snapshotClaude } from "../agents/claude";
 import { type AgentDefinition, type AgentName, Agents } from "../agents/registry";
+import { NEVER_SYNC_WARNING_PREFIX, WALKER_SECRET_WARNING_PREFIX } from "../agents/skills-walker";
 import { encryptString } from "../core/encryptor";
 import { GitClient } from "../core/git";
 import { scanForSecrets, shouldNeverSync } from "../core/sanitizer";
@@ -148,7 +149,7 @@ export async function performPush(
     // snapshot.warnings; the per-artifact loop above already catches them, so
     // a broad `Detected literal secret` match here would double-report.
     for (const w of snapshot.warnings) {
-      if (w.startsWith("never-sync inside skill: ") || w.startsWith("Detected literal secret (")) {
+      if (w.startsWith(NEVER_SYNC_WARNING_PREFIX) || w.startsWith(WALKER_SECRET_WARNING_PREFIX)) {
         secretErrors.push(`[${agent.name}] ${w}`);
       }
     }

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -115,8 +115,14 @@ export async function performPush(
       // statistically overlaps with `AKIA…` and `AIza…` credentials, so
       // scanning the encoded form would false-positive without reliably
       // catching credentials *inside* the bundle (encoding scrambles
-      // prefixes). Per-file scanning at the walker layer is tracked
-      // separately; for now skip the encoded surface entirely.
+      // prefixes). The encoded surface is intentionally skipped here.
+      // Bundle internals are covered separately at the walker layer:
+      // `collectInteriorViolations` in `src/agents/skills-walker.ts` scans
+      // each readable interior file body with `scanForSecrets` before the
+      // tar buffer is built, and the Copilot agents walk in
+      // `src/agents/copilot.ts` invokes the same helper. Both surface
+      // `Detected literal secret …` warnings on the snapshot, which the
+      // walker-warning loop below escalates to a fatal abort.
       if (artifact.vaultPath.endsWith(".tar.age")) {
         continue;
       }
@@ -124,13 +130,18 @@ export async function performPush(
         secretErrors.push(`[${agent.name}] ${w}`);
       }
     }
-    // Walker-level warnings (e.g. "never-sync inside skill: <path>") are
-    // emitted on the top-level snapshot.warnings array by the shared skills
-    // walker (src/agents/skills-walker.ts), not on individual artifacts. They
-    // must also escalate to a fatal abort so a never-sync file inside a skill
-    // directory never reaches encryption.
+    // Walker-level warnings are emitted on the top-level snapshot.warnings
+    // array (not per-artifact, since the offending bundle is dropped before
+    // any artifact is built). Two prefixes escalate to a fatal abort:
+    //   - `never-sync inside skill: <path>` — a path-pattern hit inside a
+    //     skill, so the bundle would have contained a hard never-sync file.
+    //   - `Detected literal secret …` — a credential found inside an
+    //     interior file body during the walker's per-file scan. The central
+    //     scan a few lines above skips `.tar.age` artifacts, so this is the
+    //     only layer that catches a key pasted into `SKILL.md`, READMEs, or
+    //     any other file inside a skill/agent bundle.
     for (const w of snapshot.warnings) {
-      if (w.startsWith("never-sync inside skill: ")) {
+      if (w.startsWith("never-sync inside skill: ") || w.startsWith("Detected literal secret")) {
         secretErrors.push(`[${agent.name}] ${w}`);
       }
     }

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -135,13 +135,20 @@ export async function performPush(
     // any artifact is built). Two prefixes escalate to a fatal abort:
     //   - `never-sync inside skill: <path>` — a path-pattern hit inside a
     //     skill, so the bundle would have contained a hard never-sync file.
-    //   - `Detected literal secret …` — a credential found inside an
-    //     interior file body during the walker's per-file scan. The central
-    //     scan a few lines above skips `.tar.age` artifacts, so this is the
-    //     only layer that catches a key pasted into `SKILL.md`, READMEs, or
-    //     any other file inside a skill/agent bundle.
+    //   - `Detected literal secret (<name>) in <path>` — a credential found
+    //     inside an interior file body during the walker's per-file scan.
+    //     The central scan a few lines above skips `.tar.age` artifacts, so
+    //     this is the only layer that catches a key pasted into `SKILL.md`,
+    //     READMEs, or any other file inside a skill/agent bundle.
+    //
+    // The walker prefix is matched with the trailing `(` so it stays distinct
+    // from `Detected literal secret for field <name>` emitted by
+    // `redactSecretLiterals` (sanitizeClaudeHooks/Mcp/PluginManifest/PluginMcp).
+    // Those redactor warnings land on BOTH artifact.warnings AND
+    // snapshot.warnings; the per-artifact loop above already catches them, so
+    // a broad `Detected literal secret` match here would double-report.
     for (const w of snapshot.warnings) {
-      if (w.startsWith("never-sync inside skill: ") || w.startsWith("Detected literal secret")) {
+      if (w.startsWith("never-sync inside skill: ") || w.startsWith("Detected literal secret (")) {
         secretErrors.push(`[${agent.name}] ${w}`);
       }
     }


### PR DESCRIPTION
## Summary

Closes #57. Adds per-file secret scanning at the walker layer so that literal credentials inside skill/agent bundle bodies (`SKILL.md`, READMEs, nested markdown, agent directory files) abort the push instead of being encrypted and shipped to the vault.

The Phase-1 chokepoint in `performPush` skips `.tar.age` artifacts on purpose — their "plaintext" is base64-encoded tar bytes, and base64 both scrambles credential prefixes (`sk-ant-…`, `AKIA…`) and false-positives against the AWS/Google key shapes. That skip closed the issue #47 gap for markdown and JSON-env bodies, but bundle internals stayed bypassed. This PR closes that remaining gap at the correct layer (the walker), without weakening the central scan's correctness boundary.

## Changes

- `src/agents/skills-walker.ts` — replace `collectNeverSyncHits` with `collectInteriorViolations`. One walk, both gates: never-sync path hits and `scanForSecrets` body hits. Each interior file is `lstat`-ed and UTF-8-read at most once; binary or unreadable files silently skip the body scan but still get the path-only never-sync check. A skill with any hit is dropped before the tar buffer is built.
- `src/agents/copilot.ts` — call `collectInteriorViolations` on each agent directory before `archiveDirectory`. The Copilot agents loop does NOT delegate to the shared skills walker, so it needs its own invocation; the helper is reused for symmetry.
- `src/commands/push.ts` — extend the walker-warning escalation loop to also escalate `Detected literal secret` (not just `never-sync inside skill: `). Update the explanatory comment block above the `.tar.age` skip to point at the new walker-layer coverage.
- `src/agents/claude.ts` — read-only audit, no code change. Top-level `commands/`, `agents/`, plugin `commands/`, plugin `agents/`, and plugin `hooks/` all emit per-file `*.md.age` / `*.json.age` artifacts whose plaintext is already scanned by the central chokepoint. Plugin-local skills route through `collectSkillArtifacts`, so they inherit the T1/T2 walker fix automatically.

## Diagram

```mermaid
sequenceDiagram
  participant W as collectSkillArtifacts<br/>(skills-walker.ts)
  participant V as collectInteriorViolations<br/>(new)
  participant T as archiveDirectory<br/>(core/tar.ts)
  participant P as performPush<br/>(commands/push.ts)
  participant S as scanForSecrets<br/>(core/sanitizer.ts)

  W->>V: walk skill interior
  V->>V: lstat + (path: shouldNeverSync)<br/>+ (body: scanForSecrets)
  alt any never-sync hit OR literal secret hit
    V-->>W: { neverSyncHits, secretWarnings }
    W-->>P: snapshot.warnings (no .tar.age artifact)
    Note over P: walker-warning loop<br/>escalates both prefixes<br/>to fatal Push aborted
  else clean
    V-->>W: empty violations
    W->>T: archiveDirectory(skill, skipSymlinks: true)
    T-->>W: tar buffer
    W-->>P: artifact (.tar.age)
    Note over P: central scan SKIPS .tar.age<br/>(base64 scramble/false-positive)
  end
```

## Files changed

- `src/agents/skills-walker.ts` · replace `collectNeverSyncHits` with `collectInteriorViolations`; add per-file `scanForSecrets`; export the new helper for cross-adapter reuse.
- `src/agents/copilot.ts` · per-file secret scan on each agent directory before `archiveDirectory`.
- `src/commands/push.ts` · escalate `Detected literal secret` walker warnings; refresh the `.tar.age` skip comment.
- `src/agents/__tests__/skills-walker.test.ts` · four new tests: positive (SKILL.md), positive (nested `notes/leak.md`), negative (AKIA-shaped prose stays included), mixed (clean + dirty).
- `src/agents/__tests__/copilot.test.ts` · two new tests covering the agents walk: agent dir with Anthropic key rejected; clean agent dir still produces one `.tar.age`.
- `src/commands/__tests__/push.test.ts` · end-to-end test: literal Claude API key in `SKILL.md` → `fatal: true`, `pushed: 0`, offending path appears in errors, no artifact written.

## Commits

- `99ef766` · fix(walker): scan skill/agent bundle bodies for literal secrets

## Tests run

- `bun run typecheck` · ✅ passes (no errors).
- `bun test src/agents/__tests__/skills-walker.test.ts src/agents/__tests__/copilot.test.ts src/commands/__tests__/push.test.ts` · ✅ **45 pass / 0 fail / 133 expect()**.
- `bun run lint` · same baseline as `main` (1 pre-existing error + 8 warnings, all in `docs/stylesheets/extra.css` — unrelated to this PR).
- `bun test` (full suite) · same baseline as `main` (239 pass / 20 fail / 16 errors). All failures are the pre-existing Bun mock-cache cross-file bleed (`SyntaxError: Missing 'default' export in module 'node:fs/promises'`) in `status.test.ts`, `daemon.test.ts`, `doctor.test.ts`, `packaging.test.ts`, etc. Verified by `git stash && bun test` on `main` returning identical counts. No new failures introduced.

## Verification

1. Walker rejects a literal `sk-ant-api03-…` pasted into `SKILL.md` with `Detected literal secret (anthropic-api-key) in <path>/SKILL.md` and drops the artifact (`skills-walker.test.ts`).
2. Walker rejects a nested `notes/leak.md` containing an `AKIA…` access key, naming the nested path (`skills-walker.test.ts`).
3. Walker still ships a clean skill whose prose contains `AKIA-history-of-aviation` and a `sha256:` digest — no false positive against the EMBEDDED_SECRET_PATTERNS (`skills-walker.test.ts`).
4. Mixed run: a clean skill is collected alongside a dirty one; only the dirty skill is dropped and warned (`skills-walker.test.ts`).
5. Copilot agents walk rejects an agent dir with a literal Anthropic key in `agent.md` and still ships clean agent dirs as a single `.tar.age` artifact (`copilot.test.ts`).
6. `performPush` end-to-end: literal key in a Copilot skill `SKILL.md` returns `fatal: true`, `pushed: 0`, includes the offending path in errors, and writes no `.tar.age` for the skill (`push.test.ts`).
7. `git grep -n "Detected literal secret" src/agents/` shows the walker now emits the contract-marker prefix, and the `.tar.age` skip in `src/commands/push.ts` is preserved (per the issue's "Out of scope").

Closes #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interior literal-secret scanning: bundles with embedded API keys or other secrets are skipped, produce clear warnings, and cause pushes to abort.

* **Bug Fixes**
  * Reduced false positives in prose scanning.
  * Duplicate warning reporting deduplicated during push aborts.

* **Tests**
  * Added unit and integration tests for interior secret detection, walker-level validation, abort-on-detection, and duplicate-warning handling.

* **Documentation**
  * Updated gating/security docs to describe combined interior scanning and push behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/65)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->