### PR TITLE
feat(core): HOME path portability + paths.ts corrections + .bak/*~ never-sync (phase 1)

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -28,6 +28,10 @@ export const AgentPaths = {
     mcpJson: join(HOME, ".claude.json"),
     credentials: join(HOME, ".claude", ".credentials.json"),
     skillsDir: join(HOME, ".claude", "skills"),
+    // User-customary rules folder (~/.claude/rules/*.md). Not part of the
+    // Anthropic settings schema, but widely used to keep cross-project
+    // guidance alongside CLAUDE.md.
+    rulesDir: join(HOME, ".claude", "rules"),
     // Claude Code plugin layout (upstream: anthropics/claude-code).
     // Plugins live under ~/.claude/plugins/<name>/ and each carries a
     // .claude-plugin/plugin.json manifest plus optional commands/, agents/,
@@ -36,19 +40,33 @@ export const AgentPaths = {
     pluginsDir: join(HOME, ".claude", "plugins"),
     marketplaceJson: join(HOME, ".claude", ".claude-plugin", "marketplace.json"),
   },
-  codex: {
-    root: process.env.CODEX_HOME ?? join(HOME, ".codex"),
-    agentsMd: join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "AGENTS.md"),
-    configToml: join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "config.toml"),
-    rulesDir: join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "rules"),
-    authJson: join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "auth.json"),
-    skillsDir: join(process.env.CODEX_HOME ?? join(HOME, ".codex"), "skills"),
-  },
+  codex: (() => {
+    const CODEX_HOME = process.env.CODEX_HOME ?? join(HOME, ".codex");
+    return {
+      root: CODEX_HOME,
+      agentsMd: join(CODEX_HOME, "AGENTS.md"),
+      // Per docs: AGENTS.override.md wins over AGENTS.md when both exist.
+      agentsOverrideMd: join(CODEX_HOME, "AGENTS.override.md"),
+      configToml: join(CODEX_HOME, "config.toml"),
+      // agentsync convention, not in the official codex config reference.
+      // Kept for back-compat with existing users.
+      rulesDir: join(CODEX_HOME, "rules"),
+      authJson: join(CODEX_HOME, "auth.json"),
+      // Skill-dir precedence on read: userSkillsDir wins, skillsDir is
+      // legacy fallback for installs predating the ~/.agents/skills move.
+      skillsDir: join(CODEX_HOME, "skills"),
+      userSkillsDir: join(HOME, ".agents", "skills"),
+    };
+  })(),
   copilot: {
-    instructionsFile: join(HOME, ".copilot", "instructions"),
+    // Canonical filename per GitHub Copilot CLI docs is
+    // $HOME/.copilot/copilot-instructions.md, not bare "instructions".
+    instructionsFile: join(HOME, ".copilot", "copilot-instructions.md"),
     instructionsDir: join(HOME, ".copilot", "instructions"),
     skillsDir: join(HOME, ".copilot", "skills"),
     promptsDir: join(HOME, ".copilot", "prompts"),
+    // Copilot agents live as single ~/.copilot/agents/<name>.agent.md files,
+    // not per-agent directories.
     agentsDir: join(HOME, ".copilot", "agents"),
     vscodeMcpInSettings: (() => {
       if (PLATFORM === "darwin") {

--- a/src/core/__tests__/path-portability.test.ts
+++ b/src/core/__tests__/path-portability.test.ts
@@ -85,6 +85,12 @@ describe("path-portability — string denormalization", () => {
     expect(() => denormalizeStringFromVault(`${PLACE}/x`, "")).toThrow();
     expect(() => denormalizeFromVault({ cwd: `${PLACE}/x` }, "")).toThrow();
   });
+
+  test("home containing $ is not interpreted as a replacement pattern", () => {
+    const dollarHome = "/home/$user";
+    expect(denormalizeStringFromVault(`${PLACE}/proj`, dollarHome)).toBe(`${dollarHome}/proj`);
+    expect(denormalizeStringFromVault(`${PLACE}/$$x`, "/home/u")).toBe("/home/u/$$x");
+  });
 });
 
 describe("path-portability — JSON walker", () => {

--- a/src/core/__tests__/path-portability.test.ts
+++ b/src/core/__tests__/path-portability.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AGENTSYNC_HOME_PLACEHOLDER,
+  denormalizeFromVault,
+  denormalizeStringFromVault,
+  normalizeForVault,
+  normalizeStringForVault,
+} from "../path-portability";
+
+const ALPHA = "/home/alpha";
+const BETA = "/home/beta";
+const PLACE = AGENTSYNC_HOME_PLACEHOLDER;
+
+describe("path-portability — string normalization", () => {
+  test("rewrites literal home prefix followed by separator", () => {
+    expect(normalizeStringForVault(`${ALPHA}/.claude/cache`, ALPHA)).toBe(`${PLACE}/.claude/cache`);
+  });
+
+  test("rewrites bare literal home equal to entire string", () => {
+    expect(normalizeStringForVault(ALPHA, ALPHA)).toBe(PLACE);
+  });
+
+  test("rewrites ~ when followed by separator", () => {
+    expect(normalizeStringForVault("~/projects/x", ALPHA)).toBe(`${PLACE}/projects/x`);
+  });
+
+  test("rewrites bare ~", () => {
+    expect(normalizeStringForVault("~", ALPHA)).toBe(PLACE);
+  });
+
+  test("rewrites $HOME prefix", () => {
+    expect(normalizeStringForVault("$HOME/foo", ALPHA)).toBe(`${PLACE}/foo`);
+  });
+
+  test("rewrites ${HOME} prefix", () => {
+    expect(normalizeStringForVault("${HOME}/foo", ALPHA)).toBe(`${PLACE}/foo`);
+  });
+
+  test("rewrites home inside flag-style values", () => {
+    expect(normalizeStringForVault(`--root=${ALPHA}/proj`, ALPHA)).toBe(`--root=${PLACE}/proj`);
+  });
+
+  test("leaves unrelated absolute paths alone", () => {
+    expect(normalizeStringForVault("/etc/hosts", ALPHA)).toBe("/etc/hosts");
+    expect(normalizeStringForVault("/opt/foo", ALPHA)).toBe("/opt/foo");
+  });
+
+  test("does not rewrite when home appears as substring of larger word", () => {
+    expect(normalizeStringForVault(`${ALPHA}NOTME/foo`, ALPHA)).toBe(`${ALPHA}NOTME/foo`);
+  });
+
+  test("does not rewrite trailing-only matches without separator", () => {
+    expect(normalizeStringForVault("prefix$HOMEsuffix", ALPHA)).toBe("prefix$HOMEsuffix");
+    expect(normalizeStringForVault("prefix~suffix", ALPHA)).toBe("prefix~suffix");
+  });
+
+  test("rewrites multiple occurrences in one string", () => {
+    expect(normalizeStringForVault(`from=${ALPHA}/a to=${ALPHA}/b`, ALPHA)).toBe(
+      `from=${PLACE}/a to=${PLACE}/b`,
+    );
+  });
+
+  test("empty inputs are no-ops", () => {
+    expect(normalizeStringForVault("", ALPHA)).toBe("");
+    expect(normalizeStringForVault("anything", "")).toBe("anything");
+  });
+});
+
+describe("path-portability — string denormalization", () => {
+  test("replaces every placeholder with the current home", () => {
+    expect(denormalizeStringFromVault(`${PLACE}/proj`, BETA)).toBe(`${BETA}/proj`);
+  });
+
+  test("multiple placeholders in one string", () => {
+    expect(denormalizeStringFromVault(`a=${PLACE}/x b=${PLACE}/y`, BETA)).toBe(
+      `a=${BETA}/x b=${BETA}/y`,
+    );
+  });
+
+  test("untouched if no placeholder present", () => {
+    expect(denormalizeStringFromVault("/etc/hosts", BETA)).toBe("/etc/hosts");
+  });
+
+  test("throws on empty home — denormalize must always know HOME", () => {
+    expect(() => denormalizeStringFromVault(`${PLACE}/x`, "")).toThrow();
+    expect(() => denormalizeFromVault({ cwd: `${PLACE}/x` }, "")).toThrow();
+  });
+});
+
+describe("path-portability — JSON walker", () => {
+  test("rewrites string values inside nested objects and arrays", () => {
+    const input = {
+      mcpServers: {
+        filesystem: {
+          command: "node",
+          args: [`${ALPHA}/srv/index.js`, `--root=${ALPHA}/proj`],
+          cwd: `${ALPHA}/.cursor`,
+        },
+      },
+      misc: ["/etc/hosts", "not-a-path"],
+    };
+    const out = normalizeForVault(input, ALPHA) as typeof input;
+
+    expect(out.mcpServers.filesystem.args[0]).toBe(`${PLACE}/srv/index.js`);
+    expect(out.mcpServers.filesystem.args[1]).toBe(`--root=${PLACE}/proj`);
+    expect(out.mcpServers.filesystem.cwd).toBe(`${PLACE}/.cursor`);
+    expect(out.misc).toEqual(["/etc/hosts", "not-a-path"]);
+  });
+
+  test("non-string scalars pass through", () => {
+    const input = { n: 1, b: true, z: null };
+    const out = normalizeForVault(input, ALPHA);
+    expect(out).toEqual(input);
+  });
+
+  test("returns the same reference when no string contains home", () => {
+    const input = { a: "/etc/x", b: { c: ["one", "two"] } };
+    const out = normalizeForVault(input, ALPHA);
+    expect(out).toBe(input);
+  });
+
+  test("round-trip: normalize then denormalize is byte-identical for home-rooted paths", () => {
+    const input = {
+      filesystem: { cwd: `${ALPHA}/.cursor`, args: [`${ALPHA}/proj/file.ts`] },
+    };
+    const vaulted = normalizeForVault(input, ALPHA);
+    const restored = denormalizeFromVault(vaulted, ALPHA);
+    expect(restored).toEqual(input);
+  });
+
+  test("cross-machine round-trip rewrites alpha to beta paths", () => {
+    const input = { cwd: `${ALPHA}/.config` };
+    const vaulted = normalizeForVault(input, ALPHA);
+    const restored = denormalizeFromVault(vaulted, BETA) as typeof input;
+    expect(restored.cwd).toBe(`${BETA}/.config`);
+  });
+
+  test("empty home returns the input unchanged for normalize", () => {
+    const input = { cwd: `${ALPHA}/x` };
+    expect(normalizeForVault(input, "")).toBe(input);
+  });
+
+  test("home with trailing separator is handled the same as without", () => {
+    expect(normalizeStringForVault(`${ALPHA}/proj`, `${ALPHA}/`)).toBe(`${PLACE}/proj`);
+    expect(normalizeStringForVault(ALPHA, `${ALPHA}/`)).toBe(PLACE);
+  });
+
+  test("normalize is idempotent when input already contains the placeholder", () => {
+    const input = { cwd: `${PLACE}/x` };
+    const once = normalizeForVault(input, ALPHA);
+    const twice = normalizeForVault(once, ALPHA);
+    expect(twice).toEqual(once);
+  });
+});

--- a/src/core/path-portability.ts
+++ b/src/core/path-portability.ts
@@ -53,7 +53,10 @@ export function denormalizeStringFromVault(input: string, home: string): string 
   if (input.length === 0) {
     return input;
   }
-  return input.replaceAll(AGENTSYNC_HOME_PLACEHOLDER, home);
+  // Replacement-as-function form bypasses `$&`, `$$`, `$1` pattern
+  // interpretation, which `replaceAll(str, str)` performs. A home path
+  // containing a literal `$` would otherwise corrupt the output.
+  return input.replaceAll(AGENTSYNC_HOME_PLACEHOLDER, () => home);
 }
 
 /**

--- a/src/core/path-portability.ts
+++ b/src/core/path-portability.ts
@@ -1,0 +1,108 @@
+/**
+ * Cross-machine path portability for JSON/TOML values stored in the vault.
+ *
+ * Adapters call `normalizeForVault` at snapshot and `denormalizeFromVault`
+ * at apply. A home-prefixed string is only rewritten when followed by `/`
+ * or end-of-string, so substrings inside a larger identifier are left
+ * alone. The vendor-prefixed placeholder avoids collision with shell
+ * expansion any agent runtime might attempt on its own.
+ */
+
+export const AGENTSYNC_HOME_PLACEHOLDER = "${AGENTSYNC_HOME}";
+
+/** Escape a string for inclusion inside a RegExp body. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Build the ordered set of patterns we treat as a home-prefix. Each pattern
+ * is anchored by a no-preceding-identifier-char lookbehind and a trailing
+ * `(?=\/|$)` so partial matches inside a larger identifier never fire.
+ */
+function homePatterns(home: string): RegExp[] {
+  // Trim a trailing separator so the lookahead works whether the caller
+  // passes "/Users/x" or "/Users/x/".
+  const trimmed = home.replace(/\/+$/, "");
+  const escapedHome = escapeRegExp(trimmed);
+  return [
+    /(?<![A-Za-z0-9_])\$\{HOME\}(?=\/|$)/g,
+    /(?<![A-Za-z0-9_])\$HOME(?=\/|$)/g,
+    /(?<![A-Za-z0-9_~])~(?=\/|$)/g,
+    new RegExp(`(?<![A-Za-z0-9_])${escapedHome}(?=\\/|$)`, "g"),
+  ];
+}
+
+/** Rewrite every recognizable home prefix in `input` to the placeholder. */
+export function normalizeStringForVault(input: string, home: string): string {
+  if (input.length === 0 || home.length === 0) {
+    return input;
+  }
+  let out = input;
+  for (const pattern of homePatterns(home)) {
+    out = out.replace(pattern, AGENTSYNC_HOME_PLACEHOLDER);
+  }
+  return out;
+}
+
+/** Re-expand the placeholder back to the current machine's home directory. */
+export function denormalizeStringFromVault(input: string, home: string): string {
+  if (home.length === 0) {
+    throw new Error("denormalizeStringFromVault requires a non-empty home");
+  }
+  if (input.length === 0) {
+    return input;
+  }
+  return input.replaceAll(AGENTSYNC_HOME_PLACEHOLDER, home);
+}
+
+/**
+ * Recursively walk a JSON-like value and apply `transform` to every string.
+ * Returns the same reference when nothing changes so callers can cheaply
+ * detect no-op transforms.
+ */
+function walk(value: unknown, transform: (s: string) => string): unknown {
+  if (typeof value === "string") {
+    return transform(value);
+  }
+  if (Array.isArray(value)) {
+    let mutated = false;
+    const out = value.map((item) => {
+      const next = walk(item, transform);
+      if (next !== item) {
+        mutated = true;
+      }
+      return next;
+    });
+    return mutated ? out : value;
+  }
+  if (value !== null && typeof value === "object") {
+    let mutated = false;
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      const next = walk(item, transform);
+      if (next !== item) {
+        mutated = true;
+      }
+      out[key] = next;
+    }
+    return mutated ? out : value;
+  }
+  return value;
+}
+
+/** Normalize every home-prefixed string inside a JSON-like value. */
+export function normalizeForVault(value: unknown, home: string): unknown {
+  if (home.length === 0) {
+    return value;
+  }
+  return walk(value, (s) => normalizeStringForVault(s, home));
+}
+
+/** Denormalize every placeholder back to the current machine's home. */
+export function denormalizeFromVault(value: unknown, home: string): unknown {
+  if (home.length === 0) {
+    throw new Error("denormalizeFromVault requires a non-empty home");
+  }
+  return walk(value, (s) => denormalizeStringFromVault(s, home));
+}

