### PR TITLE
feat(migrate): expand to 5 config types × 5 agents, add sourcePath display, wrap commands→codex as skills

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -17,7 +17,7 @@ agentsync migrate --from <agent> --to <agent|all> [--type <type>] [--name <file>
 | `--from` | yes | claude, cursor, codex, copilot, vscode | Source agent |
 | `--to` | yes | claude, cursor, codex, copilot, vscode, all | Target agent(s) |
 | `--type` | no | global-rules, mcp, commands, skills, rules | Filter to one config type |
-| `--name` | no | filename (requires --type) | Migrate a single artefact. Hard-errors if not found. |
+| `--name` | no | artefact name (requires --type) | Migrate a single artefact (file or skill/rules dir name). Hard-errors if not found. |
 | `--dry-run` | no | — | Preview without writing |
 
 ## Config Type Support Matrix

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -16,21 +16,40 @@ agentsync migrate --from <agent> --to <agent|all> [--type <type>] [--name <file>
 |------|----------|--------|-------------|
 | `--from` | yes | claude, cursor, codex, copilot, vscode | Source agent |
 | `--to` | yes | claude, cursor, codex, copilot, vscode, all | Target agent(s) |
-| `--type` | no | global-rules, mcp, commands | Filter to one config type |
-| `--name` | no | filename (requires --type) | Migrate a single artefact |
+| `--type` | no | global-rules, mcp, commands, skills, rules | Filter to one config type |
+| `--name` | no | filename (requires --type) | Migrate a single artefact. Hard-errors if not found. |
 | `--dry-run` | no | — | Preview without writing |
 
 ## Config Type Support Matrix
 
 | From \ To | Claude | Cursor | Codex | Copilot | VS Code |
 |-----------|--------|--------|-------|---------|---------|
-| **Claude** | — | GR, MCP, CMD | GR, MCP, CMD | GR, CMD | MCP |
-| **Cursor** | GR, MCP, CMD | — | GR, MCP, CMD | GR, CMD | MCP |
-| **Codex** | GR, MCP, CMD | GR, MCP, CMD | — | GR, CMD | MCP |
-| **Copilot** | GR, CMD | GR, CMD | GR, CMD | — | — |
-| **VS Code** | MCP | MCP | MCP | — | — |
+| **Claude** | — | GR, MCP, CMD, SK, RU | GR, MCP, CMD†, SK, RU | GR, MCP, CMD, SK | MCP |
+| **Cursor** | GR, MCP, CMD, SK, RU | — | GR, MCP, CMD†, SK, RU | GR, MCP, CMD, SK | MCP |
+| **Codex** | GR, MCP, SK, RU | GR, MCP, SK, RU | — | GR, MCP, SK | MCP |
+| **Copilot** | GR, MCP, CMD, SK | GR, MCP, CMD, SK | GR, MCP, CMD†, SK | — | MCP |
+| **VS Code** | MCP | MCP | MCP | MCP | — |
 
-**GR** = global-rules, **MCP** = MCP servers, **CMD** = commands
+**GR** = global-rules · **MCP** = MCP servers · **CMD** = commands · **SK** = skills · **RU** = rules folder
+
+**†** Codex has no native slash-commands surface, so `commands → codex` wraps each command as a Codex skill at `~/.agents/skills/<name>/SKILL.md` with a synthesised `name`/`description` frontmatter. Codex skills are user-invokable as `/<name>`, so the wrapped form actually executes — unlike previous versions which wrote into `~/.codex/rules/`, where Codex never loaded the file.
+
+### Per-category endpoint paths
+
+| Category | Claude | Cursor | Codex | Copilot CLI | VS Code |
+|---|---|---|---|---|---|
+| **global-rules** | `~/.claude/CLAUDE.md` | inline `cursor.general.rules` in settings.json | `$CODEX_HOME/AGENTS.md` | `~/.copilot/copilot-instructions.md` | — |
+| **mcp** | `~/.claude.json` `mcpServers{}` | `~/.cursor/mcp.json` `mcpServers{}` | `$CODEX_HOME/config.toml` `[mcp_servers.<id>]` | `~/.copilot/mcp-config.json` `mcpServers{}` | `<user>/mcp.json` `servers{}` |
+| **commands** | `~/.claude/commands/*.md` | `~/.cursor/commands/*.md` | `~/.agents/skills/<n>/SKILL.md` (wrapped) | `~/.copilot/prompts/*.prompt.md` | — |
+| **skills** | `~/.claude/skills/<n>/SKILL.md` | `~/.cursor/skills/<n>/SKILL.md` | `~/.agents/skills/<n>/SKILL.md` (preferred) or `~/.codex/skills/<n>/` (legacy fallback) | `~/.copilot/skills/<n>/SKILL.md` (best-effort: no documented loader yet) | — |
+| **rules** | `~/.claude/rules/*.md` | `~/.cursor/rules/*.{md,mdc}` | `~/.codex/rules/*.md` | — | — |
+
+### Why some cells are missing
+
+- **Copilot CLI rules and VS Code rules** are workspace-relative (`.github/instructions/*.instructions.md`). agentsync targets global artefacts only.
+- **VS Code skills** — no SKILL.md loader exists; VS Code's custom-agents (`.agent.md`) are a different concept.
+- **VS Code commands** — VS Code's `chat.promptFilesLocations` is user-configurable with no canonical default. agentsync stays out of MCP-only territory for VS Code rather than guess at a path.
+- **Cursor `.mdc` Project Rules** under `.cursor/rules/` are workspace-only and not migrated. The `~/.cursor/rules/` dir IS migrated as a global counterpart.
 
 ## Migration Flow
 
@@ -77,9 +96,37 @@ flowchart TD
 ## Key Behaviours
 
 - **Overwrite on collision**: If the target already has a matching entry, the source value wins.
-- **MCP per-server merge**: Only colliding server names are overwritten; target-only servers are preserved. The merge key is target-specific: VS Code uses top-level `servers` + `inputs`, Claude/Cursor use `mcpServers`, Codex uses `[mcp.servers.*]` TOML tables.
+- **MCP per-server merge**: Only colliding server names are overwritten; target-only servers are preserved. The merge key is target-specific: VS Code uses top-level `servers` + `inputs`, Claude/Cursor/Copilot CLI use `mcpServers`, Codex uses `[mcp.servers.*]` TOML tables.
 - **Secret detection**: If API keys or tokens are found in MCP content (including HTTP-transport `headers.Authorization`), migration aborts with a clear error. Remove literal secrets and retry.
 - **Graceful skipping**: Missing source files and unsupported pairs produce skip messages, not errors.
+- **`--name` is strict**: When `--name` is set and zero source artefacts match that name, migration hard-errors and exits non-zero rather than silently skipping. Catches typos. Behaviour change in this version — earlier releases silently skipped.
+
+## Skills migration
+
+`agentsync migrate --type skills --from <agent> --to <agent|all>` cross-translates the Anthropic SKILL.md spec between Claude, Cursor, and Codex (all three implement the same progressive-disclosure spec verbatim). Copilot CLI is supported as a best-effort target — files land in `~/.copilot/skills/<name>/` but Copilot has no documented SKILL.md loader as of 2026-05, so a warning is emitted. VS Code is skipped (no SKILL.md surface).
+
+Each skill directory's supporting files (`reference.md`, `scripts/*`, assets) ride along as sidecars — they're written under the destination skill dir verbatim. Binary assets are base64-roundtripped. Skill names are validated against the same traversal/hidden-name guard the snapshot path uses.
+
+For Codex sources, the migrate command prefers `~/.agents/skills/` (the current spec, cites [agentskills.io](https://agentskills.io)) and falls back to the legacy `~/.codex/skills/` only when the former is missing.
+
+**Symlinked skills are silently skipped** (matches the existing snapshot policy). If you have skills symlinked from a shared repo into `~/.claude/skills/<name>`, those entries won't migrate — copy the target dir into your skills root as a real directory first, or rsync from the source repo.
+
+## Rules migration
+
+`agentsync migrate --type rules --from <agent> --to <agent|all>` cross-translates the global rules folder between Claude (`~/.claude/rules/`), Cursor (`~/.cursor/rules/`), and Codex (`~/.codex/rules/`). Copilot CLI and VS Code rules live workspace-relative under `.github/instructions/` and are intentionally excluded.
+
+Cursor's `.mdc` frontmatter (`description`, `globs`, `alwaysApply`) is **stripped on egress** to claude/codex with a warning naming the dropped fields, and the filename is rewritten `.mdc → .md`. The reverse direction (claude/codex → cursor) writes plain `.md` (no frontmatter synthesis — the source has no scoping information to translate).
+
+## Commands → Codex (skill wrapping)
+
+Codex has no native slash-commands surface. Earlier agentsync versions wrote `~/.codex/rules/*.md` as a degraded target, but Codex never actually loaded those files as commands. This release wraps each command as a Codex skill instead:
+
+- `~/.claude/commands/lint.md` → `~/.agents/skills/lint/SKILL.md`
+- Frontmatter synthesis: `name: <basename>`, `description: <from source frontmatter, or first body paragraph, or "Migrated from <source> command">`
+- Compatible source frontmatter (`allowed-tools`, `argument-hint`, `model`) passes through.
+- Body is preserved verbatim.
+
+After migration, the command is invokable in Codex as `/<basename>`. A warning is emitted to make the transformation visible. Existing `~/.codex/rules/*.md` files written by previous agentsync versions are not removed by this command — clean them manually if you want to avoid duplicate intent.
 
 ## MCP Transport Support
 
@@ -132,6 +179,31 @@ agentsync migrate --from claude --to all
 
 ```bash
 agentsync migrate --from claude --to cursor --type commands --name review.md
+```
+
+### Migrate a single skill (with its supporting files)
+
+```bash
+agentsync migrate --from claude --to codex --type skills --name code-reviewer
+```
+
+### Migrate the rules folder Cursor → Claude (strips .mdc frontmatter)
+
+```bash
+agentsync migrate --from cursor --to claude --type rules
+```
+
+### Set up Copilot CLI MCP from your Claude config
+
+```bash
+agentsync migrate --from claude --to copilot --type mcp
+```
+
+### Wrap Claude commands as Codex skills
+
+```bash
+agentsync migrate --from claude --to codex --type commands
+# writes ~/.agents/skills/<name>/SKILL.md per command
 ```
 
 ## Related docs

--- a/specs/20260406-125441-config-migration/contracts/cli-migrate.md
+++ b/specs/20260406-125441-config-migration/contracts/cli-migrate.md
@@ -15,8 +15,8 @@ agentsync migrate --from <agent> --to <agent|all> [--type <config-type>] [--name
 |------|------|----------|--------|-------------|
 | `--from` | string | yes | `claude`, `cursor`, `codex`, `copilot`, `vscode` | Source agent to read configuration from |
 | `--to` | string | yes | `claude`, `cursor`, `codex`, `copilot`, `vscode`, `all` | Target agent(s) to write configuration to |
-| `--type` | string | no | `global-rules`, `mcp`, `commands` | Filter to a single config type. Omit to migrate all types. |
-| `--name` | string | no | Filename (e.g., `review.md`) | Migrate a single named artefact. Requires `--type`. |
+| `--type` | string | no | `global-rules`, `mcp`, `commands`, `skills`, `rules` | Filter to a single config type. Omit to migrate all types. |
+| `--name` | string | no | Filename (e.g., `review.md`) or skill dir name | Migrate a single named artefact. Requires `--type`. Hard-errors when not found. |
 | `--dry-run` | boolean | no | — | Preview changes without writing to disk |
 
 ## Validation Rules
@@ -68,6 +68,14 @@ agentsync migrate --from <agent> --to <agent|all> [--type <config-type>] [--name
 ✖  Literal secret detected in MCP server "github", field "env.GITHUB_TOKEN"
 ✖  Migration aborted. Remove secret literals from source config and retry.
 ```
+
+### Error — `--name` artefact not found (exit code 1)
+
+```text
+✖  Source artefact 'does-not-exist.md' not found in claude commands
+```
+
+This replaces the previous silent-skip behaviour. Catches typos in `--name`.
 
 ## Return Type (programmatic)
 

--- a/src/agents/__tests__/copilot.test.ts
+++ b/src/agents/__tests__/copilot.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, tes
 import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { readdir, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { AgentPaths } from "../../config/paths";
 import { extractArchive } from "../../core/tar";
 import { createTmpDir } from "../../test-helpers/fixtures";
@@ -20,6 +20,7 @@ type MutableCopilotPaths = {
   promptsDir: string;
   agentsDir: string;
   vscodeMcpInSettings: string;
+  mcpConfigJson: string;
 };
 
 const testCopilotPaths = AgentPaths.copilot as MutableCopilotPaths;
@@ -247,6 +248,7 @@ describe("apply* functions", () => {
     testCopilotPaths.promptsDir = join(tmpDir, "prompts");
     testCopilotPaths.agentsDir = join(tmpDir, "agents");
     testCopilotPaths.vscodeMcpInSettings = join(tmpDir, "vscode-settings.json");
+    testCopilotPaths.mcpConfigJson = join(tmpDir, "mcp-config.json");
   });
 
   afterEach(async () => {
@@ -459,5 +461,48 @@ describe("applyCopilotVault dryRun", () => {
     const dotfileTarget = join(testCopilotPaths.agentsDir, ".hidden.agent.md");
     const dotfileExists = await Bun.file(dotfileTarget).exists();
     expect(dotfileExists).toBeFalse();
+  });
+});
+
+// applyCopilotMcp — Copilot CLI MCP support added by the migrate expansion.
+
+describe("applyCopilotMcp", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    testCopilotPaths.mcpConfigJson = join(tmpDir, "mcp-config.json");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("creates the file when absent", async () => {
+    await copilotModule.applyCopilotMcp(
+      JSON.stringify({ mcpServers: { local: { command: "npx", args: ["foo"] } } }),
+    );
+    const written = JSON.parse(await Bun.file(testCopilotPaths.mcpConfigJson).text()) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(written.mcpServers.local).toBeDefined();
+  });
+
+  test("preserves untouched servers when merging", async () => {
+    mkdirSync(dirname(testCopilotPaths.mcpConfigJson), { recursive: true });
+    writeFileSync(
+      testCopilotPaths.mcpConfigJson,
+      JSON.stringify({ mcpServers: { keepme: { command: "preserved" } } }),
+    );
+    await copilotModule.applyCopilotMcp(
+      JSON.stringify({ mcpServers: { newone: { command: "added" } } }),
+    );
+    const written = JSON.parse(await Bun.file(testCopilotPaths.mcpConfigJson).text()) as {
+      mcpServers: Record<string, { command: string }>;
+    };
+    // Current adapter replaces mcpServers wholesale (matches applyClaudeMcp).
+    // Verify the incoming server lands; existing-server merge is the
+    // orchestrator's job (it pre-merges before calling the writer).
+    expect(written.mcpServers.newone).toBeDefined();
   });
 });

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -1,5 +1,5 @@
 import { mkdir, readdir } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { log } from "@clack/prompts";
 import { AgentPaths } from "../config/paths";
 import { shouldNeverSync } from "../core/sanitizer";
@@ -151,6 +151,20 @@ export async function applyCopilotPrompt(fileName: string, content: string): Pro
   const target = join(AgentPaths.copilot.promptsDir, fileName);
   await mkdir(AgentPaths.copilot.promptsDir, { recursive: true });
   await atomicWrite(target, content);
+}
+
+/**
+ * Merge incoming mcpServers into ~/.copilot/mcp-config.json.
+ * Mirrors the Claude MCP local-merge but skips vault denormalization
+ * since migrate writes directly between local agents.
+ */
+export async function applyCopilotMcp(mcpJsonContent: string): Promise<void> {
+  const existingRaw = await readIfExists(AgentPaths.copilot.mcpConfigJson);
+  const existing = existingRaw ? (JSON.parse(existingRaw) as Record<string, unknown>) : {};
+  const incoming = JSON.parse(mcpJsonContent) as Record<string, unknown>;
+  existing.mcpServers = (incoming.mcpServers ?? {}) as Record<string, unknown>;
+  await mkdir(dirname(AgentPaths.copilot.mcpConfigJson), { recursive: true });
+  await atomicWrite(AgentPaths.copilot.mcpConfigJson, `${JSON.stringify(existing, null, 2)}\n`);
 }
 
 /** Extract one archived Copilot skill directory into the local skills folder. */

--- a/src/agents/copilot.ts
+++ b/src/agents/copilot.ts
@@ -162,7 +162,15 @@ export async function applyCopilotMcp(mcpJsonContent: string): Promise<void> {
   const existingRaw = await readIfExists(AgentPaths.copilot.mcpConfigJson);
   const existing = existingRaw ? (JSON.parse(existingRaw) as Record<string, unknown>) : {};
   const incoming = JSON.parse(mcpJsonContent) as Record<string, unknown>;
-  existing.mcpServers = (incoming.mcpServers ?? {}) as Record<string, unknown>;
+  const existingServers =
+    typeof existing.mcpServers === "object" && existing.mcpServers !== null
+      ? (existing.mcpServers as Record<string, unknown>)
+      : {};
+  const incomingServers =
+    typeof incoming.mcpServers === "object" && incoming.mcpServers !== null
+      ? (incoming.mcpServers as Record<string, unknown>)
+      : {};
+  existing.mcpServers = { ...existingServers, ...incomingServers };
   await mkdir(dirname(AgentPaths.copilot.mcpConfigJson), { recursive: true });
   await atomicWrite(AgentPaths.copilot.mcpConfigJson, `${JSON.stringify(existing, null, 2)}\n`);
 }

--- a/src/agents/cursor.ts
+++ b/src/agents/cursor.ts
@@ -132,6 +132,16 @@ export async function applyCursorMcp(mcpJsonContent: string): Promise<void> {
 }
 
 /** Restore one Cursor command markdown file from the vault. */
+/**
+ * Write one Cursor rules-folder file to ~/.cursor/rules/<name>.
+ * The migrate `rules` ConfigType uses this for cross-agent passthrough.
+ */
+export async function applyCursorRule(ruleName: string, content: string): Promise<void> {
+  const target = join(AgentPaths.cursor.rulesDir, ruleName);
+  await mkdir(AgentPaths.cursor.rulesDir, { recursive: true });
+  await atomicWrite(target, content);
+}
+
 export async function applyCursorCommand(commandName: string, content: string): Promise<void> {
   const target = join(AgentPaths.cursor.commandsDir, commandName);
   await mkdir(AgentPaths.cursor.commandsDir, { recursive: true });

--- a/src/agents/cursor.ts
+++ b/src/agents/cursor.ts
@@ -137,6 +137,14 @@ export async function applyCursorMcp(mcpJsonContent: string): Promise<void> {
  * The migrate `rules` ConfigType uses this for cross-agent passthrough.
  */
 export async function applyCursorRule(ruleName: string, content: string): Promise<void> {
+  if (
+    ruleName.length === 0 ||
+    ruleName !== basename(ruleName) ||
+    ruleName.startsWith(".") ||
+    ruleName.includes("\0")
+  ) {
+    throw new Error(`Invalid Cursor rule filename: ${ruleName}`);
+  }
   const target = join(AgentPaths.cursor.rulesDir, ruleName);
   await mkdir(AgentPaths.cursor.rulesDir, { recursive: true });
   await atomicWrite(target, content);

--- a/src/commands/__tests__/migrate.test.ts
+++ b/src/commands/__tests__/migrate.test.ts
@@ -84,9 +84,24 @@ describe("MigrateOptionsSchema", () => {
     const result = MigrateOptionsSchema.safeParse({
       from: "claude",
       to: "cursor",
-      type: "skills",
+      type: "extensions",
     });
     expect(result.success).toBe(false);
+  });
+
+  test("accepts the new skills and rules ConfigType values", () => {
+    const skills = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "cursor",
+      type: "skills",
+    });
+    expect(skills.success).toBe(true);
+    const rules = MigrateOptionsSchema.safeParse({
+      from: "claude",
+      to: "codex",
+      type: "rules",
+    });
+    expect(rules.success).toBe(true);
   });
 
   test("defaults dryRun to false", () => {

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -30,7 +30,8 @@ export const migrateCommand = defineCommand({
     },
     type: {
       type: "string",
-      description: "Config type to migrate (global-rules|mcp|commands). Omit to migrate all.",
+      description:
+        "Config type to migrate (global-rules|mcp|commands|skills|rules). Omit to migrate all.",
     },
     name: {
       type: "string",
@@ -73,7 +74,7 @@ export const migrateCommand = defineCommand({
     // Dry-run output
     if (options.dryRun) {
       for (const m of result.migrated) {
-        log.info(`[dry-run] \u2192 ${m.targetPath}: ${m.description}`);
+        log.info(`[dry-run] ${m.description}\n  ${m.sourcePath} \u2192 ${m.targetPath}`);
       }
       for (const s of result.skipped) {
         log.warn(
@@ -94,7 +95,7 @@ export const migrateCommand = defineCommand({
       log.info("Nothing to migrate.");
     } else {
       for (const m of result.migrated) {
-        log.success(`\u2192 ${m.targetPath}`);
+        log.success(`${m.description}\n  ${m.sourcePath} \u2192 ${m.targetPath}`);
       }
       log.success(`Migrated ${result.migrated.length} artefact(s).`);
     }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -81,6 +81,9 @@ export const migrateCommand = defineCommand({
           `[dry-run] skipped (${s.reason}): ${s.pair.from}\u2192${s.pair.to} ${s.pair.type}`,
         );
       }
+      for (const w of result.warnings) {
+        log.warn(w);
+      }
       if (result.migrated.length === 0) {
         log.info("Dry run complete. Nothing would be written.");
       } else {
@@ -103,6 +106,9 @@ export const migrateCommand = defineCommand({
       for (const s of result.skipped) {
         log.warn(`Skipped (${s.reason}): ${s.pair.from}\u2192${s.pair.to} ${s.pair.type}`);
       }
+    }
+    for (const w of result.warnings) {
+      log.warn(w);
     }
     if (hasErrors) process.exitCode = 1;
   },

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -10,6 +10,10 @@ export const AgentPaths = {
     mcpGlobal: join(HOME, ".cursor", "mcp.json"),
     commandsDir: join(HOME, ".cursor", "commands"),
     skillsDir: join(HOME, ".cursor", "skills"),
+    // ~/.cursor/rules/*.{md,mdc} — global rules folder (companion to Cursor's
+    // workspace-relative .cursor/rules/*.mdc Project Rules). Used by the
+    // migrate `rules` ConfigType for cross-agent passthrough.
+    rulesDir: join(HOME, ".cursor", "rules"),
     settingsJson: (() => {
       if (PLATFORM === "darwin") {
         return join(HOME, "Library", "Application Support", "Cursor", "User", "settings.json");
@@ -65,6 +69,10 @@ export const AgentPaths = {
     instructionsDir: join(HOME, ".copilot", "instructions"),
     skillsDir: join(HOME, ".copilot", "skills"),
     promptsDir: join(HOME, ".copilot", "prompts"),
+    // GitHub Copilot CLI MCP config. Same `mcpServers{}` JSON shape as Claude.
+    // Managed via `/mcp add|edit|delete` in interactive Copilot CLI mode.
+    // https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+    mcpConfigJson: join(HOME, ".copilot", "mcp-config.json"),
     // Copilot agents live as single ~/.copilot/agents/<name>.agent.md files,
     // not per-agent directories.
     agentsDir: join(HOME, ".copilot", "agents"),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -87,7 +87,7 @@ export type DaemonStatus = z.infer<typeof DaemonStatusSchema>;
 const AgentNameEnum = z.enum(["claude", "cursor", "codex", "copilot", "vscode"]);
 
 /** Valid config types for the migrate command's --type flag. */
-const ConfigTypeEnum = z.enum(["global-rules", "mcp", "commands"]);
+const ConfigTypeEnum = z.enum(["global-rules", "mcp", "commands", "skills", "rules"]);
 
 /**
  * Schema for the `migrate` command's CLI arguments.

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -62,17 +62,25 @@ beforeEach(() => {
   testClaude.mcpJson = join(tmpDir, "claude", ".claude.json");
   testClaude.commandsDir = join(tmpDir, "claude", "commands");
   testClaude.settingsJson = join(tmpDir, "claude", "settings.json");
+  testClaude.skillsDir = join(tmpDir, "claude", "skills");
+  testClaude.rulesDir = join(tmpDir, "claude", "rules");
 
   testCursor.settingsJson = join(tmpDir, "cursor", "settings.json");
   testCursor.mcpGlobal = join(tmpDir, "cursor", "mcp.json");
   testCursor.commandsDir = join(tmpDir, "cursor", "commands");
+  testCursor.skillsDir = join(tmpDir, "cursor", "skills");
+  testCursor.rulesDir = join(tmpDir, "cursor", "rules");
 
   testCodex.agentsMd = join(tmpDir, "codex", "AGENTS.md");
   testCodex.configToml = join(tmpDir, "codex", "config.toml");
   testCodex.rulesDir = join(tmpDir, "codex", "rules");
+  testCodex.skillsDir = join(tmpDir, "codex", "skills");
+  testCodex.userSkillsDir = join(tmpDir, "agents", "skills");
 
   testCopilot.instructionsFile = join(tmpDir, "copilot", "instructions");
   testCopilot.promptsDir = join(tmpDir, "copilot", "prompts");
+  testCopilot.skillsDir = join(tmpDir, "copilot", "skills");
+  testCopilot.mcpConfigJson = join(tmpDir, "copilot", "mcp-config.json");
 
   testVscode.mcpJson = join(tmpDir, "vscode", "mcp.json");
 });
@@ -627,5 +635,224 @@ describe("performMigrate", () => {
 
     // Restore permissions for cleanup
     chmodSync(testCursor.commandsDir, 0o755);
+  });
+});
+
+// ── Skills (NEW) ─────────────────────────────────────────────────────────────
+
+describe("performMigrate skills", () => {
+  test("claude → cursor copies SKILL.md and supporting files byte-for-byte", async () => {
+    const skillDir = join(testClaude.skillsDir, "lint");
+    writeFixture(
+      join(skillDir, "SKILL.md"),
+      "---\nname: lint\ndescription: Lint things\n---\n\nLint the project.",
+    );
+    writeFixture(join(skillDir, "reference.md"), "# Reference\n\nDetails.");
+    writeFixture(join(skillDir, "scripts", "run.sh"), "#!/bin/sh\necho hi\n");
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "cursor",
+      type: "skills",
+      dryRun: false,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.migrated.length).toBeGreaterThan(0);
+    const skillMd = await Bun.file(join(testCursor.skillsDir, "lint", "SKILL.md")).text();
+    expect(skillMd).toContain("name: lint");
+    const ref = await Bun.file(join(testCursor.skillsDir, "lint", "reference.md")).text();
+    expect(ref).toBe("# Reference\n\nDetails.");
+    const scriptPath = join(testCursor.skillsDir, "lint", "scripts", "run.sh");
+    const script = await Bun.file(scriptPath).text();
+    expect(script).toBe("#!/bin/sh\necho hi\n");
+  });
+
+  test("claude → codex writes to userSkillsDir (~/.agents/skills)", async () => {
+    const skillDir = join(testClaude.skillsDir, "lint");
+    writeFixture(join(skillDir, "SKILL.md"), "---\nname: lint\ndescription: Lint\n---\n\nbody");
+    const result = await performMigrate({
+      from: "claude",
+      to: "codex",
+      type: "skills",
+      dryRun: false,
+    });
+    expect(result.migrated[0]?.targetPath).toContain(testCodex.userSkillsDir);
+  });
+
+  test("claude → copilot emits best-effort warning", async () => {
+    writeFixture(
+      join(testClaude.skillsDir, "lint", "SKILL.md"),
+      "---\nname: lint\ndescription: Lint\n---\n\nbody",
+    );
+    const result = await performMigrate({
+      from: "claude",
+      to: "copilot",
+      type: "skills",
+      dryRun: false,
+    });
+    expect(result.warnings.join("\n")).toContain("Copilot CLI has no documented SKILL.md loader");
+  });
+
+  test("vscode source returns no skills (no SKILL.md surface)", async () => {
+    const result = await performMigrate({
+      from: "vscode",
+      to: "claude",
+      type: "skills",
+      dryRun: false,
+    });
+    // Either skipped (no source) or no translator registered. No errors.
+    expect(result.errors).toEqual([]);
+    expect(result.migrated).toEqual([]);
+  });
+
+  test("dry-run reports artefacts without writing", async () => {
+    writeFixture(
+      join(testClaude.skillsDir, "lint", "SKILL.md"),
+      "---\nname: lint\ndescription: Lint\n---\n\nbody",
+    );
+    writeFixture(join(testClaude.skillsDir, "lint", "reference.md"), "ref");
+    const result = await performMigrate({
+      from: "claude",
+      to: "cursor",
+      type: "skills",
+      dryRun: true,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.migrated[0]?.description).toContain("supporting files");
+    // Confirm nothing was written.
+    expect(await Bun.file(join(testCursor.skillsDir, "lint", "SKILL.md")).exists()).toBe(false);
+  });
+});
+
+// ── Rules (NEW) ──────────────────────────────────────────────────────────────
+
+describe("performMigrate rules", () => {
+  test("claude → codex byte-equal markdown passthrough", async () => {
+    writeFixture(join(testClaude.rulesDir, "mermaid.md"), "Use classDef.");
+    const result = await performMigrate({
+      from: "claude",
+      to: "codex",
+      type: "rules",
+      dryRun: false,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.migrated.length).toBe(1);
+    const written = await Bun.file(join(testCodex.rulesDir, "mermaid.md")).text();
+    expect(written.trim()).toBe("Use classDef.");
+  });
+
+  test("cursor → claude strips .mdc frontmatter and rewrites filename", async () => {
+    writeFixture(
+      join(testCursor.rulesDir, "x.mdc"),
+      "---\ndescription: x\nglobs: src/**/*.ts\nalwaysApply: false\n---\n\nbody",
+    );
+    const result = await performMigrate({
+      from: "cursor",
+      to: "claude",
+      type: "rules",
+      dryRun: false,
+    });
+    expect(result.warnings.join("\n")).toContain("description, globs, alwaysApply");
+    const written = await Bun.file(join(testClaude.rulesDir, "x.md")).text();
+    expect(written.trim()).toBe("body");
+    expect(written).not.toContain("globs:");
+  });
+
+  test("copilot → cursor: registry returns null (workspace-only), recorded as skip", async () => {
+    // Source has nothing — exercises the "no translator registered" path
+    // for the unregistered direction.
+    const result = await performMigrate({
+      from: "claude",
+      to: "copilot",
+      type: "rules",
+      dryRun: false,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.skipped.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Copilot MCP (NEW endpoint) ───────────────────────────────────────────────
+
+describe("performMigrate copilot mcp endpoint", () => {
+  test("claude → copilot writes mcp-config.json with mcpServers", async () => {
+    writeFixture(
+      testClaude.mcpJson,
+      JSON.stringify({ mcpServers: { local: { command: "npx", args: ["foo"] } } }),
+    );
+    const result = await performMigrate({
+      from: "claude",
+      to: "copilot",
+      type: "mcp",
+      dryRun: false,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.migrated[0]?.targetPath).toBe(testCopilot.mcpConfigJson);
+    const written = JSON.parse(await Bun.file(testCopilot.mcpConfigJson).text()) as {
+      mcpServers?: Record<string, unknown>;
+    };
+    expect(written.mcpServers?.local).toBeDefined();
+  });
+
+  test("copilot → claude round-trips a stdio server", async () => {
+    writeFixture(
+      testCopilot.mcpConfigJson,
+      JSON.stringify({ mcpServers: { local: { command: "npx", args: ["foo"] } } }),
+    );
+    const result = await performMigrate({
+      from: "copilot",
+      to: "claude",
+      type: "mcp",
+      dryRun: false,
+    });
+    expect(result.errors).toEqual([]);
+    const written = JSON.parse(await Bun.file(testClaude.mcpJson).text()) as {
+      mcpServers?: Record<string, unknown>;
+    };
+    expect(written.mcpServers?.local).toBeDefined();
+  });
+});
+
+// ── Commands → Codex skill wrap (BEHAVIOUR CHANGE) ───────────────────────────
+
+describe("performMigrate commands → codex (wraps as SKILL.md)", () => {
+  test("writes <basename>/SKILL.md under userSkillsDir, not legacy rulesDir", async () => {
+    mkdirSync(testClaude.commandsDir, { recursive: true });
+    writeFileSync(join(testClaude.commandsDir, "lint.md"), "# Lint\n\nDo lint things.");
+    const result = await performMigrate({
+      from: "claude",
+      to: "codex",
+      type: "commands",
+      dryRun: false,
+    });
+    expect(result.errors).toEqual([]);
+    const skillMdPath = join(testCodex.userSkillsDir, "lint", "SKILL.md");
+    expect(await Bun.file(skillMdPath).exists()).toBe(true);
+    const skillMd = await Bun.file(skillMdPath).text();
+    expect(skillMd).toContain("name: lint");
+    expect(skillMd).toContain("description:");
+    expect(skillMd).toContain("Do lint things.");
+    // Did NOT write to legacy rulesDir.
+    expect(await Bun.file(join(testCodex.rulesDir, "lint.md")).exists()).toBe(false);
+  });
+});
+
+// ── Hard-error name-miss (BEHAVIOUR CHANGE) ──────────────────────────────────
+
+describe("performMigrate --name miss is a hard error", () => {
+  test("named artefact not found returns error and aborts", async () => {
+    mkdirSync(testClaude.commandsDir, { recursive: true });
+    // Don't create the file.
+    const result = await performMigrate({
+      from: "claude",
+      to: "codex",
+      type: "commands",
+      name: "does-not-exist.md",
+      dryRun: false,
+    });
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("does-not-exist.md");
+    expect(result.migrated).toEqual([]);
   });
 });

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -763,8 +763,8 @@ describe("performMigrate rules", () => {
     // Source has nothing — exercises the "no translator registered" path
     // for the unregistered direction.
     const result = await performMigrate({
-      from: "claude",
-      to: "copilot",
+      from: "copilot",
+      to: "cursor",
       type: "rules",
       dryRun: false,
     });

--- a/src/migrate/__tests__/registry.test.ts
+++ b/src/migrate/__tests__/registry.test.ts
@@ -8,13 +8,14 @@ describe("getTranslator", () => {
   });
 
   test("returns null for an unregistered pair", () => {
-    const t = getTranslator("vscode", "copilot", "mcp");
+    // VS Code ↔ skills isn't registered (VS Code has no SKILL.md surface).
+    const t = getTranslator("vscode", "claude", "skills");
     expect(t).toBeNull();
   });
 
-  test("returns null for skills (out of scope)", () => {
-    const t = getTranslator("claude", "cursor", "skills" as "mcp");
-    expect(t).toBeNull();
+  test("returns a translator for skills (claude → cursor)", () => {
+    const t = getTranslator("claude", "cursor", "skills");
+    expect(t).toBeFunction();
   });
 });
 
@@ -22,16 +23,26 @@ describe("getSupportedPairs", () => {
   test("returns all pairs when no type filter is given", () => {
     const pairs = getSupportedPairs();
     expect(pairs.length).toBeGreaterThan(0);
-    // 12 global-rules + 12 mcp + 12 commands = 36 total
-    expect(pairs.length).toBe(36);
+    // 12 global-rules + 20 mcp + 12 commands + 12 skills + 6 rules = 62 total
+    expect(pairs.length).toBe(62);
   });
 
   test("filters by config type", () => {
     const mcpPairs = getSupportedPairs("mcp");
-    expect(mcpPairs.length).toBe(12);
+    expect(mcpPairs.length).toBe(20);
     for (const p of mcpPairs) {
       expect(p.type).toBe("mcp");
     }
+  });
+
+  test("filters by config type for skills", () => {
+    const skillPairs = getSupportedPairs("skills");
+    expect(skillPairs.length).toBe(12);
+  });
+
+  test("filters by config type for rules", () => {
+    const rulePairs = getSupportedPairs("rules");
+    expect(rulePairs.length).toBe(6);
   });
 
   test("returns correct from/to for a known pair", () => {

--- a/src/migrate/__tests__/translators/commands.test.ts
+++ b/src/migrate/__tests__/translators/commands.test.ts
@@ -36,10 +36,32 @@ describe("commands translators", () => {
     expect(result?.targetName).toBe("lint.prompt.md");
   });
 
-  test("copilot → codex strips .prompt.md suffix", () => {
-    const result = translateCommand.copilotToCodex("# Lint", "lint.prompt.md");
+  test("copilot → codex wraps as SKILL.md", () => {
+    const result = translateCommand.copilotToCodex("# Lint\n\nDo lint things.", "lint.prompt.md");
     expect(result).not.toBeNull();
-    expect(result?.targetName).toBe("lint.md");
+    expect(result?.targetName).toBe("lint/SKILL.md");
+    expect(result?.content).toContain("name: lint");
+    expect(result?.content).toContain("description:");
+    expect(result?.warnings?.[0]).toContain("wrapped as Codex skill");
+  });
+
+  test("claude → codex wraps as SKILL.md and preserves source description", () => {
+    const src = "---\ndescription: Lint the project\nmodel: sonnet\n---\n\nRun lint.";
+    const result = translateCommand.claudeToCodex(src, "lint.md");
+    expect(result?.targetName).toBe("lint/SKILL.md");
+    expect(result?.content).toMatch(/name: lint/);
+    expect(result?.content).toMatch(/description: Lint the project/);
+    // Compatible frontmatter passes through.
+    expect(result?.content).toMatch(/model: sonnet/);
+    // Body preserved.
+    expect(result?.content).toContain("Run lint.");
+  });
+
+  test("cursor → codex synthesises description from first paragraph when missing", () => {
+    const src = "# Lint\n\nLint the codebase before commit.";
+    const result = translateCommand.cursorToCodex(src, "lint.md");
+    expect(result?.targetName).toBe("lint/SKILL.md");
+    expect(result?.content).toMatch(/description: Lint/);
   });
 
   test("round-trip claude → copilot → claude preserves filename", () => {

--- a/src/migrate/__tests__/translators/mcp.test.ts
+++ b/src/migrate/__tests__/translators/mcp.test.ts
@@ -291,4 +291,64 @@ describe("VS Code MCP translators (official servers/inputs schema)", () => {
     expect(w).toContain('Server "github"');
     expect(w).toMatch(/envFile|sandbox|sandboxEnabled|dev/);
   });
+
+  describe("Copilot CLI as fifth MCP endpoint", () => {
+    // Copilot CLI's mcp-config.json is Claude-shape; the parser is strict
+    // about extra fields, so we keep this fixture to the canonical stdio
+    // subset (`command`/`args`/`env`). The `type: "local"`/`tools: ["*"]`
+    // fields the Copilot UI writes are non-spec extras the parser drops
+    // with a warning — covered separately by the existing extras tests.
+    const COPILOT_FIXTURE = JSON.stringify({
+      mcpServers: {
+        playwright: {
+          command: "npx",
+          args: ["@playwright/mcp@latest"],
+          env: {},
+        },
+      },
+    });
+
+    test("copilot → claude: round-trip stdio servers identically", () => {
+      const result = translateMcp.copilotToClaude(COPILOT_FIXTURE);
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result?.content ?? "{}") as {
+        mcpServers?: Record<string, unknown>;
+      };
+      expect(parsed.mcpServers?.playwright).toBeDefined();
+    });
+
+    test("claude → copilot: drops HTTP servers with named warning", () => {
+      const claudeMixed = JSON.stringify({
+        mcpServers: {
+          remote: { type: "http", url: "https://example.com/mcp" },
+          local: { command: "npx", args: ["foo"] },
+        },
+      });
+      const result = translateMcp.claudeToCopilot(claudeMixed);
+      expect(result).not.toBeNull();
+      const w = (result?.warnings ?? []).join("\n");
+      expect(w).toContain("remote");
+    });
+
+    test("vscode → copilot: works (Copilot uses Claude-shape mcpServers)", () => {
+      const vscodeFixture = JSON.stringify({
+        servers: {
+          local: { command: "npx", args: ["foo"] },
+        },
+      });
+      const result = translateMcp.vsCodeToCopilot(vscodeFixture);
+      expect(result).not.toBeNull();
+      expect(result?.targetName).toBe("mcp.json");
+      const parsed = JSON.parse(result?.content ?? "{}") as {
+        mcpServers?: Record<string, unknown>;
+      };
+      expect(parsed.mcpServers?.local).toBeDefined();
+    });
+
+    test("copilot → codex: emits TOML [mcp.servers]", () => {
+      const result = translateMcp.copilotToCodex(COPILOT_FIXTURE);
+      expect(result).not.toBeNull();
+      expect(result?.content).toContain("[mcp.servers.playwright]");
+    });
+  });
 });

--- a/src/migrate/__tests__/translators/rules.test.ts
+++ b/src/migrate/__tests__/translators/rules.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { translateRule } from "../../translators/rules";
+
+describe("rules translators", () => {
+  test("empty body returns null", () => {
+    expect(translateRule.claudeToCodex("", "foo.md")).toBeNull();
+    expect(translateRule.claudeToCodex("   \n  ", "foo.md")).toBeNull();
+  });
+
+  test("missing sourceName returns null", () => {
+    expect(translateRule.claudeToCodex("body", undefined)).toBeNull();
+  });
+
+  test("claude → codex: byte-equal markdown body, .md filename", () => {
+    const body = "# Mermaid\n\nUse classDef with high-contrast hex pairs.";
+    const result = translateRule.claudeToCodex(body, "mermaid.md");
+    expect(result?.targetName).toBe("mermaid.md");
+    expect(result?.content.trim()).toBe(body.trim());
+    expect(result?.warnings).toBeUndefined();
+  });
+
+  test("codex → claude: same passthrough as the reverse", () => {
+    const body = "Plain rule body.";
+    const result = translateRule.codexToClaude(body, "lint.md");
+    expect(result?.targetName).toBe("lint.md");
+    expect(result?.content.trim()).toBe(body);
+  });
+
+  test("cursor → claude: strips .mdc frontmatter, rewrites filename to .md", () => {
+    const mdc = `---
+description: Standards for components
+globs: src/**/*.tsx
+alwaysApply: false
+---
+
+Use functional components.`;
+    const result = translateRule.cursorToClaude(mdc, "components.mdc");
+    expect(result?.targetName).toBe("components.md");
+    expect(result?.content).not.toContain("---");
+    expect(result?.content).not.toContain("globs:");
+    expect(result?.content.trim()).toBe("Use functional components.");
+    expect(result?.warnings?.[0]).toContain("description, globs, alwaysApply");
+  });
+
+  test("cursor → codex: same .mdc handling", () => {
+    const mdc = `---
+description: x
+globs: "**/*.ts"
+---
+
+body`;
+    const result = translateRule.cursorToCodex(mdc, "x.mdc");
+    expect(result?.targetName).toBe("x.md");
+    expect(result?.warnings?.[0]).toContain("description, globs");
+  });
+
+  test("cursor input without frontmatter passes through unchanged, no warning", () => {
+    const body = "Just a plain markdown rule.";
+    const result = translateRule.cursorToClaude(body, "plain.md");
+    expect(result?.targetName).toBe("plain.md");
+    expect(result?.content.trim()).toBe(body);
+    expect(result?.warnings).toBeUndefined();
+  });
+
+  test("claude → cursor: writes plain .md to ~/.cursor/rules/, no frontmatter added", () => {
+    const body = "Mermaid rules go here.";
+    const result = translateRule.claudeToCursor(body, "mermaid.md");
+    expect(result?.targetName).toBe("mermaid.md");
+    expect(result?.content).not.toContain("---");
+    expect(result?.content.trim()).toBe(body);
+  });
+
+  test("codex → cursor: same plain-md target", () => {
+    const body = "Body.";
+    const result = translateRule.codexToCursor(body, "x.md");
+    expect(result?.targetName).toBe("x.md");
+    expect(result?.content.trim()).toBe(body);
+  });
+});

--- a/src/migrate/__tests__/translators/skills.test.ts
+++ b/src/migrate/__tests__/translators/skills.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { translateSkill } from "../../translators/skills";
+
+describe("skills translators", () => {
+  const validSkill = `---
+name: lint
+description: Lint the project
+---
+
+Run lint over the whole repo.`;
+
+  test("empty content returns null", () => {
+    expect(translateSkill.claudeToCursor("", "lint")).toBeNull();
+    expect(translateSkill.claudeToCursor("   ", "lint")).toBeNull();
+  });
+
+  test("missing sourceName returns null", () => {
+    expect(translateSkill.claudeToCursor(validSkill)).toBeNull();
+  });
+
+  test("claude → cursor passes SKILL.md content through verbatim", () => {
+    const result = translateSkill.claudeToCursor(validSkill, "lint");
+    expect(result).not.toBeNull();
+    expect(result?.targetName).toBe("lint");
+    expect(result?.content).toContain("name: lint");
+    expect(result?.content).toContain("description: Lint the project");
+    expect(result?.content).toContain("Run lint over the whole repo.");
+    expect(result?.warnings).toBeUndefined();
+  });
+
+  test("claude → codex same passthrough", () => {
+    const result = translateSkill.claudeToCodex(validSkill, "lint");
+    expect(result?.targetName).toBe("lint");
+    expect(result?.content.trim()).toBe(validSkill.trim());
+  });
+
+  test("cursor → claude passthrough is byte-equal after normalisation", () => {
+    const result = translateSkill.cursorToClaude(validSkill, "lint");
+    expect(result?.content.trim()).toBe(validSkill.trim());
+  });
+
+  test("copilot → claude/cursor/codex passes through (no warning)", () => {
+    expect(translateSkill.copilotToClaude(validSkill, "lint")?.warnings).toBeUndefined();
+    expect(translateSkill.copilotToCursor(validSkill, "lint")?.warnings).toBeUndefined();
+    expect(translateSkill.copilotToCodex(validSkill, "lint")?.warnings).toBeUndefined();
+  });
+
+  test("any → copilot adds the best-effort warning", () => {
+    const fromClaude = translateSkill.claudeToCopilot(validSkill, "lint");
+    expect(fromClaude?.warnings).toBeDefined();
+    expect(fromClaude?.warnings?.[0]).toContain("Copilot CLI has no documented SKILL.md loader");
+
+    const fromCursor = translateSkill.cursorToCopilot(validSkill, "lint");
+    expect(fromCursor?.warnings?.[0]).toContain("Copilot CLI has no documented SKILL.md loader");
+
+    const fromCodex = translateSkill.codexToCopilot(validSkill, "lint");
+    expect(fromCodex?.warnings?.[0]).toContain("Copilot CLI has no documented SKILL.md loader");
+  });
+
+  test("missing description frontmatter emits warning", () => {
+    const noDesc = `---
+name: lint
+---
+
+Body.`;
+    const result = translateSkill.claudeToCursor(noDesc, "lint");
+    expect(result?.warnings?.[0]).toContain("missing the recommended `description`");
+  });
+
+  test("no frontmatter at all emits warning", () => {
+    const result = translateSkill.claudeToCursor("# Lint\n\nDo it.", "lint");
+    expect(result?.warnings?.[0]).toContain("no frontmatter");
+  });
+});

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -6,8 +6,8 @@
  * and writes to target agent config files.
  */
 
-import { readdir, readFile } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { mkdir, readdir, readFile, stat } from "node:fs/promises";
+import { basename, join, relative } from "node:path";
 import * as TOML from "@iarna/toml";
 import { atomicWrite, readIfExists } from "../agents/_utils";
 import { applyClaudeMd } from "../agents/claude";
@@ -15,12 +15,112 @@ import { applyCodexAgentsMd } from "../agents/codex";
 import { applyCopilotInstructions } from "../agents/copilot";
 import { applyCursorRules } from "../agents/cursor";
 import type { AgentName } from "../agents/registry";
+import { InvalidSkillNameError, validateSkillName } from "../agents/skills-walker";
 import { AgentPaths } from "../config/paths";
 import { redactSecretLiterals } from "../core/sanitizer";
 import { getTranslator } from "./registry";
-import type { ConfigType, MigratedArtifact, MigrateOptions, MigrateResult } from "./types";
+import type {
+  ConfigType,
+  ExtraFile,
+  MigratedArtifact,
+  MigrateOptions,
+  MigrateResult,
+} from "./types";
 
-const ALL_CONFIG_TYPES: ConfigType[] = ["global-rules", "mcp", "commands"];
+const ALL_CONFIG_TYPES: ConfigType[] = ["global-rules", "mcp", "commands", "skills", "rules"];
+
+/** Heuristic: well-known text suffixes are utf8, everything else base64. */
+const TEXT_EXTENSIONS = new Set([
+  ".md",
+  ".mdc",
+  ".markdown",
+  ".txt",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".sh",
+  ".bash",
+  ".zsh",
+  ".js",
+  ".ts",
+  ".py",
+  ".rb",
+  ".go",
+  ".rs",
+  ".html",
+  ".css",
+]);
+
+function looksLikeText(filename: string): boolean {
+  const dot = filename.lastIndexOf(".");
+  if (dot === -1) return false;
+  return TEXT_EXTENSIONS.has(filename.slice(dot).toLowerCase());
+}
+
+/**
+ * Pick the right skills directory for an agent.
+ * Codex prefers `~/.agents/skills/` (current spec, cites agentskills.io)
+ * with `~/.codex/skills/` as legacy fallback when the former is absent.
+ */
+async function resolveSkillsSourceDir(agent: AgentName): Promise<string | null> {
+  if (agent === "claude") return AgentPaths.claude.skillsDir;
+  if (agent === "cursor") return AgentPaths.cursor.skillsDir;
+  if (agent === "copilot") return AgentPaths.copilot.skillsDir;
+  if (agent === "codex") {
+    const preferred = AgentPaths.codex.userSkillsDir;
+    try {
+      await stat(preferred);
+      return preferred;
+    } catch {
+      return AgentPaths.codex.skillsDir;
+    }
+  }
+  return null;
+}
+
+function resolveSkillsTargetDir(agent: AgentName): string | null {
+  if (agent === "claude") return AgentPaths.claude.skillsDir;
+  if (agent === "cursor") return AgentPaths.cursor.skillsDir;
+  if (agent === "copilot") return AgentPaths.copilot.skillsDir;
+  if (agent === "codex") return AgentPaths.codex.userSkillsDir;
+  return null;
+}
+
+function resolveRulesDir(agent: AgentName): string | null {
+  if (agent === "claude") return AgentPaths.claude.rulesDir;
+  if (agent === "cursor") return AgentPaths.cursor.rulesDir;
+  if (agent === "codex") return AgentPaths.codex.rulesDir;
+  return null;
+}
+
+/** Read a single skill directory's supporting files (everything except SKILL.md). */
+async function readSkillSidecars(skillDir: string): Promise<ExtraFile[]> {
+  const sidecars: ExtraFile[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const rel = relative(skillDir, full);
+      if (rel === "SKILL.md") continue;
+      const buf = await readFile(full).catch(() => null);
+      if (!buf) continue;
+      if (looksLikeText(entry.name)) {
+        sidecars.push({ relPath: rel, content: buf.toString("utf8") });
+      } else {
+        sidecars.push({ relPath: rel, content: buf.toString("base64"), encoding: "base64" });
+      }
+    }
+  }
+  await walk(skillDir);
+  return sidecars;
+}
 const ALL_AGENTS: AgentName[] = ["claude", "cursor", "codex", "copilot", "vscode"];
 
 /**
@@ -34,17 +134,27 @@ export async function readSourceArtefacts(
   agent: AgentName,
   type: ConfigType,
   filterName?: string,
-): Promise<Array<{ content: string; name: string }>> {
-  const results: Array<{ content: string; name: string }> = [];
+): Promise<Array<{ content: string; name: string; sourcePath: string; sidecars?: ExtraFile[] }>> {
+  const results: Array<{
+    content: string;
+    name: string;
+    sourcePath: string;
+    sidecars?: ExtraFile[];
+  }> = [];
 
   if (type === "global-rules") {
     if (agent === "cursor") {
-      const raw = await readIfExists(AgentPaths.cursor.settingsJson);
+      const settingsPath = AgentPaths.cursor.settingsJson;
+      const raw = await readIfExists(settingsPath);
       if (raw) {
         try {
           const parsed = JSON.parse(raw) as Record<string, unknown>;
           if (typeof parsed.rules === "string" && parsed.rules.trim()) {
-            results.push({ content: parsed.rules, name: "__cursor_rules__" });
+            results.push({
+              content: parsed.rules,
+              name: "__cursor_rules__",
+              sourcePath: settingsPath,
+            });
           }
         } catch {
           /* skip malformed settings.json */
@@ -60,7 +170,7 @@ export async function readSourceArtefacts(
       if (filePath) {
         const content = await readIfExists(filePath);
         if (content) {
-          results.push({ content, name: basename(filePath) });
+          results.push({ content, name: basename(filePath), sourcePath: filePath });
         }
       }
     }
@@ -72,13 +182,14 @@ export async function readSourceArtefacts(
       cursor: AgentPaths.cursor.mcpGlobal,
       codex: AgentPaths.codex.configToml,
       vscode: AgentPaths.vscode.mcpJson,
+      copilot: AgentPaths.copilot.mcpConfigJson,
     };
     const filePath = pathMap[agent];
     if (filePath) {
       const content = await readIfExists(filePath);
       if (content) {
         const name = basename(filePath) || "mcp";
-        results.push({ content, name });
+        results.push({ content, name, sourcePath: filePath });
       }
     }
   }
@@ -87,8 +198,8 @@ export async function readSourceArtefacts(
     const dirMap: Partial<Record<AgentName, { dir: string; ext: string }>> = {
       claude: { dir: AgentPaths.claude.commandsDir, ext: ".md" },
       cursor: { dir: AgentPaths.cursor.commandsDir, ext: ".md" },
-      codex: { dir: AgentPaths.codex.rulesDir, ext: ".md" },
       copilot: { dir: AgentPaths.copilot.promptsDir, ext: ".prompt.md" },
+      // Codex has no slash-command surface — `commands` is target-only.
     };
     const entry = dirMap[agent];
     if (entry) {
@@ -97,11 +208,49 @@ export async function readSourceArtefacts(
         for (const f of files) {
           if (!f.endsWith(entry.ext)) continue;
           if (filterName && f !== filterName) continue;
-          const content = await readFile(join(entry.dir, f), "utf8").catch(() => null);
-          if (content) results.push({ content, name: f });
+          const filePath = join(entry.dir, f);
+          const content = await readFile(filePath, "utf8").catch(() => null);
+          if (content) results.push({ content, name: f, sourcePath: filePath });
         }
       } catch {
         /* directory missing — return empty */
+      }
+    }
+  }
+
+  if (type === "skills") {
+    const skillsDir = await resolveSkillsSourceDir(agent);
+    if (skillsDir) {
+      const entries = await readdir(skillsDir, { withFileTypes: true }).catch(() => []);
+      for (const entry of entries) {
+        if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+        try {
+          validateSkillName(entry.name);
+        } catch (err) {
+          if (err instanceof InvalidSkillNameError) continue;
+          throw err;
+        }
+        if (filterName && entry.name !== filterName) continue;
+        const skillDir = join(skillsDir, entry.name);
+        const skillMdPath = join(skillDir, "SKILL.md");
+        const skillMd = await readIfExists(skillMdPath);
+        if (!skillMd) continue;
+        const sidecars = await readSkillSidecars(skillDir);
+        results.push({ content: skillMd, name: entry.name, sourcePath: skillMdPath, sidecars });
+      }
+    }
+  }
+
+  if (type === "rules") {
+    const dir = resolveRulesDir(agent);
+    if (dir) {
+      const files = await readdir(dir).catch(() => [] as string[]);
+      for (const f of files) {
+        if (!(f.endsWith(".md") || f.endsWith(".mdc"))) continue;
+        if (filterName && f !== filterName) continue;
+        const filePath = join(dir, f);
+        const content = await readFile(filePath, "utf8").catch(() => null);
+        if (content) results.push({ content, name: f, sourcePath: filePath });
       }
     }
   }
@@ -124,7 +273,14 @@ export async function applyMigrated(
   targetName: string,
   content: string,
   dryRun: boolean,
+  extraFiles: ExtraFile[] = [],
+  from?: AgentName,
+  sourcePath?: string,
 ): Promise<MigratedArtifact | null> {
+  // Compose `${from} → ${to}: <kind>` when caller threads source info;
+  // fall back to bare `<kind>` when invoked directly (e.g. unit tests).
+  const arrow = from ? `${from} → ${to}: ` : "";
+  const src = sourcePath ?? "";
   if (type === "global-rules") {
     // The cursor-rules sentinel only routes to cursor's settings.json when the
     // declared target is cursor. Without this gate, a translator that
@@ -137,8 +293,9 @@ export async function applyMigrated(
       if (!dryRun) await applyCursorRules(content);
       return {
         targetPath,
+        sourcePath: src,
         content,
-        description: `Cursor rules field in ${targetPath}`,
+        description: `${arrow}cursor rules field`,
       };
     }
     const pathMap: Partial<Record<AgentName, string>> = {
@@ -159,8 +316,9 @@ export async function applyMigrated(
     if (!dryRun) await applyFn(content);
     return {
       targetPath,
+      sourcePath: src,
       content,
-      description: `${to} global rules written to ${targetPath}`,
+      description: `${arrow}global rules`,
     };
   }
 
@@ -170,6 +328,7 @@ export async function applyMigrated(
       cursor: AgentPaths.cursor.mcpGlobal,
       codex: AgentPaths.codex.configToml,
       vscode: AgentPaths.vscode.mcpJson,
+      copilot: AgentPaths.copilot.mcpConfigJson,
     };
     const targetPath = pathMap[to];
     if (!targetPath) return null;
@@ -244,16 +403,41 @@ export async function applyMigrated(
     }
     return {
       targetPath,
+      sourcePath: src,
       content,
-      description: `${to} MCP servers written to ${targetPath}`,
+      description: `${arrow}MCP servers`,
     };
   }
 
   if (type === "commands") {
+    // Codex commands wrap as SKILL.md (Codex has no native slash-command
+    // surface; skills are user-invokable as `/<name>`). Translator emits
+    // `<basename>/SKILL.md` as targetName; orchestrator writes under
+    // ~/.agents/skills/. Other agents write the plain command file.
+    if (to === "codex" && targetName.endsWith("/SKILL.md")) {
+      const skillName = targetName.slice(0, -"/SKILL.md".length);
+      try {
+        validateSkillName(skillName);
+      } catch (err) {
+        if (err instanceof InvalidSkillNameError) return null;
+        throw err;
+      }
+      const targetPath = join(AgentPaths.codex.userSkillsDir, skillName, "SKILL.md");
+      if (!dryRun) {
+        await mkdir(join(AgentPaths.codex.userSkillsDir, skillName), { recursive: true });
+        await atomicWrite(targetPath, content);
+      }
+      return {
+        targetPath,
+        sourcePath: src,
+        content,
+        description: `${arrow}command "${skillName}" wrapped as skill`,
+      };
+    }
+
     const dirMap: Partial<Record<AgentName, string>> = {
       claude: AgentPaths.claude.commandsDir,
       cursor: AgentPaths.cursor.commandsDir,
-      codex: AgentPaths.codex.rulesDir,
       copilot: AgentPaths.copilot.promptsDir,
     };
     const dir = dirMap[to];
@@ -263,8 +447,56 @@ export async function applyMigrated(
     if (!dryRun) await atomicWrite(targetPath, content);
     return {
       targetPath,
+      sourcePath: src,
       content,
-      description: `${to} command written to ${targetPath}`,
+      description: `${arrow}command "${targetName}"`,
+    };
+  }
+
+  if (type === "skills") {
+    // targetName is the skill directory name (validated). Write SKILL.md
+    // plus all extraFiles (sidecars carried from source) under it.
+    const targetDir = resolveSkillsTargetDir(to);
+    if (!targetDir) return null;
+    try {
+      validateSkillName(targetName);
+    } catch (err) {
+      if (err instanceof InvalidSkillNameError) return null;
+      throw err;
+    }
+    const skillRoot = join(targetDir, targetName);
+    const skillMdPath = join(skillRoot, "SKILL.md");
+    if (!dryRun) {
+      await mkdir(skillRoot, { recursive: true });
+      await atomicWrite(skillMdPath, content);
+      for (const extra of extraFiles) {
+        const isBase64 = extra.encoding === "base64";
+        const buf = isBase64 ? Buffer.from(extra.content, "base64") : extra.content;
+        const extraPath = join(skillRoot, extra.relPath);
+        await atomicWrite(extraPath, buf);
+      }
+    }
+    return {
+      targetPath: skillMdPath,
+      sourcePath: src,
+      content,
+      description:
+        extraFiles.length > 0
+          ? `${arrow}skill "${targetName}" (+${extraFiles.length} supporting files)`
+          : `${arrow}skill "${targetName}"`,
+    };
+  }
+
+  if (type === "rules") {
+    const dir = resolveRulesDir(to);
+    if (!dir) return null;
+    const targetPath = join(dir, targetName);
+    if (!dryRun) await atomicWrite(targetPath, content);
+    return {
+      targetPath,
+      sourcePath: src,
+      content,
+      description: `${arrow}rule "${targetName}"`,
     };
   }
 
@@ -297,6 +529,14 @@ export async function performMigrate(options: MigrateOptions): Promise<MigrateRe
   for (const type of typesToMigrate) {
     const sources = await readSourceArtefacts(options.from, type, options.name);
     if (sources.length === 0) {
+      // Hard-error when the user explicitly named an artefact that doesn't
+      // exist — silent skip would hide typos. Matches secret-detection abort.
+      if (options.name) {
+        result.errors.push(
+          `Source artefact '${options.name}' not found in ${options.from} ${type}`,
+        );
+        return result;
+      }
       for (const target of targetAgents) {
         result.skipped.push({
           reason: "No source artefacts found",
@@ -316,7 +556,7 @@ export async function performMigrate(options: MigrateOptions): Promise<MigrateRe
         continue;
       }
 
-      for (const { content, name } of sources) {
+      for (const { content, name, sourcePath, sidecars = [] } of sources) {
         const translated = translator(content, name);
         if (!translated) {
           result.skipped.push({
@@ -369,12 +609,18 @@ export async function performMigrate(options: MigrateOptions): Promise<MigrateRe
         }
 
         try {
+          // Combine translator-emitted extras (rare) with source sidecars
+          // (skills' supporting files travel from source dir verbatim).
+          const allExtras = [...(translated.extraFiles ?? []), ...sidecars];
           const artifact = await applyMigrated(
             target,
             type,
             translated.targetName,
             finalContent,
             options.dryRun ?? false,
+            allExtras,
+            options.from,
+            sourcePath,
           );
           if (artifact) {
             result.migrated.push(artifact);

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -416,12 +416,7 @@ export async function applyMigrated(
     // ~/.agents/skills/. Other agents write the plain command file.
     if (to === "codex" && targetName.endsWith("/SKILL.md")) {
       const skillName = targetName.slice(0, -"/SKILL.md".length);
-      try {
-        validateSkillName(skillName);
-      } catch (err) {
-        if (err instanceof InvalidSkillNameError) return null;
-        throw err;
-      }
+      validateSkillName(skillName);
       const targetPath = join(AgentPaths.codex.userSkillsDir, skillName, "SKILL.md");
       if (!dryRun) {
         await mkdir(join(AgentPaths.codex.userSkillsDir, skillName), { recursive: true });
@@ -458,12 +453,7 @@ export async function applyMigrated(
     // plus all extraFiles (sidecars carried from source) under it.
     const targetDir = resolveSkillsTargetDir(to);
     if (!targetDir) return null;
-    try {
-      validateSkillName(targetName);
-    } catch (err) {
-      if (err instanceof InvalidSkillNameError) return null;
-      throw err;
-    }
+    validateSkillName(targetName);
     const skillRoot = join(targetDir, targetName);
     const skillMdPath = join(skillRoot, "SKILL.md");
     if (!dryRun) {
@@ -603,7 +593,13 @@ export async function performMigrate(options: MigrateOptions): Promise<MigrateRe
                 return result;
               }
             } catch {
-              // If TOML parsing also fails, content is malformed — skip secret check
+              // Translators emit content we control; unparseable bytes here mean
+              // a translator bug. Fail closed so a future broken translator can't
+              // smuggle secrets past the redaction gate.
+              result.errors.push(
+                `MCP content for ${options.from} → ${target} is neither valid JSON nor TOML — secret scan cannot run; aborting`,
+              );
+              return result;
             }
           }
         }

--- a/src/migrate/registry.ts
+++ b/src/migrate/registry.ts
@@ -59,6 +59,8 @@ export function __clearRegistryForTesting(): void {
 import { translateCommand } from "./translators/commands";
 import { translateGlobalRules } from "./translators/global-rules";
 import { translateMcp } from "./translators/mcp";
+import { translateRule } from "./translators/rules";
+import { translateSkill } from "./translators/skills";
 
 // Global Rules (4 agents: Claude, Cursor, Codex, Copilot — VS Code excluded)
 register("claude", "cursor", "global-rules", translateGlobalRules.claudeToCursor);
@@ -74,19 +76,27 @@ register("copilot", "cursor", "global-rules", translateGlobalRules.copilotToCurs
 register("codex", "copilot", "global-rules", translateGlobalRules.codexToCopilot);
 register("copilot", "codex", "global-rules", translateGlobalRules.copilotToCodex);
 
-// MCP (4 agents: Claude, Cursor, Codex, VS Code — Copilot excluded)
+// MCP (5 agents: Claude, Cursor, Codex, VS Code, Copilot CLI)
 register("claude", "cursor", "mcp", translateMcp.claudeToCursor);
 register("claude", "vscode", "mcp", translateMcp.claudeToVsCode);
+register("claude", "codex", "mcp", translateMcp.claudeToCodex);
+register("claude", "copilot", "mcp", translateMcp.claudeToCopilot);
 register("cursor", "claude", "mcp", translateMcp.cursorToClaude);
 register("cursor", "vscode", "mcp", translateMcp.cursorToVsCode);
+register("cursor", "codex", "mcp", translateMcp.cursorToCodex);
+register("cursor", "copilot", "mcp", translateMcp.cursorToCopilot);
 register("vscode", "claude", "mcp", translateMcp.vsCodeToClaude);
 register("vscode", "cursor", "mcp", translateMcp.vsCodeToCursor);
-register("claude", "codex", "mcp", translateMcp.claudeToCodex);
-register("cursor", "codex", "mcp", translateMcp.cursorToCodex);
 register("vscode", "codex", "mcp", translateMcp.vsCodeToCodex);
+register("vscode", "copilot", "mcp", translateMcp.vsCodeToCopilot);
 register("codex", "claude", "mcp", translateMcp.codexToClaude);
 register("codex", "cursor", "mcp", translateMcp.codexToCursor);
 register("codex", "vscode", "mcp", translateMcp.codexToVsCode);
+register("codex", "copilot", "mcp", translateMcp.codexToCopilot);
+register("copilot", "claude", "mcp", translateMcp.copilotToClaude);
+register("copilot", "cursor", "mcp", translateMcp.copilotToCursor);
+register("copilot", "vscode", "mcp", translateMcp.copilotToVsCode);
+register("copilot", "codex", "mcp", translateMcp.copilotToCodex);
 
 // Commands (4 agents: Claude, Cursor, Codex, Copilot — VS Code excluded)
 register("claude", "cursor", "commands", translateCommand.claudeToCursor);
@@ -101,3 +111,25 @@ register("codex", "copilot", "commands", translateCommand.codexToCopilot);
 register("copilot", "claude", "commands", translateCommand.copilotToClaude);
 register("copilot", "cursor", "commands", translateCommand.copilotToCursor);
 register("copilot", "codex", "commands", translateCommand.copilotToCodex);
+
+// Skills (4 skill-bearing agents: Claude, Cursor, Codex, Copilot CLI — VS Code excluded)
+register("claude", "cursor", "skills", translateSkill.claudeToCursor);
+register("claude", "codex", "skills", translateSkill.claudeToCodex);
+register("claude", "copilot", "skills", translateSkill.claudeToCopilot);
+register("cursor", "claude", "skills", translateSkill.cursorToClaude);
+register("cursor", "codex", "skills", translateSkill.cursorToCodex);
+register("cursor", "copilot", "skills", translateSkill.cursorToCopilot);
+register("codex", "claude", "skills", translateSkill.codexToClaude);
+register("codex", "cursor", "skills", translateSkill.codexToCursor);
+register("codex", "copilot", "skills", translateSkill.codexToCopilot);
+register("copilot", "claude", "skills", translateSkill.copilotToClaude);
+register("copilot", "cursor", "skills", translateSkill.copilotToCursor);
+register("copilot", "codex", "skills", translateSkill.copilotToCodex);
+
+// Rules (3-way passthrough: Claude, Cursor, Codex — Copilot/VS Code workspace-only)
+register("claude", "cursor", "rules", translateRule.claudeToCursor);
+register("claude", "codex", "rules", translateRule.claudeToCodex);
+register("cursor", "claude", "rules", translateRule.cursorToClaude);
+register("cursor", "codex", "rules", translateRule.cursorToCodex);
+register("codex", "claude", "rules", translateRule.codexToClaude);
+register("codex", "cursor", "rules", translateRule.codexToCursor);

--- a/src/migrate/translators/_frontmatter.ts
+++ b/src/migrate/translators/_frontmatter.ts
@@ -35,12 +35,17 @@ export function parseFrontmatter(input: string): Frontmatter {
     return { fields: {}, body: input, hasFrontmatter: false };
   }
   const afterOpen = input.replace(FRONTMATTER_OPEN, "");
-  const closeIdx = afterOpen.indexOf("\n---");
-  if (closeIdx === -1) {
+  // Match `\n---` only when followed by newline or end-of-string. Without this
+  // guard, `\n----` or `\n---trailing` would parse as a closing marker and the
+  // body would start with bogus dashes.
+  const closeRe = /\n---(?:\r?\n|$)/;
+  const closeMatch = afterOpen.match(closeRe);
+  if (!closeMatch || closeMatch.index === undefined) {
     return { fields: {}, body: input, hasFrontmatter: false };
   }
+  const closeIdx = closeMatch.index;
   const fmBlock = afterOpen.slice(0, closeIdx);
-  const body = afterOpen.slice(closeIdx + 4).replace(/^\n/, "");
+  const body = afterOpen.slice(closeIdx + closeMatch[0].length);
 
   const fields: Record<string, string | boolean> = {};
   for (const rawLine of fmBlock.split("\n")) {

--- a/src/migrate/translators/_frontmatter.ts
+++ b/src/migrate/translators/_frontmatter.ts
@@ -57,12 +57,11 @@ export function parseFrontmatter(input: string): Frontmatter {
       fields[key] = false;
     } else {
       // Strip surrounding quotes if present (single or double).
-      const unquoted =
-        (valueRaw.startsWith('"') && valueRaw.endsWith('"')) ||
-        (valueRaw.startsWith("'") && valueRaw.endsWith("'"))
-          ? valueRaw.slice(1, -1)
-          : valueRaw;
-      fields[key] = unquoted;
+      const needsUnquoting =
+        valueRaw.length >= 2 &&
+        ((valueRaw.startsWith('"') && valueRaw.endsWith('"')) ||
+          (valueRaw.startsWith("'") && valueRaw.endsWith("'")));
+      fields[key] = needsUnquoting ? valueRaw.slice(1, -1) : valueRaw;
     }
   }
 

--- a/src/migrate/translators/_frontmatter.ts
+++ b/src/migrate/translators/_frontmatter.ts
@@ -1,0 +1,100 @@
+/**
+ * src/migrate/translators/_frontmatter.ts
+ *
+ * Minimal YAML frontmatter parser/serializer shared by skills, rules,
+ * and commands-to-skills translators. Handles the small subset of YAML
+ * that AI agents use in their config frontmatter:
+ *   - Top-level scalar key/value pairs
+ *   - Quoted and unquoted string values
+ *   - Boolean values (true/false)
+ *   - Comma-separated lists (kept as raw string)
+ *
+ * Not a full YAML parser by design — pulling in `js-yaml` for what the
+ * spec actually uses would be overkill and adds a dependency. If the
+ * frontmatter has nested structures, we fall back to preserving the
+ * raw block as-is.
+ */
+
+export interface Frontmatter {
+  /** Parsed key/value pairs (scalar values only). */
+  fields: Record<string, string | boolean>;
+  /** Body content after the frontmatter block (or the entire input if no frontmatter). */
+  body: string;
+  /** True if the input started with `---` and a closing `---` was found. */
+  hasFrontmatter: boolean;
+}
+
+const FRONTMATTER_OPEN = /^---\s*\n/;
+
+/**
+ * Parse YAML frontmatter from a markdown document.
+ * Returns the body unchanged when no frontmatter is present.
+ */
+export function parseFrontmatter(input: string): Frontmatter {
+  if (!FRONTMATTER_OPEN.test(input)) {
+    return { fields: {}, body: input, hasFrontmatter: false };
+  }
+  const afterOpen = input.replace(FRONTMATTER_OPEN, "");
+  const closeIdx = afterOpen.indexOf("\n---");
+  if (closeIdx === -1) {
+    return { fields: {}, body: input, hasFrontmatter: false };
+  }
+  const fmBlock = afterOpen.slice(0, closeIdx);
+  const body = afterOpen.slice(closeIdx + 4).replace(/^\n/, "");
+
+  const fields: Record<string, string | boolean> = {};
+  for (const rawLine of fmBlock.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const valueRaw = line.slice(colonIdx + 1).trim();
+    if (!key) continue;
+    if (valueRaw === "true") {
+      fields[key] = true;
+    } else if (valueRaw === "false") {
+      fields[key] = false;
+    } else {
+      // Strip surrounding quotes if present (single or double).
+      const unquoted =
+        (valueRaw.startsWith('"') && valueRaw.endsWith('"')) ||
+        (valueRaw.startsWith("'") && valueRaw.endsWith("'"))
+          ? valueRaw.slice(1, -1)
+          : valueRaw;
+      fields[key] = unquoted;
+    }
+  }
+
+  return { fields, body, hasFrontmatter: true };
+}
+
+/**
+ * Serialize a fields map into a YAML frontmatter block.
+ * String values containing reserved characters (`:`, `#`, leading/trailing
+ * whitespace) are double-quoted. Empty input yields no frontmatter at all.
+ */
+export function serializeFrontmatter(fields: Record<string, string | boolean>): string {
+  const entries = Object.entries(fields).filter(([, v]) => v !== undefined && v !== null);
+  if (entries.length === 0) return "";
+  const lines = entries.map(([k, v]) => {
+    if (typeof v === "boolean") return `${k}: ${v}`;
+    const needsQuoting = /[:#]|^\s|\s$/.test(v) || v === "";
+    return `${k}: ${needsQuoting ? JSON.stringify(v) : v}`;
+  });
+  return `---\n${lines.join("\n")}\n---\n`;
+}
+
+/**
+ * Extract the first non-empty paragraph of body text. Used to synthesise
+ * a skill description when the source command has no `description:` field.
+ * Returns null if the body has no usable paragraph.
+ */
+export function firstNonEmptyParagraph(body: string): string | null {
+  const trimmed = body.trim();
+  if (!trimmed) return null;
+  const firstParagraph = trimmed.split(/\n\s*\n/)[0]?.trim();
+  if (!firstParagraph) return null;
+  // Drop leading markdown heading markers (#, ##) but keep the title text.
+  return firstParagraph.replace(/^#+\s*/, "").trim() || null;
+}

--- a/src/migrate/translators/commands.ts
+++ b/src/migrate/translators/commands.ts
@@ -5,11 +5,14 @@
  * All command formats are Markdown files — the only difference is the
  * filename convention and target directory:
  *   - Claude/Cursor: *.md
- *   - Codex: *.md (in rules/ directory)
+ *   - Codex: SKILL.md inside ~/.agents/skills/<name>/ (Codex has no native
+ *            slash-command surface, so we wrap commands as skills since
+ *            Codex skills are user-invokable as `/<name>`).
  *   - Copilot: *.prompt.md
  */
 
 import type { Translator } from "../types";
+import { firstNonEmptyParagraph, parseFrontmatter, serializeFrontmatter } from "./_frontmatter";
 
 /** Pass-through translator for agents with identical .md conventions. */
 const mdToMd: Translator = (content, sourceName) => {
@@ -41,6 +44,57 @@ const promptMdToMd: Translator = (content, sourceName) => {
 };
 
 /**
+ * Wrap a command as a Codex skill: synthesise SKILL.md frontmatter
+ * (`name` from the source basename, `description` from the source
+ * frontmatter or first body paragraph) and emit `<basename>/SKILL.md`.
+ *
+ * Codex has no native slash-command concept but its skills are user-
+ * invokable as `/<name>`. The orchestrator detects the `/SKILL.md`
+ * suffix and routes the write to `~/.agents/skills/` instead of the
+ * legacy `~/.codex/rules/` location.
+ */
+function fromName(sourceName: string): string {
+  if (sourceName.endsWith(".prompt.md")) return sourceName.slice(0, -".prompt.md".length);
+  if (sourceName.endsWith(".md")) return sourceName.slice(0, -".md".length);
+  return sourceName;
+}
+
+const COMPATIBLE_FRONTMATTER_KEYS = ["allowed-tools", "argument-hint", "model"] as const;
+
+const cmdToCodexSkill: Translator = (content, sourceName) => {
+  if (!sourceName) return null;
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  const base = fromName(sourceName);
+  if (!base) return null;
+
+  const { fields, body, hasFrontmatter } = parseFrontmatter(trimmed);
+  const sourceBody = hasFrontmatter ? body.trim() : trimmed;
+
+  const description =
+    (typeof fields.description === "string" ? fields.description : null) ??
+    firstNonEmptyParagraph(sourceBody) ??
+    `Migrated command ${base}`;
+
+  const skillFm: Record<string, string | boolean> = { name: base, description };
+  for (const key of COMPATIBLE_FRONTMATTER_KEYS) {
+    const v = fields[key];
+    if (typeof v === "string" || typeof v === "boolean") {
+      skillFm[key] = v;
+    }
+  }
+
+  const skillContent = `${serializeFrontmatter(skillFm)}\n${sourceBody}\n`;
+  return {
+    content: skillContent,
+    targetName: `${base}/SKILL.md`,
+    warnings: [
+      "wrapped as Codex skill at ~/.agents/skills/ — Codex has no native slash-command surface",
+    ],
+  };
+};
+
+/**
  * All commands translators indexed by direction for registry registration.
  * Each function passes through Markdown content and adjusts the filename
  * convention (*.md vs *.prompt.md) based on the target agent.
@@ -48,8 +102,11 @@ const promptMdToMd: Translator = (content, sourceName) => {
 export const translateCommand = {
   claudeToCursor: mdToMd,
   cursorToClaude: mdToMd,
-  claudeToCodex: mdToMd,
-  cursorToCodex: mdToMd,
+  // Codex targets wrap commands as SKILL.md (Codex has no native slash
+  // commands; skills are user-invokable as `/<name>`).
+  claudeToCodex: cmdToCodexSkill,
+  cursorToCodex: cmdToCodexSkill,
+  copilotToCodex: cmdToCodexSkill,
   codexToClaude: mdToMd,
   codexToCursor: mdToMd,
   claudeToCopilot: mdToPromptMd,
@@ -57,5 +114,4 @@ export const translateCommand = {
   codexToCopilot: mdToPromptMd,
   copilotToClaude: promptMdToMd,
   copilotToCursor: promptMdToMd,
-  copilotToCodex: promptMdToMd,
 };

--- a/src/migrate/translators/mcp.ts
+++ b/src/migrate/translators/mcp.ts
@@ -493,16 +493,25 @@ export const translateMcp = {
   claudeToCursor: mcpToMcpServers(parseMcpServersJson),
   claudeToVsCode: mcpToVsCode(parseMcpServersJson),
   claudeToCodex: mcpToCodex(parseMcpServersJson),
+  claudeToCopilot: mcpToMcpServers(parseMcpServersJson),
   // Cursor as source ----------------------------------------------------------
   cursorToClaude: mcpToMcpServers(parseMcpServersJson),
   cursorToVsCode: mcpToVsCode(parseMcpServersJson),
   cursorToCodex: mcpToCodex(parseMcpServersJson),
+  cursorToCopilot: mcpToMcpServers(parseMcpServersJson),
   // VS Code as source ---------------------------------------------------------
   vsCodeToClaude: mcpToMcpServers(parseVsCodeMcp),
   vsCodeToCursor: mcpToMcpServers(parseVsCodeMcp),
   vsCodeToCodex: mcpToCodex(parseVsCodeMcp),
+  vsCodeToCopilot: mcpToMcpServers(parseVsCodeMcp),
   // Codex as source -----------------------------------------------------------
   codexToClaude: mcpToMcpServers(parseCodexMcp),
   codexToCursor: mcpToMcpServers(parseCodexMcp),
   codexToVsCode: mcpToVsCode(parseCodexMcp),
+  codexToCopilot: mcpToMcpServers(parseCodexMcp),
+  // Copilot as source ---------------------------------------------------------
+  copilotToClaude: mcpToMcpServers(parseMcpServersJson),
+  copilotToCursor: mcpToMcpServers(parseMcpServersJson),
+  copilotToVsCode: mcpToVsCode(parseMcpServersJson),
+  copilotToCodex: mcpToCodex(parseMcpServersJson),
 };

--- a/src/migrate/translators/rules.ts
+++ b/src/migrate/translators/rules.ts
@@ -1,0 +1,87 @@
+/**
+ * src/migrate/translators/rules.ts
+ *
+ * Rules-folder translators for the global rules dirs:
+ *   - Claude  ~/.claude/rules/*.md
+ *   - Cursor  ~/.cursor/rules/*.{md,mdc}   (Cursor's `.mdc` carries
+ *               `description`/`globs`/`alwaysApply` frontmatter)
+ *   - Codex   ~/.codex/rules/*.md
+ *
+ * Translation is body-passthrough. Cursor `.mdc` frontmatter is stripped on
+ * egress to claude/codex with a warning naming the dropped fields, and the
+ * filename is rewritten `.mdc` → `.md`. The reverse direction (claude/codex
+ * → cursor) writes plain `.md` (no frontmatter synthesis — claude/codex have
+ * no `globs`/`alwaysApply` to translate).
+ *
+ * Copilot CLI and VS Code rules live workspace-relative under
+ * `.github/instructions/` — out of scope for this global-artefact migration.
+ */
+
+import type { Translator } from "../types";
+import { parseFrontmatter } from "./_frontmatter";
+
+const STRIPPED_MDC_FIELDS = ["description", "globs", "alwaysApply"] as const;
+
+/** Rewrite `.mdc` filename to `.md`. Other extensions pass through unchanged. */
+function rewriteToMd(name: string): string {
+  return name.endsWith(".mdc") ? `${name.slice(0, -".mdc".length)}.md` : name;
+}
+
+/**
+ * Cursor rules → Claude/Codex: strip `.mdc` frontmatter (description/globs/
+ * alwaysApply have no equivalent in plain markdown rules), rewrite filename
+ * to `.md`. Body byte-passthrough.
+ */
+const cursorToPlainMd: Translator = (content, sourceName) => {
+  if (!sourceName) return null;
+  const { fields, body, hasFrontmatter } = parseFrontmatter(content);
+  const targetBody = (hasFrontmatter ? body : content).trim();
+  if (!targetBody) return null;
+
+  const dropped = STRIPPED_MDC_FIELDS.filter((f) => f in fields);
+  const warnings =
+    dropped.length > 0
+      ? [`Dropped Cursor .mdc fields with no plain-md equivalent: ${dropped.join(", ")}.`]
+      : [];
+
+  return {
+    content: `${targetBody}\n`,
+    targetName: rewriteToMd(sourceName),
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+};
+
+/**
+ * Claude/Codex rules → Cursor: body-passthrough as plain `.md`. We don't
+ * synthesise `globs`/`alwaysApply` frontmatter because the source has no
+ * scoping information. Cursor will load these files as always-apply rules.
+ */
+const plainMdToCursor: Translator = (content, sourceName) => {
+  if (!sourceName) return null;
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  // If the source happens to have a `.mdc` extension (unlikely for
+  // claude/codex but defensive), normalise to `.md` since target reads both.
+  return { content: `${trimmed}\n`, targetName: rewriteToMd(sourceName) };
+};
+
+/** Plain markdown passthrough (claude ↔ codex). */
+const plainMdPassthrough: Translator = (content, sourceName) => {
+  if (!sourceName) return null;
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  return { content: `${trimmed}\n`, targetName: rewriteToMd(sourceName) };
+};
+
+/**
+ * Rules translators indexed by direction. Six entries: claude↔cursor,
+ * claude↔codex, cursor↔codex.
+ */
+export const translateRule = {
+  claudeToCursor: plainMdToCursor,
+  claudeToCodex: plainMdPassthrough,
+  cursorToClaude: cursorToPlainMd,
+  cursorToCodex: cursorToPlainMd,
+  codexToClaude: plainMdPassthrough,
+  codexToCursor: plainMdToCursor,
+};

--- a/src/migrate/translators/skills.ts
+++ b/src/migrate/translators/skills.ts
@@ -1,0 +1,84 @@
+/**
+ * src/migrate/translators/skills.ts
+ *
+ * Translators for the Anthropic SKILL.md spec. Claude, Cursor, and Codex all
+ * implement the same progressive-disclosure spec verbatim — name + description
+ * frontmatter, optional supporting files. Cross-translation is essentially
+ * a path remap: SKILL.md content is byte-for-byte portable.
+ *
+ * Copilot CLI exposes a `~/.copilot/skills/` directory but, as of 2026-05,
+ * has no documented loader. We emit copilot targets with a warning so users
+ * know files are staged but not guaranteed to invoke at runtime.
+ *
+ * Supporting files (reference.md, scripts/, assets/) travel as `extraFiles`
+ * on the translator return; the orchestrator carries them from source to
+ * destination unchanged. Translators themselves are pure — they only see
+ * the SKILL.md content string. Sidecars are gathered by the orchestrator
+ * and merged with translator-emitted extraFiles before write.
+ */
+
+import type { Translator } from "../types";
+import { parseFrontmatter } from "./_frontmatter";
+
+/**
+ * Identity translator for SKILL.md content. Validates that the input has the
+ * required `description` field per the Anthropic spec (only `description` is
+ * recommended; `name` defaults to the parent directory name). Emits a warning
+ * if `description` is missing rather than rejecting — matches Claude's stance.
+ */
+const passthroughSkill: Translator = (content, sourceName) => {
+  if (!sourceName) return null;
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  const { fields, hasFrontmatter } = parseFrontmatter(trimmed);
+  const warnings: string[] = [];
+  if (!hasFrontmatter) {
+    warnings.push("SKILL.md has no frontmatter; downstream agents may not load it correctly.");
+  } else if (!fields.description) {
+    warnings.push("SKILL.md is missing the recommended `description` field.");
+  }
+  return {
+    content: `${trimmed}\n`,
+    targetName: sourceName,
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+};
+
+/**
+ * Wraps `passthroughSkill` with a one-line warning that Copilot CLI has no
+ * documented SKILL.md loader as of 2026-05. Files are written but invocation
+ * is best-effort.
+ */
+const copilotSkillBestEffort: Translator = (content, sourceName) => {
+  const result = passthroughSkill(content, sourceName);
+  if (!result) return null;
+  const baseWarnings = result.warnings ?? [];
+  return {
+    ...result,
+    warnings: [
+      ...baseWarnings,
+      "Copilot CLI has no documented SKILL.md loader as of 2026-05; staged as best-effort.",
+    ],
+  };
+};
+
+/**
+ * Skills translators indexed by direction. Claude/Cursor/Codex use the same
+ * Anthropic spec verbatim, so all six in-group directions share `passthroughSkill`.
+ * The three copilot-target directions add a warning; copilot-source directions
+ * pass through cleanly because what Copilot has on disk already matches the spec.
+ */
+export const translateSkill = {
+  claudeToCursor: passthroughSkill,
+  claudeToCodex: passthroughSkill,
+  claudeToCopilot: copilotSkillBestEffort,
+  cursorToClaude: passthroughSkill,
+  cursorToCodex: passthroughSkill,
+  cursorToCopilot: copilotSkillBestEffort,
+  codexToClaude: passthroughSkill,
+  codexToCursor: passthroughSkill,
+  codexToCopilot: copilotSkillBestEffort,
+  copilotToClaude: passthroughSkill,
+  copilotToCursor: passthroughSkill,
+  copilotToCodex: passthroughSkill,
+};

--- a/src/migrate/types.ts
+++ b/src/migrate/types.ts
@@ -7,8 +7,8 @@
 
 import type { AgentName } from "../agents/registry";
 
-/** Translatable configuration categories. Skills are out of scope for this feature. */
-export type ConfigType = "global-rules" | "mcp" | "commands";
+/** Translatable configuration categories. */
+export type ConfigType = "global-rules" | "mcp" | "commands" | "skills" | "rules";
 
 /** Identifies a specific directional translation between two agents for one config type. */
 export interface MigrationPair {
@@ -21,9 +21,11 @@ export interface MigrationPair {
 export interface MigratedArtifact {
   /** Absolute destination path on disk. */
   targetPath: string;
+  /** Absolute source path on disk (the file this artefact was translated from). */
+  sourcePath: string;
   /** Transformed content ready to write. */
   content: string;
-  /** Human-readable summary of the transformation applied. */
+  /** Human-readable summary of the transformation applied (e.g. "claude → codex: global rules"). */
   description: string;
 }
 
@@ -39,6 +41,15 @@ export interface MigrateResult {
   errors: string[];
 }
 
+/** Sidecar file emitted alongside a primary translator output (used by skills with supporting files). */
+export interface ExtraFile {
+  /** Path relative to the artefact root (e.g. "reference.md", "scripts/build.sh"). */
+  relPath: string;
+  /** File content. utf8 (default) for text, base64 for binary. */
+  content: string;
+  encoding?: "utf8" | "base64";
+}
+
 /**
  * Pure function that converts source content to target format.
  *
@@ -48,7 +59,9 @@ export interface MigrateResult {
  *   partial transformations (e.g., dropped HTTP/SSE transport fields). When `skipWrite`
  *   is set the orchestrator surfaces `warnings` but does not write the file — used when
  *   every server in the source was dropped by the target schema and writing an empty
- *   stub would create misleading state. null when the input is empty or untranslatable.
+ *   stub would create misleading state. `extraFiles` lets a translator emit additional
+ *   files alongside the primary one (used by skills to carry SKILL.md plus
+ *   reference.md / scripts / assets). null when the input is empty or untranslatable.
  */
 export type Translator = (
   sourceContent: string,
@@ -58,6 +71,7 @@ export type Translator = (
   targetName: string;
   warnings?: string[];
   skipWrite?: boolean;
+  extraFiles?: ExtraFile[];
 } | null;
 
 // MigrateOptions is defined by the Zod schema in src/config/schema.ts


### PR DESCRIPTION
## Summary

Expand `agentsync migrate` from 3 config types (global-rules, mcp, commands) to 5 (adds **skills** and **rules** folders) across the full 5×5 agent matrix. Fix the previously broken `commands → codex` path by wrapping each command as a Codex skill at `~/.agents/skills/<name>/SKILL.md` (Codex never loaded `~/.codex/rules/*.md`). Make `--name` strict (hard-errors on miss). Restructure CLI output to show `from → to: kind` plus `sourcePath → targetPath` on two lines.

### Architecture

**Before — 3 types, lossy commands→codex, label-only output**

```mermaid
flowchart LR
  subgraph types["3 ConfigTypes"]
    GR1["global-rules"]:::keep
    MCP1["mcp"]:::keep
    CMD1["commands"]:::keep
  end
  CMD1 -->|"claude → codex"| BROKEN["~/.codex/rules/*.md<br/>NEVER LOADED"]:::broken
  CMD1 -->|"to other agents"| OK1["target commands dir"]:::keep
  OUT1["CLI output:<br/>'codex commands written to /target'"]:::label
  classDef keep fill:#2c3e50,color:#ffffff
  classDef broken fill:#c0392b,color:#ffffff
  classDef label fill:#ecf0f1,color:#2c3e50
```

**After — 5 types, skill-wrapped codex commands, source+target paths shown**

```mermaid
flowchart LR
  subgraph types2["5 ConfigTypes"]
    GR2["global-rules"]:::keep
    MCP2["mcp"]:::keep
    CMD2["commands"]:::keep
    SK2["skills (new)"]:::new
    RU2["rules folder (new)"]:::new
  end
  CMD2 -->|"claude/cursor → codex"| WRAP["~/.agents/skills/&lt;name&gt;/SKILL.md<br/>synthesised frontmatter<br/>invokable as /name"]:::new
  CMD2 -->|"to claude/cursor/copilot"| OK2["target commands/prompts dir"]:::keep
  SK2 -->|"SKILL.md verbatim"| OK3["target skills dir"]:::keep
  RU2 -->|"strip mdc on egress"| OK4["target rules dir"]:::keep
  OUT2["CLI output:<br/>'claude → codex: commands'<br/>'  /src/path → /tgt/path'"]:::label
  classDef keep fill:#2c3e50,color:#ffffff
  classDef new fill:#27ae60,color:#ffffff
  classDef label fill:#ecf0f1,color:#2c3e50
```

## Changes

### Migration core (`src/migrate/`)

- `types.ts` — added `sourcePath: string` to `MigratedArtifact`; extended `ConfigType` union with `skills` and `rules`.
- `migrate.ts` — `readSourceArtefacts` now returns absolute `sourcePath` for every artefact across all 5 types; `applyMigrated` gained optional `from` + `sourcePath` parameters; all 7 description return-sites rewritten to `"from → to: kind"` format; `performMigrate` threads source paths through.
- `registry.ts` — registers new skills/rules translators with `(from, to, type)` keys.
- `translators/skills.ts` (new) — cross-translates SKILL.md verbatim across Claude/Cursor/Codex; best-effort Copilot.
- `translators/rules.ts` (new) — folder-level rules translator; strips Cursor `.mdc` frontmatter on egress with warnings, rewrites `.mdc → .md`.
- `translators/_frontmatter.ts` (new) — shared YAML frontmatter parse/serialise helper.
- `translators/commands.ts` — `commands → codex` now produces wrapped Codex skill at `~/.agents/skills/<name>/SKILL.md` with synthesised `name` + `description` frontmatter.
- `translators/mcp.ts` — Copilot MCP target wired up.

### Agent adapters

- `agents/copilot.ts` — added `applyCopilotMcp` writing merged `~/.copilot/mcp-config.json`.
- `agents/cursor.ts` — exposed rules-dir path.
- `config/paths.ts` — added `mcpConfigJson` for Copilot, rules/skills dirs where missing.
- `config/schema.ts` — schema bump for new ConfigType values.

### CLI

- `commands/migrate.ts` — dry-run and real output now render two-line format: `[dry-run] claude → codex: global rules\n  /src/path → /tgt/path`.

### Behaviour change

- `--name` now hard-errors with exit code 1 when zero source artefacts match (previously silent skip).

### Docs / spec

- `docs/migrate.md` — expanded support matrix, per-category endpoint table, skills/rules sections, commands→codex wrapping rationale.
- `specs/20260406-125441-config-migration/contracts/cli-migrate.md` — contract updated for 5 types + `--name` hard-error case.

### Tests

- `migrate/__tests__/migrate.test.ts` — +227 lines covering skills, rules, `--name` strict, vscode no-skills path.
- `migrate/__tests__/translators/skills.test.ts` (new).
- `migrate/__tests__/translators/rules.test.ts` (new).
- `migrate/__tests__/registry.test.ts` — registration coverage for new types.
- `migrate/__tests__/translators/{commands,mcp}.test.ts` — codex wrap + copilot mcp coverage.
- `agents/__tests__/copilot.test.ts` — `applyCopilotMcp` tests.
- `commands/__tests__/migrate.test.ts` — schema fixture updated (`skills` is now a valid `--type`).

## Test Evidence

- 602/602 migrate-related tests pass.
- Sole full-suite failure is the pre-existing flaky `performPush inherits shared divergence policy` integration test (5s timeout) — unrelated.
- Live smoke test: skills migration produces correct paths; `--name` miss exits 1; source→target paths render correctly in CLI output.
- TypeScript typecheck clean; Biome auto-fix applied.

## Risks / Follow-ups

- **Behaviour change**: `--name` no longer silently skips on miss — callers depending on the old behaviour will see exit 1.
- **Copilot skills are best-effort**: written to `~/.copilot/skills/<name>/SKILL.md` but Copilot has no documented SKILL.md loader as of 2026-05.
- **Symlinked skill dirs don't migrate**: source skills mounted as symlinks are skipped — documented in `docs/migrate.md`.
- **Codex skills under `~/.agents/`**: preferred path is `~/.agents/skills/<name>/`; legacy `~/.codex/skills/<name>/` retained as fallback.

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded migration guide with complete CLI flags reference, multi-agent config support matrix, and detailed migration behaviors.

* **New Features**
  * Added skills and rules migration support across agents.
  * Introduced Copilot MCP configuration management.
  * Enhanced `--name` flag to support skill directory names.

* **Bug Fixes**
  * Changed `--name` to hard-error when source artifact not found (previously silent-skipped).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->