### PR TITLE
fix(push): route --dry-run through performPush so Phase 1 security gates run

### DIFF
--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -890,6 +890,39 @@ describe("integration", () => {
     expect(existsSync(join(vaultDir, "claude", "dry-cli.age"))).toBe(false);
   });
 
+  test("pushCommand.run with dryRun=true aborts when an artifact warning reports a literal secret", async () => {
+    // Dry-run is the canonical pre-flight gate. If it ever lets a literal
+    // credential through, users (and CI) will rely on it as a safe preview
+    // only to be surprised by a fatal on the real push. The CLI dry-run
+    // path must run the same Phase 1 abort that the non-dry-run path does.
+    fakeArtifacts.length = 0;
+    fakeArtifacts.push({
+      vaultPath: "claude/leaky-cli.age",
+      sourcePath: "/fake/.claude/leaky-cli.md",
+      plaintext: "# clean prompt body",
+      warnings: ["Detected literal secret for field anthropic_api_key in /fake/.claude/leaky.json"],
+    });
+    fakeLogs.error.length = 0;
+    fakeLogs.info.length = 0;
+    process.exitCode = 0;
+
+    await pushMod.pushCommand.run?.({
+      args: { agent: "claude", dryRun: true, message: undefined },
+      rawArgs: [],
+      cmd: {} as never,
+    } as never);
+
+    expect(process.exitCode).toBe(1);
+    expect(fakeLogs.error.some((message) => message.startsWith("Push aborted"))).toBe(true);
+    expect(fakeLogs.error.some((message) => message.includes("Detected literal secret"))).toBe(
+      true,
+    );
+    expect(existsSync(join(vaultDir, "claude", "leaky-cli.age"))).toBe(false);
+
+    fakeArtifacts.length = 0;
+    process.exitCode = 0;
+  });
+
   test("pushCommand.run without dryRun encrypts and pushes artifacts", async () => {
     fakeArtifacts.push({
       vaultPath: "claude/cli-push.age",

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -923,6 +923,119 @@ describe("integration", () => {
     process.exitCode = 0;
   });
 
+  test("pushCommand.run with dryRun=true emits one SKIP line per non-skill never-sync artifact", async () => {
+    // The dry-run SKIP signal must come through onPreview only. Previously
+    // allWarnings.push fired alongside onPreview for the same artifact, and
+    // the CLI rendered allWarnings via result.errors → log.warn, producing
+    // two near-duplicate lines per never-sync source. The skill-walker
+    // never-sync case fatals in Phase 1 (covered elsewhere); this test
+    // exercises the top-level-source path where shouldNeverSync matches an
+    // artifact an adapter happened to surface (e.g. **/auth.json).
+    fakeArtifacts.length = 0;
+    fakeArtifacts.push({
+      vaultPath: "claude/auth.json.age",
+      sourcePath: "/fake/.claude/auth.json",
+      plaintext: "{}",
+      warnings: [],
+    });
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+    process.exitCode = 0;
+
+    await pushMod.pushCommand.run?.({
+      args: { agent: "claude", dryRun: true, message: undefined },
+      rawArgs: [],
+      cmd: {} as never,
+    } as never);
+
+    // Exactly one SKIP line via onPreview, no second "matches never-sync
+    // pattern" warning rendered from allWarnings.
+    const authJsonLines = fakeLogs.warn.filter((m) => m.includes("auth.json"));
+    expect(authJsonLines).toHaveLength(1);
+    expect(authJsonLines[0]).toContain("[dry-run]");
+    expect(authJsonLines[0]).toContain("SKIP");
+    expect(authJsonLines[0]).toContain("never-sync");
+    expect(fakeLogs.warn.some((m) => m.includes("matches never-sync pattern"))).toBe(false);
+    expect(existsSync(join(vaultDir, "claude", "auth.json.age"))).toBe(false);
+
+    fakeArtifacts.length = 0;
+  });
+
+  test("performPush with dryRun=true does not push the Skipped warning into result.errors for non-skill never-sync hits", async () => {
+    // API-level twin of the CLI test above: gate is at the performPush
+    // boundary, so the dry-run path must leave result.errors clean of the
+    // "matches never-sync pattern" line. A non-dry-run run on the same
+    // artifact still surfaces the warning via result.errors (covered by
+    // the next test) so the operator's post-run summary is unchanged.
+    fakeArtifacts.length = 0;
+    fakeArtifacts.push({
+      vaultPath: "claude/auth.json.age",
+      sourcePath: "/fake/.claude/auth.json",
+      plaintext: "{}",
+      warnings: [],
+    });
+
+    const previews: Array<{ sourcePath: string; skipped: boolean; skipReason?: string }> = [];
+    const result = await pushMod.performPush({
+      agent: "claude",
+      dryRun: true,
+      onPreview: (entry) => {
+        previews.push({
+          sourcePath: entry.sourcePath,
+          skipped: entry.skipped,
+          skipReason: entry.skipReason,
+        });
+      },
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.pushed).toBe(0);
+    expect(result.errors.some((e) => e.includes("matches never-sync pattern"))).toBe(false);
+    // The SKIP signal must still reach the caller — just through onPreview only.
+    expect(previews).toHaveLength(1);
+    expect(previews[0]?.skipped).toBe(true);
+    expect(previews[0]?.skipReason).toBe("never-sync");
+    expect(previews[0]?.sourcePath).toBe("/fake/.claude/auth.json");
+
+    fakeArtifacts.length = 0;
+  });
+
+  test("performPush without dryRun still surfaces the Skipped warning for non-skill never-sync hits when other artifacts pushed", async () => {
+    // The real-push post-run summary must keep this warning. performPush
+    // returns allWarnings via result.errors only when at least one artifact
+    // was actually pushed (the `pushed === 0` branch returns early), so
+    // pair the never-sync artifact with a clean sibling to exercise the
+    // summary path.
+    fakeArtifacts.length = 0;
+    fakeArtifacts.push({
+      vaultPath: "claude/auth.json.age",
+      sourcePath: "/fake/.claude/auth.json",
+      plaintext: "{}",
+      warnings: [],
+    });
+    fakeArtifacts.push({
+      vaultPath: "claude/sibling.age",
+      sourcePath: "/fake/.claude/sibling.md",
+      plaintext: "# clean sibling",
+      warnings: [],
+    });
+
+    const result = await pushMod.performPush({ agent: "claude" });
+
+    expect(result.fatal).toBe(false);
+    expect(result.pushed).toBe(1);
+    expect(
+      result.errors.some(
+        (e) => e.includes("/fake/.claude/auth.json") && e.includes("matches never-sync pattern"),
+      ),
+    ).toBe(true);
+    expect(existsSync(join(vaultDir, "claude", "auth.json.age"))).toBe(false);
+    expect(existsSync(join(vaultDir, "claude", "sibling.age"))).toBe(true);
+
+    fakeArtifacts.length = 0;
+  });
+
   test("pushCommand.run without dryRun encrypts and pushes artifacts", async () => {
     fakeArtifacts.push({
       vaultPath: "claude/cli-push.age",

--- a/src/commands/__tests__/push.test.ts
+++ b/src/commands/__tests__/push.test.ts
@@ -474,3 +474,144 @@ describe("performPush — literal secret embedded inside a skill bundle body", (
     );
   });
 });
+
+describe("performPush — dry-run still runs Phase 1 security gates", () => {
+  // Dry-run must enforce the same abort gates as a real push. A clean preview
+  // followed by a real-push abort builds false confidence: dry-run is the
+  // canonical pre-flight gate, so any path that hides a fatal must be wired
+  // back through performPush's Phase 1.
+
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  const savedEnv: Record<string, string | undefined> = {};
+  const savedCopilot = {
+    skillsDir: mutableCopilotPaths.skillsDir,
+    instructionsFile: mutableCopilotPaths.instructionsFile,
+    instructionsDir: mutableCopilotPaths.instructionsDir,
+    promptsDir: mutableCopilotPaths.promptsDir,
+    agentsDir: mutableCopilotPaths.agentsDir,
+    vscodeMcpInSettings: mutableCopilotPaths.vscodeMcpInSettings,
+  };
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    const bareRepoPath = await createBareRepo(tmpDir);
+    machine = await createMachineFixture(tmpDir, "dry-run-secret-machine");
+
+    const copilotHome = join(tmpDir, "copilot-home-dry-run");
+    mutableCopilotPaths.skillsDir = join(copilotHome, "skills");
+    mutableCopilotPaths.instructionsFile = join(copilotHome, "instructions");
+    mutableCopilotPaths.instructionsDir = join(copilotHome, "instructions");
+    mutableCopilotPaths.promptsDir = join(copilotHome, "prompts");
+    mutableCopilotPaths.agentsDir = join(copilotHome, "agents");
+    mutableCopilotPaths.vscodeMcpInSettings = join(tmpDir, "vscode-settings.json");
+
+    for (const key of RUNTIME_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+    process.env.AGENTSYNC_MACHINE = machine.machineName;
+
+    seedVaultRepo({
+      machine,
+      bareRepoPath,
+      agents: { copilot: true, claude: false },
+    });
+
+    fakeLogs.success.length = 0;
+    fakeLogs.info.length = 0;
+    fakeLogs.warn.length = 0;
+    fakeLogs.error.length = 0;
+    process.exitCode = 0;
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mutableCopilotPaths.skillsDir = savedCopilot.skillsDir;
+    mutableCopilotPaths.instructionsFile = savedCopilot.instructionsFile;
+    mutableCopilotPaths.instructionsDir = savedCopilot.instructionsDir;
+    mutableCopilotPaths.promptsDir = savedCopilot.promptsDir;
+    mutableCopilotPaths.agentsDir = savedCopilot.agentsDir;
+    mutableCopilotPaths.vscodeMcpInSettings = savedCopilot.vscodeMcpInSettings;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("aborts a dry-run when a prompt file body contains a Claude API key", async () => {
+    mkdirSync(mutableCopilotPaths.promptsDir, { recursive: true });
+    const promptPath = join(mutableCopilotPaths.promptsDir, "dry-leaky.prompt.md");
+    const fakeKey = `sk-ant-api03-${"B".repeat(48)}`;
+    writeFileSync(
+      promptPath,
+      `# Demo prompt\n\nMy API key is ${fakeKey}\n\nDo not share.\n`,
+      "utf8",
+    );
+
+    const previews: Array<{ sourcePath: string; skipped: boolean }> = [];
+    const result = await pushMod.performPush({
+      agent: "copilot",
+      dryRun: true,
+      onPreview: (entry) => {
+        previews.push({ sourcePath: entry.sourcePath, skipped: entry.skipped });
+      },
+    });
+
+    expect(result.fatal).toBe(true);
+    expect(result.pushed).toBe(0);
+    expect(result.errors.some((e) => e.startsWith("Push aborted"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("Detected literal secret"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("dry-leaky.prompt.md"))).toBe(true);
+
+    // Phase 1 aborts before Phase 2 runs, so the preview callback must not
+    // fire for the leaky artifact (otherwise the user sees a clean preview).
+    expect(previews).toHaveLength(0);
+
+    // No encrypted artifact written even though the operation was a dry-run.
+    expect(
+      existsSync(join(machine.vaultDir, "copilot", "prompts", "dry-leaky.prompt.md.age")),
+    ).toBe(false);
+  });
+
+  test("aborts a dry-run when a Copilot skill contains a never-sync file", async () => {
+    const cleanSkill = join(mutableCopilotPaths.skillsDir, "clean-skill");
+    mkdirSync(cleanSkill, { recursive: true });
+    writeFileSync(join(cleanSkill, "SKILL.md"), "# clean", "utf8");
+
+    const dirtySkill = join(mutableCopilotPaths.skillsDir, "dirty-skill");
+    mkdirSync(dirtySkill, { recursive: true });
+    writeFileSync(join(dirtySkill, "SKILL.md"), "# dirty", "utf8");
+    writeFileSync(join(dirtySkill, "auth.json"), '{"token":"x"}', "utf8");
+
+    const previews: Array<{ sourcePath: string; skipped: boolean }> = [];
+    const result = await pushMod.performPush({
+      agent: "copilot",
+      dryRun: true,
+      onPreview: (entry) => {
+        previews.push({ sourcePath: entry.sourcePath, skipped: entry.skipped });
+      },
+    });
+
+    expect(result.fatal).toBe(true);
+    expect(result.pushed).toBe(0);
+    expect(result.errors.some((e) => e.startsWith("Push aborted"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("never-sync inside skill"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("auth.json"))).toBe(true);
+
+    // Phase 1 aborts before any preview entry is emitted.
+    expect(previews).toHaveLength(0);
+
+    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "clean-skill.tar.age"))).toBe(
+      false,
+    );
+    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "dirty-skill.tar.age"))).toBe(
+      false,
+    );
+  });
+});

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -33,13 +33,28 @@ function withClaudeOptions(agent: AgentDefinition, claudeOpts: ClaudeSyncOptions
   };
 }
 
+/** Preview entry emitted to onPreview callbacks during a dry-run push. */
+export type PushPreviewEntry = {
+  agent: AgentName;
+  sourcePath: string;
+  vaultPath: string;
+  targetPath: string;
+  skipped: boolean;
+  skipReason?: string;
+};
+
 /**
  * Snapshot local agent state, encrypt it, and publish the resulting vault changes.
- * @param options Optional agent filter, dry-run flag, and commit message override.
+ * @param options Optional agent filter, dry-run flag, commit message override, and dry-run preview callback.
  * @returns The number of written artifacts, collected errors, and whether the run failed fatally.
  */
 export async function performPush(
-  options: { agent?: string; dryRun?: boolean; message?: string } = {},
+  options: {
+    agent?: string;
+    dryRun?: boolean;
+    message?: string;
+    onPreview?: (entry: PushPreviewEntry) => void;
+  } = {},
 ): Promise<{ pushed: number; errors: string[]; fatal: boolean }> {
   const errors: string[] = [];
   let pushed = 0;
@@ -175,17 +190,34 @@ export async function performPush(
     }
 
     for (const artifact of snapshot.artifacts) {
+      const target = join(runtime.vaultDir, artifact.vaultPath);
+
       // Guard: never sync files matching global never-sync patterns
       if (shouldNeverSync(artifact.sourcePath)) {
         allWarnings.push(
           `[${agent.name}] Skipped ${artifact.sourcePath} — matches never-sync pattern`,
         );
+        if (options.dryRun) {
+          options.onPreview?.({
+            agent: agent.name,
+            sourcePath: artifact.sourcePath,
+            vaultPath: artifact.vaultPath,
+            targetPath: target,
+            skipped: true,
+            skipReason: "never-sync",
+          });
+        }
         continue;
       }
 
-      const target = join(runtime.vaultDir, artifact.vaultPath);
-
       if (options.dryRun) {
+        options.onPreview?.({
+          agent: agent.name,
+          sourcePath: artifact.sourcePath,
+          vaultPath: artifact.vaultPath,
+          targetPath: target,
+          skipped: false,
+        });
         continue;
       }
 
@@ -249,37 +281,20 @@ export const pushCommand = defineCommand({
   async run({ args }) {
     const requestedAgent = args.agent as string | undefined;
 
-    if (args.dryRun) {
-      // Collect dry-run output manually for display
-      const runtime = await resolveRuntimeContext();
-      const config = await loadVaultConfigOrExit(runtime.vaultDir);
-      const claudeOpts: ClaudeSyncOptions = {
-        syncMarketplace: config.claudePlugins?.syncMarketplace ?? false,
-      };
-      const agentsToSync = agentDefinitions
-        .filter((a) => {
-          if (requestedAgent) return a.name === requestedAgent;
-          return config.agents[a.name] === true;
-        })
-        .map((a) => withClaudeOptions(a, claudeOpts));
-      for (const agent of agentsToSync) {
-        const snapshot = await agent.snapshot();
-        for (const artifact of snapshot.artifacts) {
-          if (shouldNeverSync(artifact.sourcePath)) {
-            log.warn(`[dry-run] [${agent.name}] SKIP ${artifact.sourcePath} — never-sync`);
-            continue;
-          }
-          const target = join(runtime.vaultDir, artifact.vaultPath);
-          log.info(`[dry-run] [${agent.name}] ${artifact.sourcePath} → ${target}`);
-        }
-      }
-      return;
-    }
-
     const result = await performPush({
       agent: requestedAgent,
-      dryRun: false,
+      dryRun: args.dryRun === true,
       message: args.message as string | undefined,
+      onPreview: args.dryRun
+        ? (entry) => {
+            if (entry.skipped) {
+              const reason = entry.skipReason ?? "skipped";
+              log.warn(`[dry-run] [${entry.agent}] SKIP ${entry.sourcePath} — ${reason}`);
+            } else {
+              log.info(`[dry-run] [${entry.agent}] ${entry.sourcePath} → ${entry.targetPath}`);
+            }
+          }
+        : undefined,
     });
 
     for (const err of result.errors) {
@@ -292,6 +307,10 @@ export const pushCommand = defineCommand({
 
     if (result.fatal) {
       process.exitCode = 1;
+      return;
+    }
+
+    if (args.dryRun) {
       return;
     }
 

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -192,11 +192,13 @@ export async function performPush(
     for (const artifact of snapshot.artifacts) {
       const target = join(runtime.vaultDir, artifact.vaultPath);
 
-      // Guard: never sync files matching global never-sync patterns
+      // Guard: never sync files matching global never-sync patterns. In
+      // dry-run, the SKIP signal goes only through onPreview so the CLI
+      // renders one line per artifact. In a real push, the warning goes
+      // onto allWarnings so the post-run summary still surfaces it.
+      // Emitting both in dry-run would double-print the same artifact
+      // (onPreview → SKIP line, then result.errors → log.warn).
       if (shouldNeverSync(artifact.sourcePath)) {
-        allWarnings.push(
-          `[${agent.name}] Skipped ${artifact.sourcePath} — matches never-sync pattern`,
-        );
         if (options.dryRun) {
           options.onPreview?.({
             agent: agent.name,
@@ -206,6 +208,10 @@ export async function performPush(
             skipped: true,
             skipReason: "never-sync",
           });
+        } else {
+          allWarnings.push(
+            `[${agent.name}] Skipped ${artifact.sourcePath} — matches never-sync pattern`,
+          );
         }
         continue;
       }


### PR DESCRIPTION
## Summary

`agentsync push --dry-run` ran a CLI-only snapshot loop that consulted only
`shouldNeverSync(artifact.sourcePath)` — a path-pattern check. It never invoked
`scanForSecrets`, never inspected `artifact.warnings` for
`Detected literal secret`, and never inspected `snapshot.warnings` for the
walker's `never-sync inside skill:` / `Detected literal secret (` prefixes.
A user could paste a literal credential into a markdown body, see a clean
preview with exit 0, and only discover the abort on the real push.

This routes the CLI dry-run path through `performPush({ dryRun: true })` so the
existing Phase 1 abort gates run unchanged. To preserve the existing
`[dry-run] [<agent>] <src> → <target>` preview lines, `performPush` gains an
optional `onPreview` callback that fires per-artifact in Phase 2 only when
`dryRun` is set — after Phase 1 has fully executed.

Closes #63

## Changes

- `performPush` accepts an optional `onPreview` callback and exports a new
  `PushPreviewEntry` type. The callback fires for each artifact in Phase 2
  when `options.dryRun` is set — once with `skipped: true` for the
  `shouldNeverSync` short-circuit, once with `skipped: false` for normal
  preview entries. Non-dry-run callers are unaffected.
- The CLI wrapper at `pushCommand.run` no longer reimplements
  snapshot/preview. Both dry-run and non-dry-run paths now call
  `performPush`. The dry-run branch wires an `onPreview` that emits the
  existing `[dry-run] [<agent>] <src> → <target>` (and
  `[dry-run] [<agent>] SKIP <src> — never-sync`) lines, and renders
  `result.errors` / `result.fatal` identically to the real push.
- Regression tests for the three abort gates under `dryRun: true`.

### Diagram

```mermaid
graph TD
    Cli["agentsync push --dry-run"] --> CliRun["pushCommand.run"]
    CliRun --> Perform["performPush dryRun true"]
    Perform --> Reconcile{"options.dryRun?"}
    Reconcile -- yes --> SkipReconcile["skip reconcile"]
    Reconcile -- no --> DoReconcile["reconcileWithRemote"]
    SkipReconcile --> Phase1["Phase 1 abort gates"]
    DoReconcile --> Phase1
    Phase1 --> Scan["scanForSecrets on plaintext"]
    Phase1 --> ArtifactWarn["artifact.warnings Detected literal secret"]
    Phase1 --> WalkerWarn["snapshot.warnings never-sync inside skill"]
    Scan --> Decide{"any secretErrors?"}
    ArtifactWarn --> Decide
    WalkerWarn --> Decide
    Decide -- yes --> Abort["return fatal exit 1"]
    Decide -- no --> Phase2["Phase 2 per-artifact"]
    Phase2 --> NeverSync{"shouldNeverSync?"}
    NeverSync -- yes --> SkipPreview["onPreview skipped true and continue"]
    NeverSync -- no --> DryCheck{"options.dryRun?"}
    DryCheck -- yes --> NormalPreview["onPreview skipped false and continue"]
    DryCheck -- no --> Encrypt["encrypt and write"]
    SkipPreview --> Next["next artifact"]
    NormalPreview --> Next
    Encrypt --> Next
```

## Files changed

- `src/commands/push.ts` · adds `PushPreviewEntry` and the optional
  `onPreview` callback to `performPush`; collapses the CLI dry-run branch
  into a single `performPush` call so Phase 1 gates run.
- `src/commands/__tests__/push.test.ts` · adds a `describe` block with two
  tests proving `performPush({ dryRun: true })` aborts on a literal secret
  in a `.prompt.md` body and on a never-sync file inside a skill.
- `src/commands/__tests__/integration.test.ts` · adds a CLI-level test
  that drives `pushCommand.run` with `dryRun: true` against an artifact
  whose warning contains `Detected literal secret …` and asserts
  `process.exitCode === 1`, the `Push aborted` log, and no `.age` written.

## Commits

- `e4d6e88` · fix(push): route --dry-run through performPush so Phase 1 gates run

## Tests run

- `bun test src/commands/__tests__/push.test.ts` · 6 pass / 0 fail (4 existing + 2 new dry-run cases)
- `bun test src/commands/__tests__/integration.test.ts` · 29 pass / 0 fail (28 existing + 1 new CLI dry-run secret-warning case)
- `bun test src/commands/__tests__/push.test.ts src/commands/__tests__/integration.test.ts` · 35 pass / 0 fail
- `bun run typecheck` · pass
- `bun run lint` · pass (8 pre-existing warnings in `docs/stylesheets/extra.css`, exit 0)
- `bun run check` · same 239 pass / 20 fail / 16 errors as `main` at `c8dc814` — the failures are a pre-existing Bun mock-cache aliasing issue between test files when the full suite runs in one process, not caused by this change.

## Verification

1. `grep -n "agent.snapshot" src/commands/push.ts` → only `116:    const snapshot = await agent.snapshot();`, which lives inside `performPush`. The CLI wrapper no longer calls `agent.snapshot()`, confirming the bespoke bypass loop is gone.
2. New `performPush — dry-run still runs Phase 1 security gates` describe block in `src/commands/__tests__/push.test.ts` asserts `result.fatal === true`, `result.pushed === 0`, `Push aborted` in errors, and that the preview callback never fires for the leaky artifact — proving Phase 1 aborts before Phase 2.
3. New `pushCommand.run with dryRun=true aborts when an artifact warning reports a literal secret` test in `src/commands/__tests__/integration.test.ts` asserts `process.exitCode === 1`, that `Push aborted` is logged via `log.error`, and that no `.age` file is written.
4. Existing `pushCommand.run with dryRun=true does not write vault files` test still passes — the clean preview path is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dry-run now emits per-artifact preview entries so skipped vs previewed items are reported clearly.

* **Bug Fixes**
  * Dry-run no longer shows final "Nothing to push"/"Pushed…" messaging, avoiding misleading output during previews.
  * Never-sync and literal-secret warnings are surfaced correctly in dry-run vs real push runs.

* **Tests**
  * Added integration and unit tests covering dry-run vs non-dry-run push behavior, secret detection, and never-sync handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/67)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->