--- a/src/core/sanitizer.ts
+++ b/src/core/sanitizer.ts
@@ -11,6 +11,11 @@ export const NEVER_SYNC_PATTERNS = [
   "**/.claude/settings.local.json",
   "**/agentsync.toml",
   "**/*.age",
+  // Pull writes ".bak" beside overwritten files. Without this exclusion the
+  // next push would carry stale backup copies back into the vault. Editor
+  // tilde-suffix temp files are the same risk class.
+  "**/*.bak",
+  "**/*~",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Phase 1 of the e2e bug-bash. Lands the foundation primitives and path constants. Adapter wiring and the 20-scenario harness are tracked in #70 and #71 respectively.

## What changes

**`src/core/path-portability.ts` (new, B24)** — cross-machine HOME path normalization for JSON/TOML values that adapters will plug into on snapshot/apply (in #70). Conservative match: home must be followed by `/` or end-of-string, so `prefix~suffix` and `/Users/xNOTME/y` are left verbatim. Tolerates trailing separator on `home`. Throws on empty home at denormalize. Exports `normalizeForVault`, `denormalizeFromVault`, `normalizeStringForVault`, `denormalizeStringFromVault`, `AGENTSYNC_HOME_PLACEHOLDER`.

**`src/config/paths.ts` (modified)** — five path constants added or renamed, each addressing a bug-bash finding cross-checked against official docs:

| Change | Bug | Source |
| --- | --- | --- |
| `claude.rulesDir = ~/.claude/rules` | B19 | user convention |
| `codex.agentsOverrideMd` | B17 | [Codex AGENTS guide](https://developers.openai.com/codex/guides/agents-md) |
| `codex.userSkillsDir = ~/.agents/skills` | B22 | [Codex Skills](https://developers.openai.com/codex/skills) scope table |
| `codex.skillsDir` retained as legacy fallback with precedence comment | B22 | back-compat |
| `copilot.instructionsFile = ~/.copilot/copilot-instructions.md` | B16 | [Copilot CLI instructions docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions) |

Also hoists a local `CODEX_HOME` const inside `AgentPaths.codex` to remove the 5x repeated `process.env.CODEX_HOME ?? join(HOME, ".codex")` expression (senior-review finding).

**`src/core/sanitizer.ts` (modified, B21)** — `**/*.bak` and `**/*~` added to `NEVER_SYNC_PATTERNS`. Pull writes `.bak` beside overwritten files; without this exclusion the next push would carry stale backups back into the vault. Editor tilde-suffix files share the same risk class.

## What this PR is NOT

This PR deliberately stops short of wiring the new primitives into adapters. The reasoning is that adapter wiring + the e2e fixture rebuild + 20 scenarios is roughly two more weeks of work that warrants its own PRs against the issues below.

- #70 — `src` adapter completion (B15, B17, B19, B22, B24 wiring)
- #71 — e2e bug-bash harness (fixture tree, scenarios 1–20, runtime/CI bump)

Senior-review pass on this PR applied 7 fixes before commit: trailing-slash home tolerance, idempotency test, dropped duplicated `PLACEHOLDER` const, `denormalize` empty-home guard, hoisted `CODEX_HOME`, tightened module doc, skill-dir precedence comment.

## Test plan

- [x] `bun test src/core/__tests__/path-portability.test.ts` → 24 pass (100% function, 98.51% line)
- [x] `bun test src/core/__tests__/ src/config/` → 160 pass overall
- [x] `bun run typecheck` → clean
- [x] `bunx biome check` on changed files → no errors after auto-fix
- [ ] `bun run check` — pre-existing failures in `site/research` SVG accessibility errors unrelated to this PR; will be addressed separately

## Bug-bash plan

Full plan and remaining 20 bug-bash IDs live in #70 (src adapter wiring) and #71 (e2e harness). This PR closes none on its own — it is foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-machine path portability for syncing configuration and settings, plus updated agent-related path mappings (including copilot instructions filename and new user rules/skills locations).

* **Tests**
  * Added comprehensive tests validating path normalization/denormalization and recursive vault transformations.

* **Chores**
  * Enhanced vault protection by excluding editor backup and temporary files from synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/72)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->