### PR TITLE
fix(migrate): cursorToClaude writes CLAUDE.md, gate sentinel routing in applyMigrated (#75)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6c753935-3a61-49b7-ba71-ae03a2eccab8","pid":94581,"procStart":"Fri May  8 10:30:38 2026","acquiredAt":1778707616559}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6c753935-3a61-49b7-ba71-ae03a2eccab8","pid":94581,"procStart":"Fri May  8 10:30:38 2026","acquiredAt":1778707616559}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ coverage/
 .specify/extensions/.backup/
 .specify/extensions/*/local-config.yml
 
+# Local Claude Code plugin runtime state (per-machine locks)
+.claude/scheduled_tasks.lock
+
 # Docs build + QA artifacts
 site/
 .cache/

--- a/docker/e2e/scenarios/10-migrate.sh
+++ b/docker/e2e/scenarios/10-migrate.sh
@@ -76,9 +76,9 @@ with_machine "$MACHINE" bun run src/cli.ts migrate --from cursor --to claude --t
   2>&1 | sed 's/^/    /'
 
 assert_file_exists "$MACHINE/.claude/CLAUDE.md"
-grep -q "$CURSOR_RULES_BODY" "$MACHINE/.claude/CLAUDE.md" \
+grep -Fq "$CURSOR_RULES_BODY" "$MACHINE/.claude/CLAUDE.md" \
   || fail "migrated CLAUDE.md missing canary rules body"
-grep -q "migrated from Cursor" "$MACHINE/.claude/CLAUDE.md" \
+grep -Fq "migrated from Cursor" "$MACHINE/.claude/CLAUDE.md" \
   || fail "migrated CLAUDE.md missing 'migrated from Cursor' heading"
 
 # Source must be byte-identical — the prior bug clobbered settings.json with

--- a/docker/e2e/scenarios/10-migrate.sh
+++ b/docker/e2e/scenarios/10-migrate.sh
@@ -57,14 +57,37 @@ pass "re-run produced byte-identical AGENTS.md"
 step "Subtest 4: migrate --from cursor --to claude --type global-rules"
 reset_machine
 # Force a recognisable rules string into Cursor's settings so we can assert it
-# made it into CLAUDE.md.
-# Subtest 4 deferred — surfaced a real translator bug. The registry at
-# src/migrate/translators/global-rules.ts:104 binds `cursorToClaude` to a
-# helper named `fromCursor` whose targetName returns the source filename
-# rather than `CLAUDE.md`. Running this subtest writes back into the cursor
-# settings.json instead of producing ~/.claude/CLAUDE.md. Tracking as a
-# follow-up issue; current PR is e2e-only (no src/ changes).
-info "Subtest 4 (cursor→claude) deferred — src/migrate translator bug at registry.ts:104"
+# made it into CLAUDE.md without altering cursor's settings.json.
+CURSOR_RULES_BODY="MIGRATE_CANARY_CURSOR_RULES — be concise."
+CURSOR_SETTINGS="$MACHINE/.config/Cursor/User/settings.json"
+node -e '
+  const fs = require("fs");
+  const p = process.argv[1];
+  const body = process.argv[2];
+  const s = JSON.parse(fs.readFileSync(p, "utf8"));
+  s.rules = body;
+  s.siblingSetting = "keep-me";
+  fs.writeFileSync(p, JSON.stringify(s, null, 2));
+' "$CURSOR_SETTINGS" "$CURSOR_RULES_BODY"
+cursor_settings_pre_sha=$(sha256sum "$CURSOR_SETTINGS" | awk '{print $1}')
+rm -f "$MACHINE/.claude/CLAUDE.md"
+
+with_machine "$MACHINE" bun run src/cli.ts migrate --from cursor --to claude --type global-rules \
+  2>&1 | sed 's/^/    /'
+
+assert_file_exists "$MACHINE/.claude/CLAUDE.md"
+grep -q "$CURSOR_RULES_BODY" "$MACHINE/.claude/CLAUDE.md" \
+  || fail "migrated CLAUDE.md missing canary rules body"
+grep -q "migrated from Cursor" "$MACHINE/.claude/CLAUDE.md" \
+  || fail "migrated CLAUDE.md missing 'migrated from Cursor' heading"
+
+# Source must be byte-identical — the prior bug clobbered settings.json with
+# the wrapped migration output and lost sibling fields.
+cursor_settings_post_sha=$(sha256sum "$CURSOR_SETTINGS" | awk '{print $1}')
+[ "$cursor_settings_pre_sha" = "$cursor_settings_post_sha" ] \
+  || fail "cursor settings.json was modified by cursor→claude migration ($cursor_settings_pre_sha → $cursor_settings_post_sha)"
+
+pass "cursor→claude wrote CLAUDE.md and left cursor settings.json untouched"
 
 # ── Subtest 5: claude → cursor mcp ──────────────────────────────────────────
 step "Subtest 5: migrate --from claude --to cursor --type mcp"

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -166,6 +166,65 @@ describe("performMigrate", () => {
     expect(result.migrated[0].targetPath).toBe(testCursor.settingsJson);
   });
 
+  test("migrates cursor global-rules to claude (writes CLAUDE.md, leaves source untouched)", async () => {
+    const cursorRulesBody = "Be concise.\nNo emojis.";
+    writeFixture(
+      testCursor.settingsJson,
+      JSON.stringify({ rules: cursorRulesBody, otherSetting: "keep-me" }),
+    );
+
+    const result = await performMigrate({
+      from: "cursor",
+      to: "claude",
+      type: "global-rules",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.migrated).toHaveLength(1);
+    expect(result.migrated[0].targetPath).toBe(testClaude.claudeMd);
+
+    const { readIfExists } = await import("../../agents/_utils");
+    const claudeMd = await readIfExists(testClaude.claudeMd);
+    expect(claudeMd).toContain("migrated from Cursor");
+    expect(claudeMd).toContain(cursorRulesBody);
+
+    // Regression guard: prior version routed this migration back to
+    // cursor's settings.json. The `rules` field and sibling settings
+    // must both be preserved exactly.
+    const cursorRaw = await readIfExists(testCursor.settingsJson);
+    expect(cursorRaw).not.toBeNull();
+    const cursor = JSON.parse(cursorRaw as string);
+    expect(cursor.rules).toBe(cursorRulesBody);
+    expect(cursor.otherSetting).toBe("keep-me");
+  });
+
+  test("applyMigrated ignores cursor-rules sentinel when target is not cursor", async () => {
+    // Defense in depth: even if a translator returns the sentinel for a
+    // non-cursor target, applyMigrated must route the write to the declared
+    // target agent's file, not cursor's settings.json.
+    writeFixture(testCursor.settingsJson, JSON.stringify({ rules: "untouched-cursor-rules" }));
+
+    const artifact = await applyMigrated(
+      "claude",
+      "global-rules",
+      "__cursor_rules__",
+      "# Rules\n\nbody\n",
+      false,
+    );
+
+    expect(artifact).not.toBeNull();
+    expect(artifact?.targetPath).toBe(testClaude.claudeMd);
+
+    const { readIfExists } = await import("../../agents/_utils");
+    const claudeMd = await readIfExists(testClaude.claudeMd);
+    expect(claudeMd).toContain("body");
+
+    const cursorRaw = await readIfExists(testCursor.settingsJson);
+    const cursor = JSON.parse(cursorRaw as string);
+    expect(cursor.rules).toBe("untouched-cursor-rules");
+  });
+
   test("migrates claude MCP to codex (JSON → TOML)", async () => {
     writeFixture(
       testClaude.mcpJson,

--- a/src/migrate/__tests__/translators/global-rules.test.ts
+++ b/src/migrate/__tests__/translators/global-rules.test.ts
@@ -14,12 +14,23 @@ describe("global-rules translators", () => {
     expect(result?.content).toBe("# My Rules\n\nBe helpful.");
   });
 
-  test("cursor → claude wraps content with heading", () => {
+  test("cursor → claude wraps content with heading, targets CLAUDE.md", () => {
     const result = translateGlobalRules.cursorToClaude("Be concise.");
     expect(result).not.toBeNull();
-    expect(result?.targetName).toBe("rules.md");
+    expect(result?.targetName).toBe("CLAUDE.md");
     expect(result?.content).toContain("migrated from Cursor");
     expect(result?.content).toContain("Be concise.");
+  });
+
+  test("cursor → claude ignores sourceName (no source-file overwrite)", () => {
+    // Regression guard: a prior version returned `sourceName` as targetName,
+    // routing the write back to cursor's settings.json. The translator must
+    // always emit the literal CLAUDE.md filename so the orchestrator resolves
+    // the destination via the agent path map, not the source path. Also
+    // pins the provenance wrapper so a future "simplification" can't drop it.
+    const result = translateGlobalRules.cursorToClaude("rules", "__cursor_rules__");
+    expect(result?.targetName).toBe("CLAUDE.md");
+    expect(result?.content).toContain("migrated from Cursor");
   });
 
   test("claude → codex preserves content, targets AGENTS.md", () => {

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -60,8 +60,7 @@ export async function readSourceArtefacts(
       if (filePath) {
         const content = await readIfExists(filePath);
         if (content) {
-          const name = basename(filePath) || "rules.md";
-          results.push({ content, name });
+          results.push({ content, name: basename(filePath) });
         }
       }
     }
@@ -127,7 +126,13 @@ export async function applyMigrated(
   dryRun: boolean,
 ): Promise<MigratedArtifact | null> {
   if (type === "global-rules") {
-    if (targetName === "__cursor_rules__") {
+    // The cursor-rules sentinel only routes to cursor's settings.json when the
+    // declared target is cursor. Without this gate, a translator that
+    // mistakenly returns the sentinel for a non-cursor target would overwrite
+    // cursor's settings.json instead of writing the intended agent file.
+    // Fall-through (below) preserves data integrity for the source even if
+    // the resulting target file is missing the translator's usual wrapper.
+    if (targetName === "__cursor_rules__" && to === "cursor") {
       const targetPath = AgentPaths.cursor.settingsJson;
       if (!dryRun) await applyCursorRules(content);
       return {

--- a/src/migrate/translators/global-rules.ts
+++ b/src/migrate/translators/global-rules.ts
@@ -20,11 +20,13 @@ const toCursor: Translator = (content) => {
   return { content: trimmed, targetName: CURSOR_RULES_SENTINEL };
 };
 
-const fromCursor: Translator = (content, sourceName) => {
+const cursorToClaude: Translator = (content) => {
   const trimmed = content.trim();
   if (!trimmed) return null;
-  const target = sourceName ?? "rules.md";
-  return { content: `# Rules (migrated from Cursor)\n\n${trimmed}\n`, targetName: target };
+  return {
+    content: `# Rules (migrated from Cursor)\n\n${trimmed}\n`,
+    targetName: "CLAUDE.md",
+  };
 };
 
 // ── Between file-based agents (Claude, Codex, Copilot) ───────────────────────
@@ -101,7 +103,7 @@ const copilotToCodex: Translator = (content) => {
  */
 export const translateGlobalRules = {
   claudeToCursor: toCursor,
-  cursorToClaude: fromCursor,
+  cursorToClaude,
   claudeToCodex,
   codexToClaude,
   claudeToCopilot,


### PR DESCRIPTION
## Summary

`agentsync migrate --from cursor --to claude --type global-rules` previously overwrote `~/.config/Cursor/User/settings.json` with the wrapped migration output instead of producing `~/.claude/CLAUDE.md`. Two layers caused it:

1. The translator bound as `cursorToClaude` (`fromCursor` in `global-rules.ts`) returned `sourceName` as `targetName` — for cursor reads that is the `__cursor_rules__` sentinel.
2. `applyMigrated`'s global-rules branch routes any artefact with `targetName === "__cursor_rules__"` to `applyCursorRules`, regardless of the declared `to` agent. The sentinel and the declared intent never had to agree.

Net effect: cursor→claude was a no-op for CLAUDE.md and a destructive overwrite of cursor's settings.json.

Fix is two-layered:

- Dedicated `cursorToClaude` translator that emits `targetName: "CLAUDE.md"` and ignores `sourceName`, matching `codexToClaude` / `copilotToClaude`.
- Defense-in-depth gate in `applyMigrated`: the sentinel branch now requires `to === "cursor"`. A stray sentinel from any future translator targeting another agent falls through to the agent path map and writes the correct target file — sacrificing the wrapper heading in pathological cases to preserve cursor source data.

Audit of sibling translators (`cursorToCodex`, `cursorToCopilot`) confirms they were already correct (hardcoded targetName); the bug was strictly localised to `fromCursor`.

Closes #75.

## Changes

### Architecture

```mermaid
flowchart LR
  classDef src fill:#2c3e50,color:#ffffff
  classDef bug fill:#c0392b,color:#ffffff
  classDef ok fill:#27ae60,color:#ffffff

  subgraph Before
    direction LR
    A1["cursor<br/>settings.json"]:::src --> B1["fromCursor<br/>returns sourceName"]:::bug
    B1 --> C1["applyMigrated sees<br/>__cursor_rules__"]:::bug
    C1 --> D1["overwrites<br/>cursor settings.json"]:::bug
  end
```

```mermaid
flowchart LR
  classDef src fill:#2c3e50,color:#ffffff
  classDef ok fill:#27ae60,color:#ffffff

  subgraph After
    direction LR
    A2["cursor<br/>settings.json"]:::src --> B2["cursorToClaude<br/>emits CLAUDE.md"]:::ok
    B2 --> C2["applyMigrated:<br/>sentinel only if to=cursor"]:::ok
    C2 --> D2["writes<br/>claude CLAUDE.md"]:::ok
  end
```

### Code

- `src/migrate/translators/global-rules.ts` — replace internal `fromCursor` with dedicated `cursorToClaude` returning `targetName: "CLAUDE.md"`; update registry binding.
- `src/migrate/migrate.ts` — gate the `__cursor_rules__` sentinel branch in `applyMigrated` on `to === "cursor"`; drop the dead `"rules.md"` fallback in `readSourceArtefacts` (the linguistic ancestor of the bug).

### Tests

- `src/migrate/__tests__/translators/global-rules.test.ts` — fix the assertion pinned to bug behaviour (`targetName).toBe("rules.md")` → `"CLAUDE.md"`); add regression test that passes `"__cursor_rules__"` as `sourceName` and asserts `targetName: "CLAUDE.md"` plus the `migrated from Cursor` provenance wrapper.
- `src/migrate/__tests__/migrate.test.ts` — add integration test that asserts CLAUDE.md gets the migrated body and cursor settings.json's `rules` + sibling fields are preserved; add defense-in-depth unit test calling `applyMigrated("claude", "global-rules", "__cursor_rules__", …)` directly.

### E2E

- `docker/e2e/scenarios/10-migrate.sh` — re-enable Subtest 4 (previously deferred behind an `info` marker). Plants a canary `rules` body and `siblingSetting` into cursor settings.json, snapshots its sha256, runs the migration, then asserts CLAUDE.md contains the canary + provenance heading and the cursor settings.json sha256 is byte-identical pre/post.

## Test Evidence

- \`bun test\` — 561/561 pass.
- \`bun run typecheck\` — clean.
- \`bun run lint\` — clean (11 pre-existing warnings unrelated to this diff).
- \`bash -n docker/e2e/scenarios/10-migrate.sh\` — clean.
- Senior review gate ran 2 iterations; all Valid / Partially Valid findings applied; iteration 2 converged with zero new findings.

## Risks / Follow-ups

- Defense-in-depth fall-through: if a future translator returns the cursor sentinel while targeting a non-cursor agent (a buggy translator), the target file will receive the bare content without the \`# Rules (migrated from Cursor)\` wrapper. That is preferable to corrupting cursor's settings.json; the in-source comment documents the tradeoff.
- No other registry binding has the same mis-bind shape (verified via grep \`": fromCursor"\` and audit of sibling translators).

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed (e2e scenario doc-comment updated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cursor global-rules migration to Claude now functions correctly, ensuring Cursor settings remain intact after migration.

* **Tests**
  * Comprehensive test coverage added for global-rules migration from Cursor to Claude.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/78)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->