### PR TITLE
test(e2e): re-enable scenario 17 by co-locating git daemon in machine (#76)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,12 +38,7 @@ jobs:
           - 14-dry-run.sh
           - 15-plugin-marketplace.sh
           - 16-vscode-non-mcp.sh
-          # 17-git-protocol.sh — deferred: `docker compose run --rm` does not
-          # reliably resolve the `git-daemon` service hostname even when the
-          # profile is active. Tracked separately; scenario file ships in the
-          # tree so the locally-running developer can exercise it via
-          # `bun run e2e:scenario SCENARIO=17-git-protocol.sh` after a manual
-          # `--profile git-daemon up -d git-daemon`.
+          - 17-git-protocol.sh
           - 18-copilot.sh
           - 19-codex-overrides.sh
           - 20-home-portability.sh
@@ -60,27 +55,14 @@ jobs:
       - name: Initialize vault
         run: docker compose -f docker/e2e/compose.yml up -d vault-init
 
-      # matrix.scenario is a static list literal in this file; not untrusted.
-      - name: Start git-daemon (only for scenario 17)
-        if: matrix.scenario == '17-git-protocol.sh'
-        run: docker compose -f docker/e2e/compose.yml --profile git-daemon up -d git-daemon
-
-      - name: Run scenario (non-git-daemon)
-        if: matrix.scenario != '17-git-protocol.sh'
+      - name: Run scenario
+        # matrix.scenario is a static list literal in this file (not
+        # untrusted), but route through env: anyway so future contributors
+        # can copy the pattern when wiring untrusted inputs.
         env:
           SCENARIO: ${{ matrix.scenario }}
         run: |
           docker compose -f docker/e2e/compose.yml run --rm \
-            machine "/home/agent/scenarios/$SCENARIO"
-
-      # Scenario 17 needs to share the git-daemon network — `docker compose run`
-      # only attaches to services in the active profile, so include it here.
-      - name: Run scenario 17 with git-daemon profile
-        if: matrix.scenario == '17-git-protocol.sh'
-        env:
-          SCENARIO: ${{ matrix.scenario }}
-        run: |
-          docker compose -f docker/e2e/compose.yml --profile git-daemon run --rm \
             machine "/home/agent/scenarios/$SCENARIO"
 
       - name: Capture logs on failure

--- a/docker/e2e/README.md
+++ b/docker/e2e/README.md
@@ -124,7 +124,7 @@ back to the local `homedir()` on pull (B24).
 | 14 | `14-dry-run.sh` | `push --dry-run` lists intended changes but produces no commit |
 | 15 | `15-plugin-marketplace.sh` | Plugin subpath round-trip (`.claude-plugin/plugin.json`, `commands/`, `agents/`, `skills/`, `hooks/`, `.mcp.json`) + `syncMarketplace` toggle (B4, B5) |
 | 16 | `16-vscode-non-mcp.sh` | Pin (B6): VS Code adapter syncs **only** `mcp.json.mcpServers`; settings/keybindings/snippets stay local |
-| 17 | `17-git-protocol.sh` | `git://` transport via the `git-daemon` compose profile (B7) |
+| 17 | `17-git-protocol.sh` | `git://` transport via an in-container `git daemon` on 127.0.0.1:9418 (B7) |
 | 18 | `18-copilot.sh` | Pin/verify canonical `copilot-instructions.md` filename (B16) + single-file `.agent.md` shape (B15); pin not-synced state of `lsp-config.json`, `settings.json`, `mcp-config.json` (B13, B14, B23) |
 | 19 | `19-codex-overrides.sh` | `AGENTS.override.md` precedence (B17); `~/.agents/skills` canonical + legacy fallback (B22); `themes/**` absence (B25); `~/.codex/rules/` intent pin (B18) |
 | 20 | `20-home-portability.sh` | **Headline.** HOME=`/tmp/alpha` push → HOME=`/tmp/beta` pull; every JSON/TOML absolute-HOME path rewrites to `/tmp/beta/…`; `/etc/hosts` and `/opt/foo` left verbatim; markdown bodies left verbatim |
@@ -183,20 +183,18 @@ bun run e2e:all
 ```bash
 bun run e2e:all                            # full sweep (20 scenarios)
 SCENARIOS="smoke.sh 02-multi-machine.sh" bun run e2e:all
-SKIP="17-git-protocol.sh" bun run e2e:all  # skip git:// (needs compose profile)
 SCENARIO=18-copilot.sh bun run e2e:scenario  # one scenario
 bun run e2e:smoke                          # legacy single-up smoke
 bun run e2e:audit                          # decrypted-blob leak audit
 ```
 
-Scenario 17 requires the `git-daemon` compose profile up first:
+Scenario 17 (`git://` transport) is self-contained — it spawns `git daemon`
+inside the `machine` container on 127.0.0.1:9418, so no compose profile or
+sidecar service is required. Run it like any other scenario:
 
 ```bash
-docker compose -f docker/e2e/compose.yml --profile git-daemon up -d git-daemon
 SCENARIO=17-git-protocol.sh bun run e2e:scenario
 ```
-
-`bun run e2e:all` handles the profile lifecycle automatically.
 
 ## Layout
 
@@ -204,7 +202,7 @@ SCENARIO=17-git-protocol.sh bun run e2e:scenario
 docker/e2e/
 ├── README.md                  this file
 ├── Dockerfile.machine         node:24 + bun (latest) + claude/codex/cursor (@latest) + jq + rsync + netcat + age
-├── compose.yml                vault-init + machine + git-daemon (profile)
+├── compose.yml                vault-init + machine (scenario 17 runs git-daemon inside machine)
 ├── entrypoint.sh              rsync fixtures/home/ → /home/agent, drift-check CLIs, exec scenario
 ├── canary-isolation.sh        host-side leak verifier
 ├── run-all.sh                 local driver — iterates scenarios/*.sh

--- a/docker/e2e/compose.yml
+++ b/docker/e2e/compose.yml
@@ -30,29 +30,11 @@ services:
     # Default CMD runs the smoke scenario. Per-scenario CI runs override CMD
     # via `docker compose run --rm machine /home/agent/scenarios/$NAME.sh`.
 
-  # Scenario 17 (git:// protocol). Brought up only when the `git-daemon`
-  # profile is selected so default `compose up` stays cheap. Modern git refuses
-  # to run `git daemon` as root unless --user is set; we drop to the alpine
-  # `git` user (uid 1000 in alpine/git) for the listener.
-  git-daemon:
-    image: alpine/git:latest
-    profiles: ["git-daemon"]
-    volumes:
-      - vault-data:/vault
-    user: "1000:1000"
-    expose: ["9418"]
-    command:
-      - sh
-      - -c
-      - |
-        set -e
-        git daemon \
-          --reuseaddr \
-          --base-path=/vault \
-          --export-all \
-          --enable=receive-pack \
-          --verbose \
-          /vault
+  # Scenario 17 (git:// protocol) is self-contained — it spawns `git daemon`
+  # inside the `machine` container on 127.0.0.1:9418 rather than relying on a
+  # cross-container service. That avoids the DNS quirk we hit on GitHub
+  # Actions runners where `compose --profile … run --rm` could not resolve a
+  # sibling service hostname. See docker/e2e/scenarios/17-git-protocol.sh.
 
 volumes:
   vault-data:

--- a/docker/e2e/run-all.sh
+++ b/docker/e2e/run-all.sh
@@ -11,7 +11,7 @@
 # Usage:
 #   bash docker/e2e/run-all.sh
 #   SCENARIOS="smoke.sh 02-multi-machine.sh" bash docker/e2e/run-all.sh
-#   SKIP="17-git-protocol.sh" bash docker/e2e/run-all.sh
+#   SKIP="11-daemon-ipc.sh" bash docker/e2e/run-all.sh
 
 set -euo pipefail
 
@@ -80,12 +80,6 @@ for scenario in "${active_scenarios[@]}"; do
     continue
   fi
 
-  # Scenario 17 wants the git-daemon profile up.
-  if [ "$scenario" = "17-git-protocol.sh" ]; then
-    yellow "▶ Bringing up git-daemon profile for $scenario"
-    docker compose -f "$COMPOSE_FILE" --profile git-daemon up -d git-daemon
-  fi
-
   yellow "▶ RUN  $scenario"
   if docker compose -f "$COMPOSE_FILE" run --rm \
        machine "/home/agent/scenarios/${scenario}"; then
@@ -94,10 +88,6 @@ for scenario in "${active_scenarios[@]}"; do
   else
     red "✗ FAIL $scenario"
     failed+=("$scenario")
-  fi
-
-  if [ "$scenario" = "17-git-protocol.sh" ]; then
-    docker compose -f "$COMPOSE_FILE" stop git-daemon >/dev/null 2>&1 || true
   fi
 done
 

--- a/docker/e2e/scenarios/17-git-protocol.sh
+++ b/docker/e2e/scenarios/17-git-protocol.sh
@@ -3,28 +3,74 @@ set -euo pipefail
 # shellcheck source=/home/agent/scenarios/_lib.sh
 source /home/agent/scenarios/_lib.sh
 
-# Validate that AgentSync works through the unauthenticated git:// transport
-# served by the compose `git-daemon` profile. The daemon is started by CI (or
-# by docker/e2e/run-all.sh) before this scenario; if absent, fail fast with a
-# clear remediation hint instead of hanging on a TCP connect retry.
+# Validate that AgentSync works through the unauthenticated git:// transport.
+# The daemon runs *inside this same container* on 127.0.0.1:9418 to avoid the
+# cross-container DNS quirk that occasionally surfaces on GitHub Actions
+# runners — co-locating the daemon keeps the scenario hermetic and matches
+# every other scenario's shape (no compose profile, no host-side prep).
 
-GIT_REMOTE="git://git-daemon:9418/repo.git"
+GIT_REMOTE="git://127.0.0.1:9418/repo.git"
 MACHINE_A=/tmp/gitproto-machine-a
 MACHINE_B=/tmp/gitproto-machine-b
+DAEMON_PID=""
+DAEMON_LOG=$(mktemp)
+
+cleanup() {
+  if [ -n "$DAEMON_PID" ] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  rm -f "$DAEMON_LOG"
+}
+trap cleanup EXIT INT TERM HUP
+
+# ─── Start an in-container git-daemon ────────────────────────────────────────
+
+step "Start git-daemon on 127.0.0.1:9418 (in-container, --base-path=/vault)"
+# --reuseaddr: forgive a stale TIME_WAIT if the previous run died mid-flight
+# --export-all: skip per-repo git-daemon-export-ok marker (vault-init does not write one)
+# --enable=receive-pack: allow push (default exposes upload-pack only)
+# --informative-errors: clearer client-side errors than the default
+# --timeout / --init-timeout: bound any pathological client hang to 30s
+# Daemon and vault are both owned by uid 1001 (agent user; see Dockerfile.machine
+# and vault-init's `chown -R 1001:1001 /vault`). If the agent uid changes,
+# receive-pack will EACCES — keep them in sync.
+git daemon \
+  --reuseaddr \
+  --base-path=/vault \
+  --export-all \
+  --enable=receive-pack \
+  --informative-errors \
+  --timeout=30 \
+  --init-timeout=30 \
+  --listen=127.0.0.1 \
+  --port=9418 \
+  /vault >"$DAEMON_LOG" 2>&1 &
+DAEMON_PID=$!
 
 # ─── Liveness probe ──────────────────────────────────────────────────────────
 
-step "Probe git-daemon liveness (10s timeout)"
+step "Probe git-daemon liveness (10s wall-clock cap)"
+# `git ls-remote` against a not-yet-listening daemon retries — cap each probe
+# to 0.5s so the overall loop stays inside the advertised 10s wall-clock. Do
+# NOT use --exit-code: an empty bare repo (no refs yet) is still "alive"; the
+# first push creates refs.
 set +e
-# `git ls-remote` against a missing service hangs on connect; cap it. We do
-# NOT use --exit-code here so an empty repo (no refs yet) is still treated as
-# alive — the next `git init --bare` push will create refs.
-probe_out=$(timeout 10s git ls-remote "$GIT_REMOTE" 2>&1)
-probe_exit=$?
+SECONDS=0
+probe_exit=1
+while [ $SECONDS -lt 10 ]; do
+  if probe_out=$(timeout 0.5s git ls-remote "$GIT_REMOTE" 2>&1); then
+    probe_exit=0
+    break
+  fi
+  sleep 0.5
+done
 set -e
-echo "$probe_out" | sed 's/^/    /'
+echo "${probe_out:-<no output>}" | sed 's/^/    /'
 if [ "$probe_exit" -ne 0 ]; then
-  fail "Scenario 17 requires \`docker compose --profile git-daemon up -d git-daemon\` first."
+  echo "── git-daemon log ──"
+  sed 's/^/    /' "$DAEMON_LOG"
+  fail "git-daemon did not become reachable at $GIT_REMOTE within 10s"
 fi
 pass "git-daemon reachable at $GIT_REMOTE"
 


### PR DESCRIPTION
## Summary

Scenario 17 (`docker/e2e/scenarios/17-git-protocol.sh`) was deferred from PR #74 because cross-container DNS for the `git-daemon` compose service failed under `docker compose --profile … run --rm` on GitHub Actions runners — the one-off container could not resolve the sibling service hostname.

This PR adopts **avenue 3** from the issue body: co-locate `git daemon` inside the same `machine` container, listening on 127.0.0.1:9418. The scenario becomes self-contained — no compose profile, no host-side prep, no cross-container networking — and matches every other scenario's shape.

Closes #76.

## Changes

### Architecture

```mermaid
flowchart LR
  classDef src fill:#2c3e50,color:#ffffff
  classDef bad fill:#c0392b,color:#ffffff
  classDef ok fill:#27ae60,color:#ffffff

  subgraph Before
    direction LR
    A1["compose<br/>--profile git-daemon"]:::src --> B1["sidecar service<br/>git-daemon"]:::bad
    A1 --> C1["machine container<br/>compose run --rm"]:::bad
    C1 -.->|"DNS fails<br/>on GHA runners"| B1
  end
```

```mermaid
flowchart LR
  classDef src fill:#2c3e50,color:#ffffff
  classDef ok fill:#27ae60,color:#ffffff

  subgraph After
    direction LR
    A2["compose run --rm<br/>machine"]:::src --> B2["scenario 17 spawns<br/>git daemon"]:::ok
    B2 -->|"git://127.0.0.1:9418"| C2["agentsync push/pull<br/>round-trip"]:::ok
  end
```

### Scenario

- `docker/e2e/scenarios/17-git-protocol.sh` — rewritten:
  - spawn `git daemon --base-path=/vault --export-all --enable=receive-pack --timeout=30 --init-timeout=30 --listen=127.0.0.1 --port=9418` as a background process.
  - `trap cleanup EXIT INT TERM HUP` reaps the daemon and tidies its log on exit.
  - wall-clock-bounded liveness probe (10s cap, per-probe 0.5s timeout); on failure the daemon log is dumped inline for diagnosability.
  - documents the UID-1001 invariant linking the agent user (`Dockerfile.machine`) and `vault-init`'s `chown -R 1001:1001 /vault`.

### Infrastructure

- `docker/e2e/compose.yml` — removed the `git-daemon` service and its `git-daemon` profile; left a pointer comment to the scenario.
- `.github/workflows/e2e.yml` — added `17-git-protocol.sh` to the scenarios matrix; replaced the two scenario-17 special-case run steps with a single uniform `Run scenario` step (matrix.scenario is still routed through `env:` per the workflow-injection guide for forward compatibility).
- `docker/e2e/run-all.sh` — dropped the scenario-17 profile-lifecycle special case; updated the SKIP example in the header.

### Docs

- `docker/e2e/README.md` — dropped the "needs git-daemon profile" paragraph and the `SKIP=\"17-git-protocol.sh\"` example; updated the scenarios table entry and layout description to reflect the self-contained model.

## Test Evidence

- \`bun test\` — 561/561 pass.
- \`bun run typecheck\` — clean.
- \`bun run lint\` — clean (11 pre-existing warnings).
- \`bash -n\` — clean on both touched shell scripts.
- Senior review gate ran 2 iterations; 5 Valid/Partially-Valid findings applied (10s wall-clock cap, daemon `--timeout` / `--init-timeout`, UID-1001 doc, HUP trap, workflow comment reflow); iteration 2 converged with zero new findings.

## Risks / Follow-ups

- The scenario depends on \`git daemon\` being present in the machine image. Debian \`git\` ships it, and the Dockerfile already installs \`git\` — no new package required. If git is ever stripped from the image, this scenario will fail loudly at the liveness probe rather than corrupting vault state.
- 127.0.0.1 bind is intentional — the daemon is **not** reachable from sibling containers or the host. Vault contents remain age-encrypted; loopback-only listener adds no exposure surface.
- The UID-1001 invariant is now documented inline; future changes to the agent user UID must also update \`vault-init\`'s chown target or scenario 17 fails on \`receive-pack\`.

## Checklist

- [x] New code has tests where appropriate (scenario itself is the test)
- [x] Documentation updated if behavior changed (README, run-all.sh header, compose.yml comment, workflow comment)