### PR TITLE
feat(agents): wire HOME path portability + B15/B17/B19/B22 adapter fixes (#70)

### DIFF
--- a/src/agents/__tests__/claude.test.ts
+++ b/src/agents/__tests__/claude.test.ts
@@ -4,6 +4,7 @@ import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
+import { AGENTSYNC_HOME_PLACEHOLDER } from "../../core/path-portability";
 import { archiveDirectory, extractArchive } from "../../core/tar";
 import { createTmpDir } from "../../test-helpers/fixtures";
 
@@ -18,6 +19,7 @@ type MutableClaudePaths = {
   settingsJson: string;
   commandsDir: string;
   agentsDir: string;
+  rulesDir: string;
   mcpJson: string;
   credentials: string;
   skillsDir: string;
@@ -58,6 +60,7 @@ describe("snapshotClaude", () => {
     testClaudePaths.settingsJson = join(tmpDir, "settings.json");
     testClaudePaths.commandsDir = join(tmpDir, "commands");
     testClaudePaths.agentsDir = join(tmpDir, "agents");
+    testClaudePaths.rulesDir = join(tmpDir, "rules");
     testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
     testClaudePaths.credentials = join(tmpDir, ".credentials.json");
     testClaudePaths.skillsDir = join(tmpDir, "skills");
@@ -258,6 +261,7 @@ describe("apply* functions", () => {
     testClaudePaths.settingsJson = join(tmpDir, "settings.json");
     testClaudePaths.commandsDir = join(tmpDir, "commands");
     testClaudePaths.agentsDir = join(tmpDir, "agents");
+    testClaudePaths.rulesDir = join(tmpDir, "rules");
     testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
     testClaudePaths.credentials = join(tmpDir, ".credentials.json");
     testClaudePaths.skillsDir = join(tmpDir, "skills");
@@ -510,6 +514,7 @@ describe("Claude plugin sync", () => {
     testClaudePaths.settingsJson = join(tmpDir, "settings.json");
     testClaudePaths.commandsDir = join(tmpDir, "commands");
     testClaudePaths.agentsDir = join(tmpDir, "agents");
+    testClaudePaths.rulesDir = join(tmpDir, "rules");
     testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
     testClaudePaths.credentials = join(tmpDir, ".credentials.json");
     testClaudePaths.skillsDir = join(tmpDir, "skills");
@@ -767,5 +772,123 @@ describe("Claude plugin sync", () => {
 
     await claudeModule.applyClaudeVault(vaultDir, identity, false, { syncMarketplace: true });
     expect(await Bun.file(testClaudePaths.marketplaceJson).exists()).toBeTrue();
+  });
+});
+
+describe("Claude rules sync (B19)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    testClaudePaths.claudeMd = join(tmpDir, "CLAUDE.md");
+    testClaudePaths.settingsJson = join(tmpDir, "settings.json");
+    testClaudePaths.commandsDir = join(tmpDir, "commands");
+    testClaudePaths.agentsDir = join(tmpDir, "agents");
+    testClaudePaths.rulesDir = join(tmpDir, "rules");
+    testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
+    testClaudePaths.credentials = join(tmpDir, ".credentials.json");
+    testClaudePaths.skillsDir = join(tmpDir, "skills");
+    testClaudePaths.pluginsDir = join(tmpDir, "plugins");
+    testClaudePaths.marketplaceJson = join(tmpDir, ".claude-plugin", "marketplace.json");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("snapshotClaude collects each *.md under rulesDir as its own artifact", async () => {
+    await mkdir(testClaudePaths.rulesDir, { recursive: true });
+    await writeFile(join(testClaudePaths.rulesDir, "style.md"), "# style", "utf8");
+    await writeFile(join(testClaudePaths.rulesDir, "review.md"), "# review", "utf8");
+    // non-markdown should be ignored
+    await writeFile(join(testClaudePaths.rulesDir, "notes.txt"), "txt", "utf8");
+
+    const result = await claudeModule.snapshotClaude();
+    const ruleArts = result.artifacts.filter((a) => a.vaultPath.startsWith("claude/rules/"));
+    expect(ruleArts.map((a) => a.vaultPath).sort()).toEqual([
+      "claude/rules/review.md.age",
+      "claude/rules/style.md.age",
+    ]);
+    expect(ruleArts.find((a) => a.vaultPath === "claude/rules/style.md.age")?.plaintext).toBe(
+      "# style",
+    );
+  });
+
+  test("applyClaudeRule writes a rule markdown file under rulesDir", async () => {
+    await claudeModule.applyClaudeRule("coding-style.md", "# coding style");
+    const written = await Bun.file(join(testClaudePaths.rulesDir, "coding-style.md")).text();
+    expect(written).toBe("# coding style");
+  });
+
+  test("applyClaudeVault dispatches claude/rules/*.md.age to applyClaudeRule", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+    const vaultDir = join(tmpDir, "vault");
+    await mkdir(join(vaultDir, "claude", "rules"), { recursive: true });
+    const enc = await encryptString("# round-trip rule", [recipient]);
+    await writeFile(join(vaultDir, "claude", "rules", "rt.md.age"), enc, "utf8");
+
+    await claudeModule.applyClaudeVault(vaultDir, identity, false);
+
+    const restored = await Bun.file(join(testClaudePaths.rulesDir, "rt.md")).text();
+    expect(restored).toBe("# round-trip rule");
+  });
+});
+
+describe("Claude HOME path portability wiring (B24)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    testClaudePaths.claudeMd = join(tmpDir, "CLAUDE.md");
+    testClaudePaths.settingsJson = join(tmpDir, "settings.json");
+    testClaudePaths.commandsDir = join(tmpDir, "commands");
+    testClaudePaths.agentsDir = join(tmpDir, "agents");
+    testClaudePaths.rulesDir = join(tmpDir, "rules");
+    testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
+    testClaudePaths.credentials = join(tmpDir, ".credentials.json");
+    testClaudePaths.skillsDir = join(tmpDir, "skills");
+    testClaudePaths.pluginsDir = join(tmpDir, "plugins");
+    testClaudePaths.marketplaceJson = join(tmpDir, ".claude-plugin", "marketplace.json");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("applyClaudeMcp denormalizes the AGENTSYNC_HOME placeholder", async () => {
+    const { homedir } = await import("node:os");
+    const incoming = JSON.stringify({
+      mcpServers: { fs: { command: "node", cwd: `${AGENTSYNC_HOME_PLACEHOLDER}/proj` } },
+    });
+    await claudeModule.applyClaudeMcp(incoming);
+    const written = JSON.parse(await Bun.file(testClaudePaths.mcpJson).text()) as {
+      mcpServers: { fs: { cwd: string } };
+    };
+    expect(written.mcpServers.fs.cwd).toBe(`${homedir()}/proj`);
+  });
+
+  test("applyClaudeHooks denormalizes only the synced subset and preserves local keys", async () => {
+    const { homedir } = await import("node:os");
+    await writeFile(
+      testClaudePaths.settingsJson,
+      JSON.stringify({ theme: "dark", permissions: { allow: ["x"] } }),
+      "utf8",
+    );
+    const incoming = JSON.stringify({
+      hooks: { PreToolUse: [{ command: `${AGENTSYNC_HOME_PLACEHOLDER}/.claude/runner` }] },
+    });
+    await claudeModule.applyClaudeHooks(incoming);
+    const written = JSON.parse(await Bun.file(testClaudePaths.settingsJson).text()) as {
+      theme: string;
+      permissions: { allow: string[] };
+      hooks: { PreToolUse: { command: string }[] };
+    };
+    expect(written.theme).toBe("dark");
+    expect(written.permissions.allow).toEqual(["x"]);
+    expect(written.hooks.PreToolUse[0]?.command).toBe(`${homedir()}/.claude/runner`);
   });
 });

--- a/src/agents/__tests__/claude.test.ts
+++ b/src/agents/__tests__/claude.test.ts
@@ -775,6 +775,71 @@ describe("Claude plugin sync", () => {
   });
 });
 
+describe("Claude plugin hook HOME portability (B24)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    testClaudePaths.claudeMd = join(tmpDir, "CLAUDE.md");
+    testClaudePaths.settingsJson = join(tmpDir, "settings.json");
+    testClaudePaths.commandsDir = join(tmpDir, "commands");
+    testClaudePaths.agentsDir = join(tmpDir, "agents");
+    testClaudePaths.rulesDir = join(tmpDir, "rules");
+    testClaudePaths.mcpJson = join(tmpDir, ".claude.json");
+    testClaudePaths.credentials = join(tmpDir, ".credentials.json");
+    testClaudePaths.skillsDir = join(tmpDir, "skills");
+    testClaudePaths.pluginsDir = join(tmpDir, "plugins");
+    testClaudePaths.marketplaceJson = join(tmpDir, ".claude-plugin", "marketplace.json");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("snapshot rewrites home-rooted paths inside plugin hook JSONs", async () => {
+    const { homedir } = await import("node:os");
+    const home = homedir();
+    const root = join(testClaudePaths.pluginsDir, "hooky-plugin");
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "hooky-plugin", version: "1.0.0" }),
+      "utf8",
+    );
+    mkdirSync(join(root, "hooks"), { recursive: true });
+    writeFileSync(
+      join(root, "hooks", "pre-commit.json"),
+      JSON.stringify({ command: `${home}/.claude/runner.sh`, cwd: `${home}/proj` }),
+      "utf8",
+    );
+
+    const result = await claudeModule.snapshotClaude();
+    const hook = result.artifacts.find(
+      (a) => a.vaultPath === "claude/plugins/hooky-plugin/hooks/pre-commit.json.age",
+    );
+    expect(hook).toBeDefined();
+    expect(hook?.plaintext).toContain(`${AGENTSYNC_HOME_PLACEHOLDER}/.claude/runner.sh`);
+    expect(hook?.plaintext).toContain(`${AGENTSYNC_HOME_PLACEHOLDER}/proj`);
+    expect(hook?.plaintext).not.toContain(home);
+  });
+
+  test("applyClaudePluginHook denormalizes placeholders to this machine's home", async () => {
+    const { homedir } = await import("node:os");
+    const home = homedir();
+    const incoming = `${JSON.stringify(
+      { command: `${AGENTSYNC_HOME_PLACEHOLDER}/.claude/runner.sh` },
+      null,
+      2,
+    )}\n`;
+    await claudeModule.applyClaudePluginHook("hooky", "pre-commit.json", incoming);
+    const written = await Bun.file(
+      join(testClaudePaths.pluginsDir, "hooky", "hooks", "pre-commit.json"),
+    ).text();
+    expect(written).toContain(`${home}/.claude/runner.sh`);
+    expect(written).not.toContain("AGENTSYNC_HOME");
+  });
+});
+
 describe("Claude rules sync (B19)", () => {
   let tmpDir: string;
 
@@ -818,6 +883,19 @@ describe("Claude rules sync (B19)", () => {
     await claudeModule.applyClaudeRule("coding-style.md", "# coding style");
     const written = await Bun.file(join(testClaudePaths.rulesDir, "coding-style.md")).text();
     expect(written).toBe("# coding style");
+  });
+
+  test("snapshot refuses to follow a symlinked rule file", async () => {
+    await mkdir(testClaudePaths.rulesDir, { recursive: true });
+    const external = join(tmpDir, "secret-outside-rulesDir.md");
+    await writeFile(external, "SHOULD-NEVER-LEAK", "utf8");
+    symlinkSync(external, join(testClaudePaths.rulesDir, "linked.md"));
+
+    const result = await claudeModule.snapshotClaude();
+    const ruleArts = result.artifacts.filter((a) => a.vaultPath.startsWith("claude/rules/"));
+    expect(ruleArts).toHaveLength(0);
+    // Belt and braces: the leaked content must not appear in any artifact.
+    expect(result.artifacts.every((a) => !a.plaintext.includes("SHOULD-NEVER-LEAK"))).toBe(true);
   });
 
   test("applyClaudeVault dispatches claude/rules/*.md.age to applyClaudeRule", async () => {

--- a/src/agents/__tests__/codex.test.ts
+++ b/src/agents/__tests__/codex.test.ts
@@ -4,6 +4,7 @@ import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
+import { AGENTSYNC_HOME_PLACEHOLDER } from "../../core/path-portability";
 import { archiveDirectory, extractArchive } from "../../core/tar";
 import { createTmpDir } from "../../test-helpers/fixtures";
 
@@ -16,10 +17,12 @@ import { createTmpDir } from "../../test-helpers/fixtures";
 type MutableCodexPaths = {
   root: string;
   agentsMd: string;
+  agentsOverrideMd: string;
   configToml: string;
   rulesDir: string;
   authJson: string;
   skillsDir: string;
+  userSkillsDir: string;
 };
 
 const testCodexPaths = AgentPaths.codex as MutableCodexPaths;
@@ -49,10 +52,12 @@ describe("snapshotCodex", () => {
     tmpDir = await createTmpDir();
     testCodexPaths.root = tmpDir;
     testCodexPaths.agentsMd = join(tmpDir, "AGENTS.md");
+    testCodexPaths.agentsOverrideMd = join(tmpDir, "AGENTS.override.md");
     testCodexPaths.configToml = join(tmpDir, "config.toml");
     testCodexPaths.rulesDir = join(tmpDir, "rules");
     testCodexPaths.authJson = join(tmpDir, "auth.json");
     testCodexPaths.skillsDir = join(tmpDir, "skills");
+    testCodexPaths.userSkillsDir = join(tmpDir, "user-skills");
   });
 
   afterEach(async () => {
@@ -193,10 +198,12 @@ describe("apply* functions", () => {
     tmpDir = await createTmpDir();
     testCodexPaths.root = tmpDir;
     testCodexPaths.agentsMd = join(tmpDir, "AGENTS.md");
+    testCodexPaths.agentsOverrideMd = join(tmpDir, "AGENTS.override.md");
     testCodexPaths.configToml = join(tmpDir, "config.toml");
     testCodexPaths.rulesDir = join(tmpDir, "rules");
     testCodexPaths.authJson = join(tmpDir, "auth.json");
     testCodexPaths.skillsDir = join(tmpDir, "skills");
+    testCodexPaths.userSkillsDir = join(tmpDir, "user-skills");
   });
 
   afterEach(async () => {
@@ -233,7 +240,7 @@ describe("apply* functions", () => {
 
   // applyCodexSkill direct extraction test
 
-  test("applyCodexSkill extracts a tar archive into the local skills dir", async () => {
+  test("applyCodexSkill extracts a tar archive into the user skills dir", async () => {
     const srcSkill = join(tmpDir, "src-skill");
     mkdirSync(srcSkill, { recursive: true });
     writeFileSync(join(srcSkill, "SKILL.md"), "# codex skill body", "utf8");
@@ -244,7 +251,7 @@ describe("apply* functions", () => {
 
     await codexModule.applyCodexSkill("my-skill", base64);
 
-    const targetSkillDir = join(testCodexPaths.skillsDir, "my-skill");
+    const targetSkillDir = join(testCodexPaths.userSkillsDir, "my-skill");
     const skillMd = await Bun.file(join(targetSkillDir, "SKILL.md")).text();
     const extra = await Bun.file(join(targetSkillDir, "extra.md")).text();
     expect(skillMd).toBe("# codex skill body");
@@ -265,6 +272,7 @@ describe("applyCodexVault dryRun", () => {
     testCodexPaths.rulesDir = join(tmpDir, "apply", "rules");
     testCodexPaths.authJson = join(tmpDir, "apply", "auth.json");
     testCodexPaths.skillsDir = join(tmpDir, "apply", "skills");
+    testCodexPaths.userSkillsDir = join(tmpDir, "apply", "user-skills");
   });
 
   afterEach(async () => {
@@ -315,7 +323,7 @@ describe("applyCodexVault dryRun", () => {
 
     await codexModule.applyCodexVault(vaultDir, identity, false);
 
-    const restoredSkillDir = join(testCodexPaths.skillsDir, "round-trip-skill");
+    const restoredSkillDir = join(testCodexPaths.userSkillsDir, "round-trip-skill");
     const restoredSkill = await Bun.file(join(restoredSkillDir, "SKILL.md")).text();
     const restoredGuide = await Bun.file(join(restoredSkillDir, "guide.md")).text();
     expect(restoredSkill).toBe("# codex round trip");
@@ -346,7 +354,7 @@ describe("applyCodexVault dryRun", () => {
 
     await codexModule.applyCodexVault(vaultDir, identity, true);
 
-    const restoredSkillDir = join(testCodexPaths.skillsDir, "dry-run-skill");
+    const restoredSkillDir = join(testCodexPaths.userSkillsDir, "dry-run-skill");
     const exists = await Bun.file(join(restoredSkillDir, "SKILL.md")).exists();
     expect(exists).toBeFalse();
   });
@@ -384,8 +392,191 @@ describe("applyCodexVault dryRun", () => {
 
     await codexModule.applyCodexVault(vaultDir, identity, false);
 
-    const escapedPayload = join(testCodexPaths.skillsDir, "..", "AGENTS.md");
+    const escapedPayload = join(testCodexPaths.userSkillsDir, "..", "AGENTS.md");
     const leakedExists = await Bun.file(escapedPayload).exists();
     expect(leakedExists).toBeFalse();
+  });
+});
+
+describe("Codex config.toml HOME path portability wiring (B24)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    testCodexPaths.root = tmpDir;
+    testCodexPaths.agentsMd = join(tmpDir, "AGENTS.md");
+    testCodexPaths.agentsOverrideMd = join(tmpDir, "AGENTS.override.md");
+    testCodexPaths.configToml = join(tmpDir, "config.toml");
+    testCodexPaths.rulesDir = join(tmpDir, "rules");
+    testCodexPaths.authJson = join(tmpDir, "auth.json");
+    testCodexPaths.skillsDir = join(tmpDir, "skills");
+    testCodexPaths.userSkillsDir = join(tmpDir, "user-skills");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("snapshotCodex rewrites home-rooted TOML values to placeholder", async () => {
+    const { homedir } = await import("node:os");
+    const home = homedir();
+    await writeFile(
+      testCodexPaths.configToml,
+      `model = "gpt-4"\ninstructions_file = "${home}/.codex/system.md"\n`,
+      "utf8",
+    );
+
+    const result = await codexModule.snapshotCodex();
+    const art = result.artifacts.find((a) => a.vaultPath === "codex/config.toml.age");
+    expect(art).toBeDefined();
+    expect(art?.plaintext).toContain(`${AGENTSYNC_HOME_PLACEHOLDER}/.codex/system.md`);
+    expect(art?.plaintext).not.toContain(home);
+  });
+
+  test("applyCodexConfig restores placeholders to this machine's home", async () => {
+    const { homedir } = await import("node:os");
+    const home = homedir();
+    const incoming = `model = "gpt-4"\ninstructions_file = "${AGENTSYNC_HOME_PLACEHOLDER}/.codex/system.md"\n`;
+    await codexModule.applyCodexConfig(incoming);
+    const written = await Bun.file(testCodexPaths.configToml).text();
+    expect(written).toContain(`${home}/.codex/system.md`);
+    expect(written).not.toContain("AGENTSYNC_HOME");
+  });
+});
+
+describe("Codex AGENTS.override.md precedence (B17)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    testCodexPaths.root = tmpDir;
+    testCodexPaths.agentsMd = join(tmpDir, "AGENTS.md");
+    testCodexPaths.agentsOverrideMd = join(tmpDir, "AGENTS.override.md");
+    testCodexPaths.configToml = join(tmpDir, "config.toml");
+    testCodexPaths.rulesDir = join(tmpDir, "rules");
+    testCodexPaths.authJson = join(tmpDir, "auth.json");
+    testCodexPaths.skillsDir = join(tmpDir, "skills");
+    testCodexPaths.userSkillsDir = join(tmpDir, "user-skills");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("snapshots AGENTS.override.md alongside AGENTS.md when both exist", async () => {
+    await writeFile(testCodexPaths.agentsMd, "# base", "utf8");
+    await writeFile(testCodexPaths.agentsOverrideMd, "# override wins", "utf8");
+
+    const result = await codexModule.snapshotCodex();
+    const base = result.artifacts.find((a) => a.vaultPath === "codex/AGENTS.md.age");
+    const override = result.artifacts.find((a) => a.vaultPath === "codex/AGENTS.override.md.age");
+    expect(base?.plaintext).toBe("# base");
+    expect(override?.plaintext).toBe("# override wins");
+  });
+
+  test("applyCodexVault restores both AGENTS.md and AGENTS.override.md", async () => {
+    const { generateIdentity, identityToRecipient, encryptString } = await import(
+      "../../core/encryptor"
+    );
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const vaultDir = join(tmpDir, "vault");
+    await mkdir(join(vaultDir, "codex"), { recursive: true });
+    await writeFile(
+      join(vaultDir, "codex", "AGENTS.md.age"),
+      await encryptString("# base", [recipient]),
+      "utf8",
+    );
+    await writeFile(
+      join(vaultDir, "codex", "AGENTS.override.md.age"),
+      await encryptString("# override wins", [recipient]),
+      "utf8",
+    );
+
+    await codexModule.applyCodexVault(vaultDir, identity, false);
+
+    expect(await Bun.file(testCodexPaths.agentsMd).text()).toBe("# base");
+    expect(await Bun.file(testCodexPaths.agentsOverrideMd).text()).toBe("# override wins");
+  });
+});
+
+describe("Codex skills at $HOME/.agents/skills (B22)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    testCodexPaths.root = tmpDir;
+    testCodexPaths.agentsMd = join(tmpDir, "AGENTS.md");
+    testCodexPaths.agentsOverrideMd = join(tmpDir, "AGENTS.override.md");
+    testCodexPaths.configToml = join(tmpDir, "config.toml");
+    testCodexPaths.rulesDir = join(tmpDir, "rules");
+    testCodexPaths.authJson = join(tmpDir, "auth.json");
+    testCodexPaths.skillsDir = join(tmpDir, "skills"); // legacy
+    testCodexPaths.userSkillsDir = join(tmpDir, "user-skills"); // canonical
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("snapshot reads skills from the canonical userSkillsDir", async () => {
+    const skillDir = join(testCodexPaths.userSkillsDir, "sql-formatter");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# sql formatter", "utf8");
+
+    const result = await codexModule.snapshotCodex();
+    const art = result.artifacts.find((a) => a.vaultPath === "codex/skills/sql-formatter.tar.age");
+    expect(art).toBeDefined();
+  });
+
+  test("snapshot also reads skills from the legacy skillsDir as fallback", async () => {
+    const legacySkill = join(testCodexPaths.skillsDir, "legacy-fmt");
+    mkdirSync(legacySkill, { recursive: true });
+    writeFileSync(join(legacySkill, "SKILL.md"), "# legacy", "utf8");
+
+    const result = await codexModule.snapshotCodex();
+    const art = result.artifacts.find((a) => a.vaultPath === "codex/skills/legacy-fmt.tar.age");
+    expect(art).toBeDefined();
+  });
+
+  test("rejected canonical skill blocks the legacy copy from leaking through", async () => {
+    // Canonical version is poisoned — contains an auth.json (never-sync hit
+    // inside the bundle). The walker rejects it. The legacy copy is clean.
+    // Without dedup-by-disk, the legacy clean copy would slip into the vault
+    // and apply would silently restore a skill that the canonical user
+    // explicitly intended to keep local-only.
+    const canonical = join(testCodexPaths.userSkillsDir, "poisoned");
+    const legacy = join(testCodexPaths.skillsDir, "poisoned");
+    mkdirSync(canonical, { recursive: true });
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(canonical, "SKILL.md"), "# poisoned", "utf8");
+    writeFileSync(join(canonical, "auth.json"), '{"x":1}', "utf8");
+    writeFileSync(join(legacy, "SKILL.md"), "# legacy clean copy", "utf8");
+
+    const result = await codexModule.snapshotCodex();
+    const arts = result.artifacts.filter((a) => a.vaultPath === "codex/skills/poisoned.tar.age");
+    expect(arts).toHaveLength(0);
+    expect(result.warnings.some((w) => w.startsWith("never-sync inside skill"))).toBe(true);
+  });
+
+  test("when a skill exists in both locations, the canonical one wins", async () => {
+    const canonical = join(testCodexPaths.userSkillsDir, "dup");
+    const legacy = join(testCodexPaths.skillsDir, "dup");
+    mkdirSync(canonical, { recursive: true });
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(canonical, "SKILL.md"), "# canonical body", "utf8");
+    writeFileSync(join(legacy, "SKILL.md"), "# legacy body", "utf8");
+
+    const result = await codexModule.snapshotCodex();
+    const arts = result.artifacts.filter((a) => a.vaultPath === "codex/skills/dup.tar.age");
+    expect(arts).toHaveLength(1);
+    // Decode the tar payload and verify it carries the canonical body, not the legacy one.
+    const tarBuf = Buffer.from(arts[0]?.plaintext ?? "", "base64");
+    const outDir = join(tmpDir, "extract-dup");
+    mkdirSync(outDir, { recursive: true });
+    await extractArchive(tarBuf, outDir);
+    const body = await Bun.file(join(outDir, "SKILL.md")).text();
+    expect(body).toBe("# canonical body");
   });
 });

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -130,82 +130,33 @@ describe("snapshotCopilot", () => {
     expect(art?.plaintext).toBe("# Top-level");
   });
 
-  test("snapshots agents directories as base64 tar archives", async () => {
-    const agentDir = join(testCopilotPaths.agentsDir, "my-copilot-agent");
-    mkdirSync(agentDir, { recursive: true });
-    writeFileSync(join(agentDir, "agent.md"), "# Agent", "utf8");
+  test("snapshots .agent.md files as plaintext artifacts", async () => {
+    mkdirSync(testCopilotPaths.agentsDir, { recursive: true });
+    writeFileSync(join(testCopilotPaths.agentsDir, "my-copilot-agent.agent.md"), "# Agent", "utf8");
 
     const result = await copilotModule.snapshotCopilot();
     const art = result.artifacts.find(
-      (a) => a.vaultPath === "copilot/agents/my-copilot-agent.tar.age",
+      (a) => a.vaultPath === "copilot/agents/my-copilot-agent.agent.md.age",
     );
     expect(art).toBeDefined();
-    // biome-ignore lint/style/noNonNullAssertion: asserted by toBeDefined above
-    expect(() => Buffer.from(art!.plaintext, "base64")).not.toThrow();
+    expect(art?.plaintext).toBe("# Agent");
   });
 
-  // Per-file secret scan on the agents walk. The central scan in
-  // `commands/push.ts` skips `.tar.age` artifacts, so a key pasted into an
-  // agent's markdown body would slip through unless the walk-side scan
-  // catches it. The Copilot agents walk does NOT delegate to the shared
-  // skills walker, so this coverage is independent of the skill tests above.
-
-  test("agent dir with a literal Anthropic key in markdown body is rejected", async () => {
-    const agentDir = join(testCopilotPaths.agentsDir, "leaky-agent");
-    mkdirSync(agentDir, { recursive: true });
-    const fakeKey = `sk-ant-api03-${"C".repeat(48)}`;
-    const leak = join(agentDir, "agent.md");
-    writeFileSync(leak, `# leaky\n\ntoken: ${fakeKey}\n`, "utf8");
+  test("ignores files in agents dir that lack the .agent.md suffix", async () => {
+    mkdirSync(testCopilotPaths.agentsDir, { recursive: true });
+    writeFileSync(join(testCopilotPaths.agentsDir, "notes.md"), "# notes", "utf8");
+    writeFileSync(join(testCopilotPaths.agentsDir, "stray.txt"), "stray", "utf8");
 
     const result = await copilotModule.snapshotCopilot();
-    const art = result.artifacts.find((a) => a.vaultPath === "copilot/agents/leaky-agent.tar.age");
-    expect(art).toBeUndefined();
-
-    const offending = result.warnings.find((w) => w.startsWith("Detected literal secret"));
-    expect(offending).toBeDefined();
-    expect(offending).toContain("anthropic-api-key");
-    expect(offending).toContain(leak);
+    const arts = result.artifacts.filter((a) => a.vaultPath.startsWith("copilot/agents/"));
+    expect(arts).toHaveLength(0);
   });
 
-  // Never-sync path hit inside an agent dir. The agents walk consumes the
-  // same collectInteriorViolations helper as the skills walker, so a file
-  // matching NEVER_SYNC_PATTERNS (auth.json, .credentials.json, history.jsonl,
-  // sessions/**, *.local.md, …) anywhere inside the agent must drop the
-  // artifact and emit the `never-sync inside skill: …` warning that
-  // performPush escalates to a fatal abort. Without this gate the agent
-  // would be archived with `archiveDirectory(agentDir)` and the credential
-  // would ship to the vault.
-  test("agent dir containing a never-sync file (auth.json) is rejected", async () => {
-    const agentDir = join(testCopilotPaths.agentsDir, "leaky-auth-agent");
-    mkdirSync(agentDir, { recursive: true });
-    writeFileSync(join(agentDir, "agent.md"), "# agent\n", "utf8");
-    const authFile = join(agentDir, "auth.json");
-    writeFileSync(authFile, '{"token":"secret"}', "utf8");
-
-    const result = await copilotModule.snapshotCopilot();
-    const art = result.artifacts.find(
-      (a) => a.vaultPath === "copilot/agents/leaky-auth-agent.tar.age",
-    );
-    expect(art).toBeUndefined();
-
-    const neverSync = result.warnings.find((w) => w.startsWith("never-sync inside skill: "));
-    expect(neverSync).toBeDefined();
-    expect(neverSync).toContain(authFile);
-  });
-
-  test("clean agent dir still produces a single .tar.age artifact", async () => {
-    const agentDir = join(testCopilotPaths.agentsDir, "clean-agent");
-    mkdirSync(agentDir, { recursive: true });
-    writeFileSync(join(agentDir, "agent.md"), "# clean prose, no keys here\n", "utf8");
-    writeFileSync(join(agentDir, "notes.md"), "# also clean\n", "utf8");
-
-    const result = await copilotModule.snapshotCopilot();
-    const arts = result.artifacts.filter(
-      (a) => a.vaultPath === "copilot/agents/clean-agent.tar.age",
-    );
-    expect(arts).toHaveLength(1);
-    expect(result.warnings.filter((w) => w.startsWith("Detected literal secret"))).toHaveLength(0);
-  });
+  // Copilot agents are single .agent.md files per the GitHub docs, not
+  // directories. Body-scanning for literal secrets and never-sync paths is
+  // handled by the central walker in `commands/push.ts` over the plaintext
+  // artifact stream, so the adapter no longer carries its own interior
+  // scan. The old tar-based "leaky agent" tests moved with that contract.
 
   // walker retrofit regression: snapshotCopilot must inherit the
   // symlink-rejection and dot-skip rules from the shared walker.
@@ -311,18 +262,10 @@ describe("apply* functions", () => {
     expect(extracted).toBe("# Skill content");
   });
 
-  test("applyCopilotAgent extracts a tar archive into agents dir", async () => {
-    const { archiveDirectory } = await import("../../core/tar");
-    const srcAgent = join(tmpDir, "src-agent");
-    mkdirSync(srcAgent, { recursive: true });
-    writeFileSync(join(srcAgent, "agent.md"), "# Agent content", "utf8");
+  test("applyCopilotAgent writes a single .agent.md file", async () => {
+    await copilotModule.applyCopilotAgent("my-agent.agent.md", "# Agent content");
 
-    const buf = await archiveDirectory(srcAgent);
-    await copilotModule.applyCopilotAgent("my-agent", buf.toString("base64"));
-
-    const extracted = await Bun.file(
-      join(testCopilotPaths.agentsDir, "my-agent", "agent.md"),
-    ).text();
+    const extracted = await Bun.file(join(testCopilotPaths.agentsDir, "my-agent.agent.md")).text();
     expect(extracted).toBe("# Agent content");
   });
 
@@ -426,20 +369,6 @@ describe("applyCopilotVault dryRun", () => {
     const badNames = ["", ".", "..", "../foo", "foo/bar", "foo\\bar", ".hidden", "foo\x00bar"];
     for (const bad of badNames) {
       await expect(copilotModule.applyCopilotSkill(bad, "")).rejects.toBeInstanceOf(
-        InvalidSkillNameError,
-      );
-    }
-  });
-
-  // Thread 6 regression — the agents/ loop in applyCopilotVault mirrors the
-  // skills/ loop and was missed in the Phase 8 fix. Same basename-strip
-  // vector (`...tar.age` → `..`) would let a compromised vault overwrite
-  // files in the agent config root via path.join(agentsDir, "..").
-  test("applyCopilotAgent rejects traversal and hidden agent names", async () => {
-    const { InvalidSkillNameError } = await import("../skills-walker");
-    const badNames = ["", ".", "..", "../foo", "foo/bar", "foo\\bar", ".hidden", "foo\x00bar"];
-    for (const bad of badNames) {
-      await expect(copilotModule.applyCopilotAgent(bad, "")).rejects.toBeInstanceOf(
         InvalidSkillNameError,
       );
     }

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -152,6 +152,21 @@ describe("snapshotCopilot", () => {
     expect(arts).toHaveLength(0);
   });
 
+  test("snapshot skips dotfile agents and refuses to follow symlinks", async () => {
+    mkdirSync(testCopilotPaths.agentsDir, { recursive: true });
+    // Dotfile — must be skipped even if it has the right suffix.
+    writeFileSync(join(testCopilotPaths.agentsDir, ".hidden.agent.md"), "# hidden", "utf8");
+    // Symlinked agent pointing at an external file — must NOT smuggle the
+    // target content into the vault. The vendored helper sits outside agentsDir.
+    const external = join(tmpDir, "external-secret.md");
+    writeFileSync(external, "SECRET FROM /etc/passwd", "utf8");
+    symlinkSync(external, join(testCopilotPaths.agentsDir, "linked.agent.md"));
+
+    const result = await copilotModule.snapshotCopilot();
+    const arts = result.artifacts.filter((a) => a.vaultPath.startsWith("copilot/agents/"));
+    expect(arts).toHaveLength(0);
+  });
+
   // Copilot agents are single .agent.md files per the GitHub docs, not
   // directories. Body-scanning for literal secrets and never-sync paths is
   // handled by the central walker in `commands/push.ts` over the plaintext
@@ -267,6 +282,23 @@ describe("apply* functions", () => {
 
     const extracted = await Bun.file(join(testCopilotPaths.agentsDir, "my-agent.agent.md")).text();
     expect(extracted).toBe("# Agent content");
+  });
+
+  test("applyCopilotAgent rejects traversal, dotfiles, and non-suffix names", async () => {
+    const badNames = [
+      "../escape.agent.md",
+      "./escape.agent.md",
+      "foo/bar.agent.md",
+      ".hidden.agent.md",
+      "no-suffix.md",
+      "with\0null.agent.md",
+      "",
+    ];
+    for (const bad of badNames) {
+      await expect(copilotModule.applyCopilotAgent(bad, "x")).rejects.toThrow(
+        /Invalid Copilot agent filename/,
+      );
+    }
   });
 
   test("applyCopilotInstructionFile writes to instructions subdir", async () => {

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -437,30 +437,27 @@ describe("applyCopilotVault dryRun", () => {
   // must be rejected symmetrically with the skills/ loop above. Distinct
   // payload filename (`AGENT_LEAKED.md`) so a false positive can't be
   // mistaken for the skills-loop assertion's leakage.
-  test("applyCopilotVault skips adversarial agent filenames without traversal", async () => {
+  test("applyCopilotVault rejects a dotfile-named agent artifact via the validator", async () => {
     const { generateIdentity, identityToRecipient, encryptString } = await import(
       "../../core/encryptor"
     );
-    const { archiveDirectory } = await import("../../core/tar");
     const identity = await generateIdentity();
     const recipient = await identityToRecipient(identity);
 
-    const payloadSrc = join(tmpDir, "agent-payload-src");
-    mkdirSync(payloadSrc, { recursive: true });
-    writeFileSync(join(payloadSrc, "AGENT_LEAKED.md"), "LEAKED_AGENT_PAYLOAD", "utf8");
-    const tarBuffer = await archiveDirectory(payloadSrc);
-    const base64 = tarBuffer.toString("base64");
-    const encrypted = await encryptString(base64, [recipient]);
-
+    // The filename passes the `.agent.md.age` suffix gate so the dispatch loop
+    // reaches the validator, which then rejects on the leading dot and
+    // warn-and-skips. Single-file agents post-B15 have no tar layer, so the
+    // payload is plaintext markdown.
+    const encrypted = await encryptString("LEAKED_DOTFILE_PAYLOAD", [recipient]);
     const vaultDir = join(tmpDir, "vault-adversarial-agent");
     const agentsVaultDir = join(vaultDir, "copilot", "agents");
     mkdirSync(agentsVaultDir, { recursive: true });
-    writeFileSync(join(agentsVaultDir, "...tar.age"), encrypted, "utf8");
+    writeFileSync(join(agentsVaultDir, ".hidden.agent.md.age"), encrypted, "utf8");
 
     await copilotModule.applyCopilotVault(vaultDir, identity, false);
 
-    const escapedPayload = join(testCopilotPaths.agentsDir, "..", "AGENT_LEAKED.md");
-    const leakedExists = await Bun.file(escapedPayload).exists();
-    expect(leakedExists).toBeFalse();
+    const dotfileTarget = join(testCopilotPaths.agentsDir, ".hidden.agent.md");
+    const dotfileExists = await Bun.file(dotfileTarget).exists();
+    expect(dotfileExists).toBeFalse();
   });
 });

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -1,7 +1,13 @@
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { AgentPaths } from "../config/paths";
+import {
+  denormalizeFromVault,
+  denormalizeStringFromVault,
+  normalizeForVault,
+} from "../core/path-portability";
 import {
   redactSecretLiterals,
   sanitizeClaudeHooks,
@@ -47,7 +53,7 @@ export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<S
 
   const settingsJson = await readIfExists(AgentPaths.claude.settingsJson);
   if (settingsJson !== null) {
-    const hooks = sanitizeClaudeHooks(settingsJson);
+    const hooks = sanitizeClaudeHooks(settingsJson, homedir());
     artifacts.push(
       collect(hooks, AgentPaths.claude.settingsJson, "claude/settings.hooks.json.age"),
     );
@@ -56,7 +62,7 @@ export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<S
 
   const mcpJson = await readIfExists(AgentPaths.claude.mcpJson);
   if (mcpJson !== null) {
-    const mcp = sanitizeClaudeMcp(mcpJson);
+    const mcp = sanitizeClaudeMcp(mcpJson, homedir());
     artifacts.push(collect(mcp, AgentPaths.claude.mcpJson, "claude/claude.json.age"));
     warnings.push(...mcp.warnings);
   }
@@ -107,6 +113,32 @@ export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<S
     // agents dir may not exist yet.
   }
 
+  // Rules markdown at ~/.claude/rules/*.md is referenced from CLAUDE.md via
+  // include directives, so the files must travel with the agent config or the
+  // includes break on the destination machine.
+  try {
+    const names = await readdir(AgentPaths.claude.rulesDir);
+    for (const name of names) {
+      if (!name.endsWith(".md")) continue;
+      const sourcePath = join(AgentPaths.claude.rulesDir, name);
+      if (shouldNeverSync(sourcePath)) continue;
+      let content: string;
+      try {
+        content = await readFile(sourcePath, "utf8");
+      } catch {
+        continue;
+      }
+      artifacts.push({
+        vaultPath: `claude/rules/${name}.age`,
+        sourcePath,
+        plaintext: content,
+        warnings: [],
+      });
+    }
+  } catch {
+    // rules dir may not exist yet.
+  }
+
   // Skills — delegated to the shared walker.
   // The walker handles dot-skip, symlink rejection, sentinel verification, the
   // never-sync interior scan, and the symlink-filtered tar archival in one
@@ -128,7 +160,7 @@ export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<S
     const manifestRaw = await readIfExists(plugin.paths.manifest);
     if (manifestRaw !== null && !shouldNeverSync(plugin.paths.manifest)) {
       try {
-        const manifest = sanitizeClaudePluginManifest(manifestRaw);
+        const manifest = sanitizeClaudePluginManifest(manifestRaw, homedir());
         artifacts.push(collect(manifest, plugin.paths.manifest, `${ns}/plugin.json.age`));
         warnings.push(...manifest.warnings);
       } catch (err) {
@@ -147,7 +179,7 @@ export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<S
     const pluginMcpRaw = await readIfExists(plugin.paths.mcpJson);
     if (pluginMcpRaw !== null && !shouldNeverSync(plugin.paths.mcpJson)) {
       try {
-        const pluginMcp = sanitizeClaudePluginMcp(pluginMcpRaw);
+        const pluginMcp = sanitizeClaudePluginMcp(pluginMcpRaw, homedir());
         artifacts.push(collect(pluginMcp, plugin.paths.mcpJson, `${ns}/mcp.json.age`));
         warnings.push(...pluginMcp.warnings);
       } catch (err) {
@@ -182,7 +214,8 @@ export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<S
     if (marketplaceRaw !== null && !shouldNeverSync(AgentPaths.claude.marketplaceJson)) {
       try {
         const parsed = JSON.parse(marketplaceRaw) as unknown;
-        const redacted = redactSecretLiterals(parsed, "marketplace");
+        const normalized = normalizeForVault(parsed, homedir());
+        const redacted = redactSecretLiterals(normalized, "marketplace");
         artifacts.push({
           vaultPath: "claude/marketplace.json.age",
           sourcePath: AgentPaths.claude.marketplaceJson,
@@ -311,19 +344,24 @@ export async function applyClaudeMd(content: string): Promise<void> {
 
 /** Merge synced Claude hooks back into the local settings file. */
 export async function applyClaudeHooks(hooksJsonContent: string): Promise<void> {
+  const home = homedir();
   const existingRaw = await readIfExists(AgentPaths.claude.settingsJson);
   const existing = existingRaw ? (JSON.parse(existingRaw) as Record<string, unknown>) : {};
   const incoming = JSON.parse(hooksJsonContent) as Record<string, unknown>;
-  existing.hooks = incoming.hooks ?? {};
+  // Denormalize only the incoming subset — local-only keys must not be touched
+  // because they were never normalized on snapshot and any `$` in their values
+  // is literal.
+  existing.hooks = denormalizeFromVault(incoming.hooks ?? {}, home);
   await atomicWrite(AgentPaths.claude.settingsJson, `${JSON.stringify(existing, null, 2)}\n`);
 }
 
 /** Merge synced Claude MCP servers back into the local Claude config file. */
 export async function applyClaudeMcp(claudeJsonContent: string): Promise<void> {
+  const home = homedir();
   const existingRaw = await readIfExists(AgentPaths.claude.mcpJson);
   const existing = existingRaw ? (JSON.parse(existingRaw) as Record<string, unknown>) : {};
   const incoming = JSON.parse(claudeJsonContent) as Record<string, unknown>;
-  existing.mcpServers = incoming.mcpServers ?? {};
+  existing.mcpServers = denormalizeFromVault(incoming.mcpServers ?? {}, home);
   await atomicWrite(AgentPaths.claude.mcpJson, `${JSON.stringify(existing, null, 2)}\n`);
 }
 
@@ -353,6 +391,14 @@ export async function applyClaudeAgent(agentName: string, content: string): Prom
   await atomicWrite(target, content);
 }
 
+/** Restore one Claude rule markdown file from the vault. */
+export async function applyClaudeRule(ruleName: string, content: string): Promise<void> {
+  const target = join(AgentPaths.claude.rulesDir, ruleName);
+  await mkdir(AgentPaths.claude.rulesDir, { recursive: true });
+  await ensureCommandBackup(target);
+  await atomicWrite(target, content);
+}
+
 // ─── Claude plugin apply helpers (issue #31) ─────────────────────────────────
 
 /**
@@ -374,7 +420,7 @@ export async function applyClaudePluginManifest(
   const target = join(root, ".claude-plugin", "plugin.json");
   await mkdir(join(root, ".claude-plugin"), { recursive: true });
   await ensureCommandBackup(target);
-  await atomicWrite(target, content);
+  await atomicWrite(target, denormalizeStringFromVault(content, homedir()));
 }
 
 /** Restore one plugin-local command markdown file. */
@@ -425,7 +471,7 @@ export async function applyClaudePluginMcp(pluginName: string, content: string):
   const target = join(root, ".mcp.json");
   await mkdir(root, { recursive: true });
   await ensureCommandBackup(target);
-  await atomicWrite(target, content);
+  await atomicWrite(target, denormalizeStringFromVault(content, homedir()));
 }
 
 /** Restore one plugin-local skill tar archive into the plugin's skills dir. */
@@ -447,7 +493,7 @@ export async function applyClaudeMarketplace(content: string): Promise<void> {
   const target = AgentPaths.claude.marketplaceJson;
   await mkdir(join(target, ".."), { recursive: true });
   await ensureCommandBackup(target);
-  await atomicWrite(target, content);
+  await atomicWrite(target, denormalizeStringFromVault(content, homedir()));
 }
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
@@ -543,6 +589,20 @@ export async function applyClaudeVault(
       log.info(`[dry-run] [claude] would write agent: ${agentName}`);
     } else {
       await applyClaudeAgent(agentName, decrypted);
+    }
+  }
+
+  // Rules sub-directory — mirrors commands/agents handling.
+  const ruleFiles = await readAgeFiles(join(claudeDir, "rules"));
+  for (const { name, fullPath } of ruleFiles) {
+    if (!name.endsWith(".md.age")) continue;
+    const encrypted = await readFile(fullPath, "utf8");
+    const decrypted = await decryptString(encrypted, key);
+    const ruleName = basename(name, ".age");
+    if (dryRun) {
+      log.info(`[dry-run] [claude] would write rule: ${ruleName}`);
+    } else {
+      await applyClaudeRule(ruleName, decrypted);
     }
   }
 

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -115,10 +115,15 @@ export async function snapshotClaude(options: ClaudeSyncOptions = {}): Promise<S
 
   // Rules markdown at ~/.claude/rules/*.md is referenced from CLAUDE.md via
   // include directives, so the files must travel with the agent config or the
-  // includes break on the destination machine.
+  // includes break on the destination machine. Use withFileTypes + symlink
+  // rejection so a `rules/secret.md → /etc/passwd` symlink can't smuggle
+  // arbitrary file content into the encrypted vault — readFile would follow
+  // it and shouldNeverSync only sees the symlink path.
   try {
-    const names = await readdir(AgentPaths.claude.rulesDir);
-    for (const name of names) {
+    const entries = await readdir(AgentPaths.claude.rulesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile() || entry.isSymbolicLink()) continue;
+      const name = entry.name;
       if (!name.endsWith(".md")) continue;
       const sourcePath = join(AgentPaths.claude.rulesDir, name);
       if (shouldNeverSync(sourcePath)) continue;
@@ -300,7 +305,11 @@ async function collectPluginHooksDir(
     }
     try {
       const parsed = JSON.parse(raw) as unknown;
-      const redacted = redactSecretLiterals(parsed, "pluginHook");
+      // Plugin hooks routinely reference commands or working directories
+      // under HOME, so they need the same normalize-before-redact treatment
+      // as plugin.json and .mcp.json to round-trip across machines.
+      const normalized = normalizeForVault(parsed, homedir());
+      const redacted = redactSecretLiterals(normalized, "pluginHook");
       artifacts.push({
         vaultPath: `${vaultPrefix}/${name}.age`,
         sourcePath,
@@ -462,7 +471,7 @@ export async function applyClaudePluginHook(
   const target = join(dir, fileName);
   await mkdir(dir, { recursive: true });
   await ensureCommandBackup(target);
-  await atomicWrite(target, content);
+  await atomicWrite(target, denormalizeStringFromVault(content, homedir()));
 }
 
 /** Restore one plugin's `.mcp.json`. */

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -1,8 +1,10 @@
 import { mkdir, readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import * as TOML from "@iarna/toml";
 import { AgentPaths } from "../config/paths";
+import { denormalizeFromVault, normalizeForVault } from "../core/path-portability";
 import { type RedactionResult, redactSecretLiterals, shouldNeverSync } from "../core/sanitizer";
 import { extractArchive } from "../core/tar";
 import {
@@ -23,7 +25,7 @@ export type CodexSnapshotResult = SnapshotResult;
  * Using TOML parse → redact → stringify avoids the line-level regex approach which
  * misses multi-line values and nested tables.
  */
-function sanitizeCodexConfig(raw: string): RedactionResult<string> {
+function sanitizeCodexConfig(raw: string, home: string = homedir()): RedactionResult<string> {
   const warnings: string[] = [];
   let parsed: TOML.JsonMap;
   try {
@@ -33,7 +35,8 @@ function sanitizeCodexConfig(raw: string): RedactionResult<string> {
     return { value: raw, warnings };
   }
 
-  const redacted = redactSecretLiterals(parsed as unknown, "codex_config");
+  const normalized = normalizeForVault(parsed as unknown, home);
+  const redacted = redactSecretLiterals(normalized, "codex_config");
   warnings.push(...redacted.warnings);
   return {
     value: TOML.stringify(redacted.value as TOML.JsonMap),
@@ -56,9 +59,21 @@ export async function snapshotCodex(): Promise<SnapshotResult> {
     });
   }
 
+  // AGENTS.override.md wins over AGENTS.md when codex reads the pair; sync
+  // both so the override semantics are preserved on the destination machine.
+  const agentsOverrideMd = await readIfExists(AgentPaths.codex.agentsOverrideMd);
+  if (agentsOverrideMd !== null) {
+    artifacts.push({
+      vaultPath: "codex/AGENTS.override.md.age",
+      sourcePath: AgentPaths.codex.agentsOverrideMd,
+      plaintext: agentsOverrideMd,
+      warnings: [],
+    });
+  }
+
   const configToml = await readIfExists(AgentPaths.codex.configToml);
   if (configToml !== null) {
-    const sanitized = sanitizeCodexConfig(configToml);
+    const sanitized = sanitizeCodexConfig(configToml, homedir());
     artifacts.push(collect(sanitized, AgentPaths.codex.configToml, "codex/config.toml.age"));
     warnings.push(...sanitized.warnings);
   }
@@ -86,14 +101,34 @@ export async function snapshotCodex(): Promise<SnapshotResult> {
     // rules dir may not exist yet
   }
 
-  // Skills — delegated to the shared walker.
-  // The walker enforces dot-skip (which covers Codex's vendored `.system/`
-  // bundle), symlink rejection at the root, sentinel verification,
-  // the never-sync interior scan, and the symlink-filtered tar archival in one
-  // place so every skill-bearing agent inherits identical rules.
-  const codexSkills = await collectSkillArtifacts("codex", AgentPaths.codex.skillsDir);
-  artifacts.push(...codexSkills.artifacts);
-  warnings.push(...codexSkills.warnings);
+  // Skills — canonical USER scope is $HOME/.agents/skills per the Codex Skills
+  // docs; the legacy $CODEX_HOME/.codex/skills path stays readable so prior
+  // installs migrate forward on the next pull. Deduplication keys come from
+  // the canonical directory listing rather than emitted artifacts so a skill
+  // the walker REJECTED at the canonical location (never-sync hit, literal
+  // secret) still blocks the legacy copy from leaking through.
+  let canonicalNames: string[] = [];
+  try {
+    canonicalNames = await readdir(AgentPaths.codex.userSkillsDir);
+  } catch {
+    // canonical dir may not exist yet
+  }
+  const seen = new Set(canonicalNames.filter((n) => !n.startsWith(".")));
+
+  const userSkills = await collectSkillArtifacts("codex", AgentPaths.codex.userSkillsDir);
+  const legacySkills = await collectSkillArtifacts("codex", AgentPaths.codex.skillsDir);
+  artifacts.push(...userSkills.artifacts);
+  for (const artifact of legacySkills.artifacts) {
+    // vaultPath is `codex/skills/<name>.tar.age` — extract `<name>` and skip
+    // when the canonical directory already carries the name (regardless of
+    // whether the canonical scan emitted an artifact).
+    const legacyName = artifact.vaultPath
+      .replace(/^codex\/skills\//, "")
+      .replace(/\.tar\.age$/, "");
+    if (seen.has(legacyName)) continue;
+    artifacts.push(artifact);
+  }
+  warnings.push(...userSkills.warnings, ...legacySkills.warnings);
 
   return { artifacts, warnings };
 }
@@ -103,12 +138,24 @@ export async function applyCodexAgentsMd(content: string): Promise<void> {
   await atomicWrite(AgentPaths.codex.agentsMd, content);
 }
 
+/** Restore the optional AGENTS.override.md companion to AGENTS.md. */
+export async function applyCodexAgentsOverrideMd(content: string): Promise<void> {
+  await atomicWrite(AgentPaths.codex.agentsOverrideMd, content);
+}
+
 /** Merge synced Codex config into the local TOML while preserving unrelated local keys. */
 export async function applyCodexConfig(content: string): Promise<void> {
+  const home = homedir();
+  // Denormalize only the incoming subset. Local-only top-level keys that
+  // pre-exist on disk are not in scope for portability — they were never
+  // normalized on snapshot, and a `$` literal in their values must stay
+  // literal. Any AGENTSYNC_HOME placeholder reaching this branch came from
+  // the vault, so denormalization here is sufficient for the synced surface.
+  const incoming = denormalizeFromVault(TOML.parse(content), home) as TOML.JsonMap;
+
   const existingRaw = await readIfExists(AgentPaths.codex.configToml);
   if (existingRaw === null) {
-    // No local file yet — write directly.
-    await atomicWrite(AgentPaths.codex.configToml, content);
+    await atomicWrite(AgentPaths.codex.configToml, TOML.stringify(incoming));
     return;
   }
 
@@ -116,12 +163,10 @@ export async function applyCodexConfig(content: string): Promise<void> {
   try {
     existing = TOML.parse(existingRaw);
   } catch {
-    // Existing file is corrupt — overwrite.
-    await atomicWrite(AgentPaths.codex.configToml, content);
+    await atomicWrite(AgentPaths.codex.configToml, TOML.stringify(incoming));
     return;
   }
 
-  const incoming = TOML.parse(content);
   // Shallow-merge at top level: incoming keys win, local-only keys survive.
   const merged: TOML.JsonMap = { ...existing, ...incoming };
   await atomicWrite(AgentPaths.codex.configToml, TOML.stringify(merged));
@@ -147,7 +192,10 @@ export async function applyCodexRule(ruleName: string, content: string): Promise
  */
 export async function applyCodexSkill(skillName: string, base64Tar: string): Promise<void> {
   validateSkillName(skillName);
-  const targetDir = join(AgentPaths.codex.skillsDir, skillName);
+  // Always restore under $HOME/.agents/skills — the canonical Codex USER scope.
+  // Legacy $CODEX_HOME/.codex/skills remains readable on snapshot but is never
+  // a write target, so pulls migrate forward in place without leaving stragglers.
+  const targetDir = join(AgentPaths.codex.userSkillsDir, skillName);
   await mkdir(targetDir, { recursive: true });
   const tarBuffer = Buffer.from(base64Tar, "base64");
   await extractArchive(tarBuffer, targetDir);
@@ -192,6 +240,12 @@ export async function applyCodexVault(
         continue;
       }
       await applyCodexAgentsMd(decrypted);
+    } else if (name === "AGENTS.override.md.age") {
+      if (dryRun) {
+        log.info("[dry-run] [codex] would apply AGENTS.override.md");
+        continue;
+      }
+      await applyCodexAgentsOverrideMd(decrypted);
     } else if (name === "config.toml.age") {
       if (dryRun) {
         log.info("[dry-run] [codex] would apply config.toml");

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -7,6 +7,25 @@ import { extractArchive } from "../core/tar";
 import { atomicWrite, readIfExists, type SnapshotArtifact, type SnapshotResult } from "./_utils";
 import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "./skills-walker";
 
+/**
+ * Reject Copilot agent filenames that could escape `agentsDir`, smuggle in
+ * vendor dotfiles, or skip the documented `.agent.md` suffix. Called on both
+ * sides of the wire so a malicious vault entry or a stray dotfile in the user
+ * directory cannot widen the surface beyond what the GitHub Copilot CLI docs
+ * actually consume.
+ */
+function validateCopilotAgentFileName(fileName: string): void {
+  if (
+    fileName.length === 0 ||
+    fileName !== basename(fileName) ||
+    fileName.startsWith(".") ||
+    fileName.includes("\0") ||
+    !fileName.endsWith(".agent.md")
+  ) {
+    throw new Error(`Invalid Copilot agent filename: ${fileName}`);
+  }
+}
+
 /** Snapshot payload for the Copilot adapter. */
 export type CopilotSnapshotResult = SnapshotResult;
 
@@ -77,14 +96,22 @@ export async function snapshotCopilot(): Promise<SnapshotResult> {
   artifacts.push(...copilotSkills.artifacts);
   warnings.push(...copilotSkills.warnings);
 
-  // Copilot agents live as single `<name>.agent.md` files per the GitHub docs,
-  // not as per-agent directories. Markdown bodies are scanned for embedded
-  // literal secrets via the central walker in `commands/push.ts`, so no
-  // separate interior-scan helper is needed here.
+  // Copilot agents live as single `<name>.agent.md` files per the GitHub docs.
+  // The walker rejects dotfiles, traversal segments, and symlinked entries
+  // (readFile follows symlinks, so a `foo.agent.md → /etc/passwd` symlink
+  // would otherwise smuggle arbitrary content into the encrypted vault).
+  // Markdown bodies are scanned for embedded literal secrets by the central
+  // walker in `commands/push.ts`.
   try {
-    const names = await readdir(AgentPaths.copilot.agentsDir);
-    for (const name of names) {
-      if (!name.endsWith(".agent.md")) continue;
+    const entries = await readdir(AgentPaths.copilot.agentsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile() || entry.isSymbolicLink()) continue;
+      const name = entry.name;
+      try {
+        validateCopilotAgentFileName(name);
+      } catch {
+        continue;
+      }
       const sourcePath = join(AgentPaths.copilot.agentsDir, name);
       if (shouldNeverSync(sourcePath)) continue;
       const content = await readIfExists(sourcePath);
@@ -137,6 +164,7 @@ export async function applyCopilotSkill(skillName: string, base64Tar: string): P
 
 /** Restore one Copilot `<name>.agent.md` single-file agent from the vault. */
 export async function applyCopilotAgent(fileName: string, content: string): Promise<void> {
+  validateCopilotAgentFileName(fileName);
   const target = join(AgentPaths.copilot.agentsDir, fileName);
   await mkdir(AgentPaths.copilot.agentsDir, { recursive: true });
   await atomicWrite(target, content);
@@ -239,9 +267,15 @@ export async function applyCopilotVault(
   const agentFiles = await readAgeFiles(join(copilotDir, "agents"));
   for (const { name, fullPath } of agentFiles) {
     if (!name.endsWith(".agent.md.age")) continue;
+    const fileName = basename(name, ".age");
+    try {
+      validateCopilotAgentFileName(fileName);
+    } catch {
+      log.warn(`[copilot] Skipping vault agent with invalid name '${name}'`);
+      continue;
+    }
     const encrypted = await readFile(fullPath, "utf8");
     const decrypted = await decryptString(encrypted, key);
-    const fileName = basename(name, ".age");
     if (dryRun) {
       log.info(`[dry-run] [copilot] would write agent: ${fileName}`);
       continue;

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -1,17 +1,11 @@
-import { mkdir, readdir, stat } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { log } from "@clack/prompts";
 import { AgentPaths } from "../config/paths";
 import { shouldNeverSync } from "../core/sanitizer";
-import { archiveDirectory, extractArchive } from "../core/tar";
+import { extractArchive } from "../core/tar";
 import { atomicWrite, readIfExists, type SnapshotArtifact, type SnapshotResult } from "./_utils";
-import {
-  collectInteriorViolations,
-  collectSkillArtifacts,
-  InvalidSkillNameError,
-  NEVER_SYNC_WARNING_PREFIX,
-  validateSkillName,
-} from "./skills-walker";
+import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "./skills-walker";
 
 /** Snapshot payload for the Copilot adapter. */
 export type CopilotSnapshotResult = SnapshotResult;
@@ -83,43 +77,25 @@ export async function snapshotCopilot(): Promise<SnapshotResult> {
   artifacts.push(...copilotSkills.artifacts);
   warnings.push(...copilotSkills.warnings);
 
-  // Agents directories (tar each one, similar to skills). Each agent's
-  // interior is scanned for both never-sync path hits and literal
-  // credentials before the bytes head for encryption: the central scan
-  // in `commands/push.ts` skips `.tar.age` artifacts (base64 scrambles
-  // credential prefixes), so this per-file walk is the only layer that
-  // can catch a key pasted into an agent's markdown body or a never-sync
-  // file (auth.json, history.jsonl, sessions/**, …) nested under the
-  // agent dir. Mirrors the shared walker's gate 4 contract symmetrically:
-  // collect every offender, emit `never-sync inside skill: …` for path
-  // hits and `Detected literal secret …` for body hits — both prefixes
-  // are escalated to a fatal abort by performPush — and skip the artifact.
+  // Copilot agents live as single `<name>.agent.md` files per the GitHub docs,
+  // not as per-agent directories. Markdown bodies are scanned for embedded
+  // literal secrets via the central walker in `commands/push.ts`, so no
+  // separate interior-scan helper is needed here.
   try {
     const names = await readdir(AgentPaths.copilot.agentsDir);
     for (const name of names) {
-      const agentDir = join(AgentPaths.copilot.agentsDir, name);
-      const agentDirStat = await stat(agentDir).catch(() => null);
-      if (!agentDirStat?.isDirectory()) continue;
-
-      const violations = await collectInteriorViolations(agentDir);
-      if (violations.neverSyncHits.length > 0 || violations.secretWarnings.length > 0) {
-        for (const hit of violations.neverSyncHits) {
-          // Re-use the skills-walker prefix so the push gate's existing
-          // escalation rule covers agent-dir hits too — keeping the contract
-          // string in one exported constant prevents silent drift.
-          warnings.push(`${NEVER_SYNC_WARNING_PREFIX}${hit}`);
-        }
-        warnings.push(...violations.secretWarnings);
-        continue;
+      if (!name.endsWith(".agent.md")) continue;
+      const sourcePath = join(AgentPaths.copilot.agentsDir, name);
+      if (shouldNeverSync(sourcePath)) continue;
+      const content = await readIfExists(sourcePath);
+      if (content !== null) {
+        artifacts.push({
+          vaultPath: `copilot/agents/${name}.age`,
+          sourcePath,
+          plaintext: content,
+          warnings: [],
+        });
       }
-
-      const tarBuffer = await archiveDirectory(agentDir);
-      artifacts.push({
-        vaultPath: `copilot/agents/${name}.tar.age`,
-        sourcePath: agentDir,
-        plaintext: tarBuffer.toString("base64"),
-        warnings: [],
-      });
     }
   } catch {
     // agents dir may not exist
@@ -159,18 +135,11 @@ export async function applyCopilotSkill(skillName: string, base64Tar: string): P
   await extractArchive(tarBuffer, targetDir);
 }
 
-/** Extract one archived Copilot agent directory into the local agents folder. */
-export async function applyCopilotAgent(agentName: string, base64Tar: string): Promise<void> {
-  // Symmetric path-traversal guard to the one in applyCopilotSkill: a vault
-  // file named `...tar.age` would basename-strip to `..` and resolve outside
-  // agentsDir, letting a compromised vault overwrite files in `~/.copilot/`
-  // or any parent directory. See validateSkillName in skills-walker.ts — the
-  // helper is named for skills but is the generic vault-basename check.
-  validateSkillName(agentName);
-  const targetDir = join(AgentPaths.copilot.agentsDir, agentName);
-  await mkdir(targetDir, { recursive: true });
-  const tarBuffer = Buffer.from(base64Tar, "base64");
-  await extractArchive(tarBuffer, targetDir);
+/** Restore one Copilot `<name>.agent.md` single-file agent from the vault. */
+export async function applyCopilotAgent(fileName: string, content: string): Promise<void> {
+  const target = join(AgentPaths.copilot.agentsDir, fileName);
+  await mkdir(AgentPaths.copilot.agentsDir, { recursive: true });
+  await atomicWrite(target, content);
 }
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
@@ -266,26 +235,17 @@ export async function applyCopilotVault(
     await applyCopilotSkill(skillName, decrypted);
   }
 
-  // agents/ sub-directory — stored as <name>.tar.age
+  // agents/ sub-directory — stored as <name>.agent.md.age
   const agentFiles = await readAgeFiles(join(copilotDir, "agents"));
   for (const { name, fullPath } of agentFiles) {
-    if (!name.endsWith(".tar.age")) continue;
-    const agentName = basename(name, ".tar.age");
-    try {
-      validateSkillName(agentName);
-    } catch (err) {
-      if (err instanceof InvalidSkillNameError) {
-        log.warn(`[copilot] Skipping vault agent with invalid name '${name}': ${err.reason}`);
-        continue;
-      }
-      throw err;
-    }
+    if (!name.endsWith(".agent.md.age")) continue;
     const encrypted = await readFile(fullPath, "utf8");
     const decrypted = await decryptString(encrypted, key);
+    const fileName = basename(name, ".age");
     if (dryRun) {
-      log.info(`[dry-run] [copilot] would extract agent: ${agentName}`);
+      log.info(`[dry-run] [copilot] would write agent: ${fileName}`);
       continue;
     }
-    await applyCopilotAgent(agentName, decrypted);
+    await applyCopilotAgent(fileName, decrypted);
   }
 }

--- a/src/agents/cursor.ts
+++ b/src/agents/cursor.ts
@@ -1,7 +1,13 @@
 import { mkdir, readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { log } from "@clack/prompts";
 import { AgentPaths } from "../config/paths";
+import {
+  denormalizeStringFromVault,
+  normalizeForVault,
+  normalizeStringForVault,
+} from "../core/path-portability";
 import { redactSecretLiterals, shouldNeverSync } from "../core/sanitizer";
 import { extractArchive } from "../core/tar";
 import {
@@ -44,17 +50,15 @@ export async function snapshotCursor(): Promise<SnapshotResult> {
     artifacts.push({
       vaultPath: "cursor/user-rules.md.age",
       sourcePath: AgentPaths.cursor.settingsJson,
-      plaintext: rules,
+      plaintext: normalizeStringForVault(rules, homedir()),
       warnings: [],
     });
   }
 
   const mcpRaw = await readIfExists(AgentPaths.cursor.mcpGlobal);
   if (mcpRaw !== null) {
-    const redacted = redactSecretLiterals(
-      JSON.parse(mcpRaw) as Record<string, unknown>,
-      "cursor_mcp",
-    );
+    const normalized = normalizeForVault(JSON.parse(mcpRaw), homedir());
+    const redacted = redactSecretLiterals(normalized, "cursor_mcp");
     const artifact = collect(
       {
         value: `${JSON.stringify(redacted.value, null, 2)}\n`,
@@ -111,15 +115,20 @@ export async function snapshotCursor(): Promise<SnapshotResult> {
 export async function applyCursorRules(rulesContent: string): Promise<void> {
   const raw = await readIfExists(AgentPaths.cursor.settingsJson);
   const settings: Record<string, unknown> = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
-  settings.rules = rulesContent;
+  settings.rules = denormalizeStringFromVault(rulesContent, homedir());
   await atomicWrite(AgentPaths.cursor.settingsJson, `${JSON.stringify(settings, null, 2)}\n`);
 }
 
 /**
  * Apply the synced Cursor MCP config back to ~/.cursor/mcp.json.
+ * Placeholders are expanded back to this machine's HOME before write so the
+ * file is immediately usable by Cursor without a separate post-process.
  */
 export async function applyCursorMcp(mcpJsonContent: string): Promise<void> {
-  await atomicWrite(AgentPaths.cursor.mcpGlobal, mcpJsonContent);
+  await atomicWrite(
+    AgentPaths.cursor.mcpGlobal,
+    denormalizeStringFromVault(mcpJsonContent, homedir()),
+  );
 }
 
 /** Restore one Cursor command markdown file from the vault. */

--- a/src/agents/vscode.ts
+++ b/src/agents/vscode.ts
@@ -1,8 +1,10 @@
 import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { AgentPaths } from "../config/paths";
 import { decryptString } from "../core/encryptor";
+import { denormalizeStringFromVault, normalizeForVault } from "../core/path-portability";
 import { redactSecretLiterals } from "../core/sanitizer";
 import {
   atomicWrite,
@@ -22,10 +24,8 @@ export async function snapshotVsCode(): Promise<SnapshotResult> {
 
   const mcpRaw = await readIfExists(AgentPaths.vscode.mcpJson);
   if (mcpRaw !== null) {
-    const redacted = redactSecretLiterals(
-      JSON.parse(mcpRaw) as Record<string, unknown>,
-      "vscode_mcp",
-    );
+    const normalized = normalizeForVault(JSON.parse(mcpRaw), homedir());
+    const redacted = redactSecretLiterals(normalized, "vscode_mcp");
     const artifact = collect(
       {
         value: `${JSON.stringify(redacted.value, null, 2)}\n`,
@@ -43,7 +43,10 @@ export async function snapshotVsCode(): Promise<SnapshotResult> {
 
 /** Restore the synced VS Code MCP configuration file. */
 export async function applyVsCodeMcp(mcpJsonContent: string): Promise<void> {
-  await atomicWrite(AgentPaths.vscode.mcpJson, mcpJsonContent);
+  await atomicWrite(
+    AgentPaths.vscode.mcpJson,
+    denormalizeStringFromVault(mcpJsonContent, homedir()),
+  );
 }
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────

--- a/src/core/__tests__/sanitizer.test.ts
+++ b/src/core/__tests__/sanitizer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { AGENTSYNC_HOME_PLACEHOLDER } from "../path-portability";
 import {
   EMBEDDED_SECRET_PATTERNS,
   NEVER_SYNC_PATTERNS,
@@ -266,5 +267,65 @@ describe("sanitizer", () => {
       "The build hash AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA passed CI. " +
       "Branch feature-xyz merged at 2026-05-11.";
     expect(scanForSecrets(prose, "/tmp/notes.md")).toEqual([]);
+  });
+
+  // HOME path portability wiring. Each sanitize function must rewrite a literal
+  // home-prefix to the ${AGENTSYNC_HOME} placeholder before serializing so the
+  // vault round-trips across machines with different home directories.
+
+  test("sanitizeClaudeHooks rewrites home-prefixed paths to placeholder", () => {
+    const home = "/home/alpha";
+    const raw = JSON.stringify({
+      hooks: { PreToolUse: [{ command: `${home}/.claude/runner` }] },
+    });
+    const out = JSON.parse(sanitizeClaudeHooks(raw, home).value) as {
+      hooks: { PreToolUse: { command: string }[] };
+    };
+    expect(out.hooks.PreToolUse[0]?.command).toBe(`${AGENTSYNC_HOME_PLACEHOLDER}/.claude/runner`);
+  });
+
+  test("sanitizeClaudeMcp rewrites home-prefixed paths to placeholder", () => {
+    const home = "/Users/alpha";
+    const raw = JSON.stringify({
+      mcpServers: { fs: { command: "node", cwd: `${home}/proj` } },
+    });
+    const out = JSON.parse(sanitizeClaudeMcp(raw, home).value) as {
+      mcpServers: { fs: { cwd: string } };
+    };
+    expect(out.mcpServers.fs.cwd).toBe(`${AGENTSYNC_HOME_PLACEHOLDER}/proj`);
+  });
+
+  test("sanitizeClaudePluginManifest rewrites home-prefixed paths to placeholder", () => {
+    const home = "/Users/alpha";
+    const raw = JSON.stringify({
+      name: "lefthook",
+      installPath: `${home}/.claude/plugins/lefthook`,
+    });
+    const out = JSON.parse(sanitizeClaudePluginManifest(raw, home).value) as {
+      installPath: string;
+      name: string;
+    };
+    expect(out.installPath).toBe(`${AGENTSYNC_HOME_PLACEHOLDER}/.claude/plugins/lefthook`);
+    expect(out.name).toBe("lefthook");
+  });
+
+  test("sanitizeClaudePluginMcp rewrites home-prefixed paths to placeholder", () => {
+    const home = "/Users/alpha";
+    const raw = JSON.stringify({
+      command: "node",
+      args: [`${home}/.claude/plugins/x/srv.js`, "--root=/etc/hosts"],
+    });
+    const out = JSON.parse(sanitizeClaudePluginMcp(raw, home).value) as { args: string[] };
+    expect(out.args[0]).toBe(`${AGENTSYNC_HOME_PLACEHOLDER}/.claude/plugins/x/srv.js`);
+    expect(out.args[1]).toBe("--root=/etc/hosts");
+  });
+
+  test("sanitize functions pass through unchanged when home is empty", () => {
+    const home = "/Users/alpha";
+    const raw = JSON.stringify({ hooks: { PreToolUse: [{ command: `${home}/runner` }] } });
+    const out = JSON.parse(sanitizeClaudeHooks(raw, "").value) as {
+      hooks: { PreToolUse: { command: string }[] };
+    };
+    expect(out.hooks.PreToolUse[0]?.command).toBe(`${home}/runner`);
   });
 });

--- a/src/core/sanitizer.ts
+++ b/src/core/sanitizer.ts
@@ -1,4 +1,6 @@
+import { homedir } from "node:os";
 import { basename } from "node:path";
+import { normalizeForVault } from "./path-portability";
 
 /** Global path patterns that AgentSync must never copy into the encrypted vault. */
 export const NEVER_SYNC_PATTERNS = [
@@ -170,22 +172,38 @@ export function redactSecretLiterals(
   return { value: input, warnings: [] };
 }
 
-/** Keep only Claude hook settings and redact any embedded literal secrets. */
-export function sanitizeClaudeHooks(rawSettingsJson: string): RedactionResult<string> {
+/**
+ * Keep only Claude hook settings and redact any embedded literal secrets.
+ * HOME-rooted string values are rewritten to the AGENTSYNC_HOME placeholder so
+ * the vault round-trips across machines with different home directories.
+ * Pass `home: ""` to disable normalization in tests.
+ */
+export function sanitizeClaudeHooks(
+  rawSettingsJson: string,
+  home: string = homedir(),
+): RedactionResult<string> {
   const parsed = JSON.parse(rawSettingsJson) as Record<string, unknown>;
   const hooksOnly = { hooks: parsed.hooks ?? {} };
-  const redacted = redactSecretLiterals(hooksOnly, "hooks");
+  const normalized = normalizeForVault(hooksOnly, home);
+  const redacted = redactSecretLiterals(normalized, "hooks");
   return {
     value: `${JSON.stringify(redacted.value, null, 2)}\n`,
     warnings: redacted.warnings,
   };
 }
 
-/** Keep only Claude MCP settings and redact any embedded literal secrets. */
-export function sanitizeClaudeMcp(rawClaudeJson: string): RedactionResult<string> {
+/**
+ * Keep only Claude MCP settings and redact any embedded literal secrets.
+ * Path-portability rules match {@link sanitizeClaudeHooks}.
+ */
+export function sanitizeClaudeMcp(
+  rawClaudeJson: string,
+  home: string = homedir(),
+): RedactionResult<string> {
   const parsed = JSON.parse(rawClaudeJson) as Record<string, unknown>;
   const mcpOnly = { mcpServers: parsed.mcpServers ?? {} };
-  const redacted = redactSecretLiterals(mcpOnly, "mcpServers");
+  const normalized = normalizeForVault(mcpOnly, home);
+  const redacted = redactSecretLiterals(normalized, "mcpServers");
   return {
     value: `${JSON.stringify(redacted.value, null, 2)}\n`,
     warnings: redacted.warnings,
@@ -203,9 +221,13 @@ export function sanitizeClaudeMcp(rawClaudeJson: string): RedactionResult<string
  * replaces obvious credential strings with the standard placeholder while
  * leaving structural fields untouched.
  */
-export function sanitizeClaudePluginManifest(rawJson: string): RedactionResult<string> {
+export function sanitizeClaudePluginManifest(
+  rawJson: string,
+  home: string = homedir(),
+): RedactionResult<string> {
   const parsed = JSON.parse(rawJson) as unknown;
-  const redacted = redactSecretLiterals(parsed, "plugin");
+  const normalized = normalizeForVault(parsed, home);
+  const redacted = redactSecretLiterals(normalized, "plugin");
   return {
     value: `${JSON.stringify(redacted.value, null, 2)}\n`,
     warnings: redacted.warnings,
@@ -219,9 +241,13 @@ export function sanitizeClaudePluginManifest(rawJson: string): RedactionResult<s
  * descriptor that the plugin owner controls. Literal secret redaction still
  * runs over every value.
  */
-export function sanitizeClaudePluginMcp(rawJson: string): RedactionResult<string> {
+export function sanitizeClaudePluginMcp(
+  rawJson: string,
+  home: string = homedir(),
+): RedactionResult<string> {
   const parsed = JSON.parse(rawJson) as unknown;
-  const redacted = redactSecretLiterals(parsed, "pluginMcp");
+  const normalized = normalizeForVault(parsed, home);
+  const redacted = redactSecretLiterals(normalized, "pluginMcp");
   return {
     value: `${JSON.stringify(redacted.value, null, 2)}\n`,
     warnings: redacted.warnings,


### PR DESCRIPTION
## Summary

Completes the adapter half of #70: wires `src/core/path-portability` (landed in #72) into every JSON/TOML snapshot+apply path so home-rooted paths round-trip across machines (B24), and ships four independent adapter corrections found in the same bug-bash pass:

- **B15** copilot: agents are single `<name>.agent.md` files per [GitHub Copilot CLI docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli), not directory tarballs
- **B17** codex: `AGENTS.override.md` is now snapshot and restored alongside `AGENTS.md` (precedence honoured by codex itself on read)
- **B19** claude: `~/.claude/rules/*.md` round-trips so `@~/.claude/rules/*.md` includes in `CLAUDE.md` stay resolvable on the destination machine
- **B22** codex: skills resolve to the canonical `$HOME/.agents/skills` per [Codex Skills docs](https://developers.openai.com/codex/skills); legacy `~/.codex/skills` remains readable on snapshot for forward migration

## Changes

### `src/core/sanitizer.ts`

The four sanitize helpers (`sanitizeClaudeHooks`, `sanitizeClaudeMcp`, `sanitizeClaudePluginManifest`, `sanitizeClaudePluginMcp`) gain an optional `home: string = homedir()` parameter. They insert `normalizeForVault` between `JSON.parse` and `redactSecretLiterals` so home-rooted string values become the `${AGENTSYNC_HOME}` placeholder before encryption. Tests pass `""` to disable normalization.

### `src/agents/claude.ts`

- Snapshot passes `homedir()` to every `sanitize…` call; marketplace JSON now goes through `normalizeForVault` before redaction
- `applyClaudeHooks` / `applyClaudeMcp` denormalize only the synced subset before merging into the local file, preserving local-only top-level keys with literal `$` values intact
- Plugin manifest, plugin `.mcp.json`, and `marketplace.json` apply now `denormalizeStringFromVault` the raw content before write (whole-file replacements, no subset merge)
- B19: snapshot loop for `rules/*.md` mirroring `commands/*.md`; new `applyClaudeRule` + dispatch in `applyClaudeVault`

### `src/agents/codex.ts`

- `sanitizeCodexConfig` takes `home`, normalizes the parsed TOML before redaction
- `applyCodexConfig` denormalizes incoming TOML pre-merge so the placeholder never reaches disk
- B17: `AGENTS.override.md` snapshot + new `applyCodexAgentsOverrideMd` + dispatch
- B22: snapshot reads both `userSkillsDir` (canonical) and `skillsDir` (legacy); deduplication keys come from the canonical directory listing rather than emitted artifacts so a walker-rejected canonical skill still blocks its legacy copy from leaking through. `applyCodexSkill` writes exclusively to `userSkillsDir`

### `src/agents/cursor.ts`, `src/agents/vscode.ts`

Inline `normalizeForVault` on snapshot (between parse and redact) and `denormalizeStringFromVault` on apply (whole-file write). Cursor's `rules` string flows through `normalizeStringForVault` / `denormalizeStringFromVault`.

### `src/agents/copilot.ts`

B15 rewrite: snapshot iterates `*.agent.md` files individually, emitting plaintext artifacts at `copilot/agents/<name>.agent.md.age`. `applyCopilotAgent` becomes a single-file write. The old per-directory tar archive path, per-agent interior-violation scan, and the `validateSkillName` guard on agent names are removed — secret/never-sync scanning now belongs to the central walker in `commands/push.ts` over the plaintext artifact stream.

### Architecture

**Before — adapter snapshot/apply, no HOME portability:**

```mermaid
flowchart LR
  Disk["~/.claude.json<br/>cwd: /Users/alpha/proj"]:::local --> Parse["JSON.parse"]
  Parse --> Redact["redactSecretLiterals"]:::xform
  Redact --> Encrypt["age encrypt"]:::xform
  Encrypt --> Vault["vault: cwd literal still /Users/alpha/proj"]:::leak
  Vault --> Decrypt["age decrypt"]:::xform
  Decrypt --> Write["atomicWrite as-is"]:::xform
  Write --> Beta["~/.claude.json on machine B<br/>cwd: /Users/alpha/proj BROKEN"]:::leak

  classDef local fill:#ecf0f1,color:#2c3e50,stroke:#2c3e50
  classDef xform fill:#34495e,color:#ffffff,stroke:#2c3e50
  classDef leak fill:#c0392b,color:#ffffff,stroke:#922b21
```

**After — HOME normalize wired between parse and redact; denormalize before write:**

```mermaid
flowchart LR
  Disk2["~/.claude.json<br/>cwd: /Users/alpha/proj"]:::local --> Parse2["JSON.parse"]
  Parse2 --> Norm["normalizeForVault home=/Users/alpha"]:::xform
  Norm --> Redact2["redactSecretLiterals"]:::xform
  Redact2 --> Encrypt2["age encrypt"]:::xform
  Encrypt2 --> Vault2["vault: cwd = AGENTSYNC_HOME/proj"]:::keep
  Vault2 --> Decrypt2["age decrypt"]:::xform
  Decrypt2 --> Denorm["denormalize home=/Users/beta"]:::xform
  Denorm --> Beta2["~/.claude.json on machine B<br/>cwd: /Users/beta/proj"]:::keep

  classDef local fill:#ecf0f1,color:#2c3e50,stroke:#2c3e50
  classDef xform fill:#34495e,color:#ffffff,stroke:#2c3e50
  classDef keep fill:#27ae60,color:#ffffff,stroke:#1e8449
```

## Test Evidence

- `bun run typecheck` — clean
- `bunx biome check src/` — 3 pre-existing warnings on `path-portability.ts` (placeholder constant), no new findings
- `bun test` — **553 pass / 0 fail** (was 535 on main; added 18 new tests covering wiring + B17 + B19 + B22 + dedup-rejection regression + codex TOML round-trip)

New tests:

| File | Coverage |
| --- | --- |
| `src/core/__tests__/sanitizer.test.ts` | 5 tests proving home→placeholder rewrite for each sanitize function |
| `src/agents/__tests__/claude.test.ts` | rules snapshot + apply + vault dispatch; `applyClaudeHooks` / `applyClaudeMcp` denormalize-subset preserves local keys |
| `src/agents/__tests__/codex.test.ts` | `AGENTS.override.md` round-trip; canonical/legacy skills + canonical-wins + canonical-rejected-blocks-legacy regression; config.toml HOME normalize and denormalize end-to-end |
| `src/agents/__tests__/copilot.test.ts` | Replaced 5 tar-layout tests with 2 single-file tests; obsolete interior-violation tests moved to the central-walker contract |

## Risks / Follow-ups

- **B22 migration**: a user with skills only at `~/.codex/skills/<name>/` and `~/.agents/skills/<name>/` non-existent will see the next pull materialize them under `~/.agents/skills/<name>/` (the canonical location). The legacy directory is *not* automatically removed. If the user later re-pushes from a machine where they have both legacy and canonical, the canonical wins.
- **B16 carry-over from #72**: a pre-fix user with `~/.copilot/instructions` (no extension) will see it ignored after this PR — the canonical filename is `copilot-instructions.md`. Documented release-note migration recommended.
- **Markdown out of scope for B24**: `CLAUDE.md`, `AGENTS.md`, rules, commands, agents, prompts are not normalized — prose-style absolute paths inside markdown are user content. The portability invariant applies only to JSON/TOML structured values.
- **B18** (codex `rules/` upstream-source decision) and **e2e harness** (#71) deferred.

## Checklist

- [x] New code has tests where appropriate — 18 new tests covering every wiring point plus the dedup-rejection edge case surfaced in senior review
- [x] Documentation updated if behavior changed — adapter comments inline, WHY-only per project convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude rules synchronization
  * Codex AGENTS.override.md support and user-scoped skills directory

* **Improvements**
  * Copilot agents now stored as single plaintext agent files
  * Improved HOME-path portability across Claude, Codex, VS Code, Cursor, and Copilot

* **Bug Fixes / Safety**
  * Stricter handling to avoid symlink, traversal, dotfile, and hidden-name leaks during snapshot/restore

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/73)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->