### PR TITLE
fix(config): tighten schema for recipients, branch, and remote.url

### DIFF
--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -10,8 +10,9 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { rm, symlink } from "node:fs/promises";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
+import { AgentSyncConfigSchema } from "../../config/schema";
 import { createTmpDir } from "../../test-helpers/fixtures";
-import { buildSkillsDirChecks } from "../doctor";
+import { buildSkillsDirChecks, formatSchemaError } from "../doctor";
 
 type MutablePaths = {
   claude: { skillsDir: string };
@@ -127,5 +128,61 @@ describe("buildSkillsDirChecks", () => {
     const claudeRow = rows.find((r) => r.name === "Claude skills directory");
     expect(claudeRow?.status).toBe("warn");
     expect(claudeRow?.detail).toContain("Symlinked skills root");
+  });
+});
+
+describe("formatSchemaError", () => {
+  test("names the offending recipient alias on a non-age1 value", () => {
+    const result = AgentSyncConfigSchema.safeParse({
+      recipients: { alice: "notage1xyz" },
+      agents: {
+        cursor: true,
+        claude: true,
+        codex: true,
+        copilot: true,
+        vscode: false,
+      },
+      remote: { url: "git@github.com:user/vault.git", branch: "main" },
+      sync: {
+        debounceMs: 300,
+        autoPush: true,
+        autoPull: true,
+        pullIntervalMs: 300_000,
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const detail = formatSchemaError(result.error);
+      expect(detail).toContain("recipients.alice");
+    }
+  });
+
+  test("names remote.branch on empty branch", () => {
+    const result = AgentSyncConfigSchema.safeParse({
+      recipients: { me: "age1qpzry9x8gf2tvdw0s3jn54khce6mua7l" },
+      agents: {
+        cursor: true,
+        claude: true,
+        codex: true,
+        copilot: true,
+        vscode: false,
+      },
+      remote: { url: "git@github.com:user/vault.git", branch: "" },
+      sync: {
+        debounceMs: 300,
+        autoPush: true,
+        autoPull: true,
+        pullIntervalMs: 300_000,
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const detail = formatSchemaError(result.error);
+      expect(detail).toContain("remote.branch");
+    }
+  });
+
+  test("falls back to String(err) for non-Zod errors", () => {
+    expect(formatSchemaError(new Error("disk full"))).toBe("Invalid: Error: disk full");
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,9 +6,28 @@ import { join, relative } from "node:path";
 import { promisify } from "node:util";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
+import { z } from "zod";
 import { loadConfig, resolveConfigPath } from "../config/loader";
 import { AgentPaths } from "../config/paths";
 import { resolveRuntimeContext } from "./shared";
+
+/**
+ * Render a ZodError as a one-line `field: message` summary so the
+ * doctor row points the user at the offending field (e.g. the recipient
+ * alias, `remote.branch`, `remote.url`) instead of dumping `[ZodError: ...]`.
+ * Caps at three issues to keep the row readable.
+ */
+export function formatSchemaError(err: unknown): string {
+  if (err instanceof z.ZodError) {
+    const parts = err.issues.slice(0, 3).map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      return `${path}: ${issue.message}`;
+    });
+    const suffix = err.issues.length > 3 ? ` (+${err.issues.length - 3} more)` : "";
+    return `Invalid: ${parts.join("; ")}${suffix}`;
+  }
+  return `Invalid: ${String(err)}`;
+}
 
 /** Single diagnostic check row rendered by the doctor command. */
 export interface Check {
@@ -165,7 +184,7 @@ export const doctorCommand = defineCommand({
       checks.push({
         name: "agentsync.toml schema",
         status: "fail",
-        detail: `Invalid: ${String(err)}`,
+        detail: formatSchemaError(err),
       });
     }
 

--- a/src/commands/key.ts
+++ b/src/commands/key.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
 import { loadConfig, resolveConfigPath, writeConfig } from "../config/loader";
+import { AgePublicKeySchema } from "../config/schema";
 import {
   decryptString,
   encryptString,
@@ -62,7 +63,7 @@ export const keyCommand = defineCommand({
         const name = args.name as string;
         const pubkey = args.pubkey as string;
 
-        if (!pubkey.startsWith("age1")) {
+        if (!AgePublicKeySchema.safeParse(pubkey).success) {
           log.error("Invalid key: age public keys must start with 'age1'");
           process.exitCode = 1;
           return;

--- a/src/commands/key.ts
+++ b/src/commands/key.ts
@@ -63,8 +63,9 @@ export const keyCommand = defineCommand({
         const name = args.name as string;
         const pubkey = args.pubkey as string;
 
-        if (!AgePublicKeySchema.safeParse(pubkey).success) {
-          log.error("Invalid key: age public keys must start with 'age1'");
+        const parsed = AgePublicKeySchema.safeParse(pubkey);
+        if (!parsed.success) {
+          log.error(`Invalid key: ${parsed.error.issues[0].message}`);
           process.exitCode = 1;
           return;
         }

--- a/src/config/__tests__/schema.test.ts
+++ b/src/config/__tests__/schema.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { AgentSyncConfigSchema } from "../schema";
+import { AgentSyncConfigSchema, AgePublicKeySchema } from "../schema";
+
+// A bech32-only recipient. `age1abc` cannot be used as a fixture because `b`
+// is not in the bech32 charset `qpzry9x8gf2tvdw0s3jn54khce6mua7l` that the
+// schema now enforces.
+const VALID_RECIPIENT = "age1qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 
 const VALID_BASE = {
   version: "1",
-  recipients: { local: "age1abc" },
+  recipients: { local: VALID_RECIPIENT },
   agents: {
     cursor: true,
     claude: true,
@@ -36,7 +41,7 @@ describe("AgentSyncConfigSchema", () => {
 
   test("rejects config with missing remote", () => {
     const result = AgentSyncConfigSchema.safeParse({
-      recipients: { me: "age1xxx" },
+      recipients: { me: VALID_RECIPIENT },
       agents: {
         cursor: true,
         claude: false,
@@ -51,7 +56,7 @@ describe("AgentSyncConfigSchema", () => {
   test("rejects recipients as array instead of object", () => {
     const result = AgentSyncConfigSchema.safeParse({
       ...VALID_BASE,
-      recipients: ["age1xxx"],
+      recipients: [VALID_RECIPIENT],
     });
     expect(result.success).toBe(false);
   });
@@ -60,6 +65,51 @@ describe("AgentSyncConfigSchema", () => {
     const result = AgentSyncConfigSchema.safeParse({
       ...VALID_BASE,
       recipients: { me: "" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty recipients map — empty vault is a misconfiguration, not a state", () => {
+    const result = AgentSyncConfigSchema.safeParse({
+      ...VALID_BASE,
+      recipients: {},
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const message = result.error.issues.map((i) => i.message).join("\n");
+      expect(message).toContain("at least one entry");
+    }
+  });
+
+  test("rejects recipient value without age1 prefix", () => {
+    const result = AgentSyncConfigSchema.safeParse({
+      ...VALID_BASE,
+      recipients: { me: "notage1xyz" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects recipient value with invalid bech32 characters", () => {
+    // 'B' / 'I' / 'O' / '1' are explicitly excluded from the bech32 charset.
+    const result = AgentSyncConfigSchema.safeParse({
+      ...VALID_BASE,
+      recipients: { me: "age1BAD" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty branch — would push to empty refspec", () => {
+    const result = AgentSyncConfigSchema.safeParse({
+      ...VALID_BASE,
+      remote: { url: "git@github.com:user/vault.git", branch: "" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects remote.url that is obviously not a URL", () => {
+    const result = AgentSyncConfigSchema.safeParse({
+      ...VALID_BASE,
+      remote: { url: "not a url", branch: "main" },
     });
     expect(result.success).toBe(false);
   });
@@ -104,7 +154,7 @@ describe("AgentSyncConfigSchema", () => {
   test("recipients object must have at least one entry with non-empty key", () => {
     const result = AgentSyncConfigSchema.safeParse({
       ...VALID_BASE,
-      recipients: { "": "age1abc" },
+      recipients: { "": VALID_RECIPIENT },
     });
     expect(result.success).toBe(false);
   });
@@ -118,5 +168,32 @@ describe("AgentSyncConfigSchema", () => {
     const { version: _v, ...withoutVersion } = VALID_BASE;
     const parsed = AgentSyncConfigSchema.parse(withoutVersion);
     expect(parsed.version).toBe("1");
+  });
+});
+
+describe("AgePublicKeySchema", () => {
+  test("accepts a bech32-charset key with age1 prefix", () => {
+    expect(AgePublicKeySchema.safeParse("age1qpzry9x8gf2tvdw0s3jn54khce6mua7l").success).toBe(true);
+  });
+
+  test("rejects empty string", () => {
+    expect(AgePublicKeySchema.safeParse("").success).toBe(false);
+  });
+
+  test("rejects missing age1 prefix", () => {
+    expect(AgePublicKeySchema.safeParse("notage1xyz").success).toBe(false);
+  });
+
+  test("rejects uppercase letters (bech32 is case-segregated)", () => {
+    expect(AgePublicKeySchema.safeParse("age1BAD").success).toBe(false);
+  });
+
+  test("rejects characters outside the bech32 data charset", () => {
+    // 'b' is one of the four bech32-excluded letters (b/i/o/1).
+    expect(AgePublicKeySchema.safeParse("age1abc").success).toBe(false);
+  });
+
+  test("rejects whitespace around an otherwise-valid key", () => {
+    expect(AgePublicKeySchema.safeParse(" age1qpzry9 ").success).toBe(false);
   });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,9 +1,43 @@
 import { z } from "zod";
 
+/**
+ * Age public-key (X25519 recipient) format: `age1` HRP followed by the bech32
+ * data charset. Enforced everywhere a recipient enters the system so the
+ * CLI, vault config, and pulled remote state agree on what "valid" means —
+ * otherwise an invalid value only surfaces inside the age library at push
+ * time as an opaque error, after the snapshot pipeline has done work.
+ */
+export const AgePublicKeySchema = z
+  .string()
+  .regex(
+    /^age1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+$/,
+    "Invalid age public key: must start with 'age1' and contain only bech32 characters",
+  );
+
+/**
+ * Minimal sanity check for the vault's git remote URL. We do not try to
+ * fully validate every git URL form (https, ssh, git, scp-style, file)
+ * because the user-facing failure is the next `git ls-remote` / `git push`,
+ * which gives a precise message. The schema only rejects strings that
+ * obviously cannot be a URL at all (no protocol marker and no path
+ * separator), so a typo like `branch = "main"` accidentally placed in the
+ * URL field fails fast at config load.
+ */
+const RemoteUrlSchema = z
+  .string()
+  .min(1)
+  .refine((url) => /[:/]/.test(url), {
+    message: "remote.url does not look like a git URL (expected ':' or '/')",
+  });
+
 /** Schema for the vault configuration file shared by every command and test. */
 export const AgentSyncConfigSchema = z.object({
   version: z.string().default("1"),
-  recipients: z.record(z.string().min(1), z.string().min(1)),
+  recipients: z
+    .record(z.string().min(1), AgePublicKeySchema)
+    .refine((r) => Object.keys(r).length > 0, {
+      message: "recipients must contain at least one entry — run `agentsync key add` to add one",
+    }),
   agents: z.object({
     cursor: z.boolean().default(true),
     claude: z.boolean().default(true),
@@ -12,8 +46,8 @@ export const AgentSyncConfigSchema = z.object({
     vscode: z.boolean().default(false),
   }),
   remote: z.object({
-    url: z.string().min(1),
-    branch: z.string().default("main"),
+    url: RemoteUrlSchema,
+    branch: z.string().min(1).default("main"),
   }),
   sync: z.object({
     debounceMs: z.number().int().min(50).max(10_000).default(300),


### PR DESCRIPTION
## Summary

`AgentSyncConfigSchema` validated shape but not structure. Empty
`recipients` map, recipient values that don't match the age1 bech32
format, an empty `remote.branch`, and obviously non-URL `remote.url`
strings all passed `safeParse`. Failures only surfaced later inside
`encryptString`, the age library, or `git push` after the snapshot
pipeline had already done work. The only `age1` guard lived on a single
CLI argv path in `src/commands/key.ts`, so manual TOML edits, the
`init` recipients spread, and pulled vault state silently accepted
garbage. `doctor`'s schema check inherited the gaps and just dumped
`[ZodError: ...]`.

This PR moves the format checks down into the schema so every command
crossing `loadConfig` fails fast at config load with the offending field
named, instead of crashing later inside the age library or `git push`.

## Changes

- New exported `AgePublicKeySchema` Zod validator enforcing the `age1`
  HRP + bech32 data charset.
- `AgentSyncConfigSchema.recipients` now requires at least one entry
  and uses `AgePublicKeySchema` for every value, so the error names the
  offending alias key.
- `remote.branch` is now non-empty; `remote.url` rejects obviously
  non-URL strings (no `:` or `/`).
- `agentsync key add`'s `age1` guard now goes through the shared schema
  so the CLI and schema agree on what "valid" means.
- `doctor`'s schema-validity row now formats ZodError issues as
  `field: message` instead of `[ZodError: ...]`, via a new
  `formatSchemaError` helper.

## Diagram

```mermaid
graph TD
    TomlEdit["Manual edit / pulled vault / init spread"] --> LoadCfg
    KeyAdd["agentsync key add bob age1xyz"] --> CliGuard{"AgePublicKeySchema.safeParse"}
    CliGuard -- ok --> LoadCfg["loadConfig"]
    LoadCfg --> Schema{"AgentSyncConfigSchema"}
    Schema --> AgeKey{"AgePublicKeySchema per recipient"}
    AgeKey -- valid + non-empty map + branch + url --> OK["Continue: doctor / push / pull / daemon"]
    AgeKey -- invalid --> Reject["Clean reject at config load, names offending field"]
    Schema -- empty recipients / empty branch / non-URL --> Reject
    Reject -. avoids .-> OldCrash["Previously: cryptic crash at encryption or git push"]
```

## Files changed (path · one-line rationale)

- `src/config/schema.ts` · export `AgePublicKeySchema`; tighten
  `recipients` (>=1 entry + age1 charset), `remote.branch` (min 1),
  `remote.url` (minimal URL refine).
- `src/commands/key.ts` · replace ad-hoc `startsWith("age1")` with
  `AgePublicKeySchema.safeParse(pubkey)` so all `age1` checks share one
  definition.
- `src/commands/doctor.ts` · add `formatSchemaError` and use it in the
  `agentsync.toml schema` diagnostic row so the offending field is
  named.
- `src/config/__tests__/schema.test.ts` · cover empty recipients map,
  non-age1 value, invalid bech32 chars, empty branch, non-URL url;
  update existing fixtures to use a bech32-only recipient (the old
  `"age1abc"` placeholder contains a bech32-excluded letter).
- `src/commands/__tests__/doctor.test.ts` · cover `formatSchemaError`
  naming `recipients.<alias>` and `remote.branch`, plus the non-Zod
  fallback.

## Commits (sha · subject)

- `39d2ec6` · fix(config): tighten schema for recipients, branch, and remote.url

## Tests run (command · result)

- `bun run typecheck` · pass.
- `bun run lint` · pass (no errors; 8 pre-existing CSS warnings unchanged).
- `bun test src/config/__tests__/schema.test.ts` · 22/22 pass.
- `bun test src/commands/__tests__/doctor.test.ts` · 9/9 pass.
- `bun test` · 250 pass / 20 fail / 16 errors. The 20 fails + 16
  errors reproduce identically on `main` (239 pass / 20 fail / 16
  errors) and are unrelated to this PR — `node:fs/promises` named-import
  resolution problems in the pull / status / daemon / doctor entry
  harnesses. This branch adds 11 new passing tests (239 -> 250) and
  introduces no new failures.

## Verification

- Manual smoke (mental): `agentsync.toml` with `recipients = {}`,
  `recipients = { me = "notage1" }`, `recipients = { me = "age1BAD" }`,
  `branch = ""`, or `url = "not a url"` now fails at `loadConfig` with
  the offending field named, instead of surviving until
  `encryptString` (`No recipients configured for encryption`) or the
  age library's `Encrypter.addRecipient` opaque error on the next push.
- The two trust boundaries that touched `age1`-format validation —
  `key add` argv and the schema — now share one definition
  (`AgePublicKeySchema`), so adding a recipient through any path
  (manual TOML edit, `init` spreading `existing.recipients`, pulled
  vault state) is validated by the same rule.
- `doctor`'s `agentsync.toml schema` row now prints
  `Invalid: recipients.alice: <message>` instead of the prior
  `Invalid: ZodError: [...]` dump (covered by new tests in
  `src/commands/__tests__/doctor.test.ts`).

Closes #66


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation for age public keys and remote URLs; remote branch now must be non-empty (default "main").
  * Command output for configuration validation failures is clearer and highlights specific failing fields.
* **Behavior Changes**
  * Key-add now validates supplied public keys and returns a non-zero exit code on invalid input.
* **Tests**
  * Expanded test coverage for config and public-key validation cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/68)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->