### PR TITLE
refactor: unify TUI state in a store and rewrite vault apply as data plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,11 @@ system model.
 
 ```text
 src/
-  cli.ts                  CLI entry — wires citty commands
+  cli.ts                  CLI entry — wires citty commands; bare invocation opens the TUI
   agents/                 Per-agent adapters (claude, cursor, codex, copilot, vscode)
   commands/               User-facing commands (init, push, pull, status, daemon, key, skill, …)
+    destroy.ts            CLI vault teardown — local rm, remote commit, or both
+    tui/                  Interactive TUI: app loop, tab modules, IPC client, render panes
   config/                 Path resolution + agentsync.toml schema
   core/                   encryptor, git, sanitizer, tar, watcher, sync-queue, ipc
   daemon/                 Long-running process + per-OS installers
@@ -36,7 +38,7 @@ src/
   test-helpers/           Shared test fixtures
 docs/                     Architecture, commands, migrate, operations, contributing
 specs/                    speckit feature specs and plans
-scripts/                  Build / packaging scripts
+scripts/                  Build / packaging scripts (build.ts, build-package.ts)
 ```
 
 Tests live in co-located `__tests__/` directories beside the code under test
@@ -71,6 +73,18 @@ bun run check:act     # run CI workflow locally via nektos/act
 - **Path resolution**: always resolve agent paths through `AgentPaths` in
   `src/config/paths.ts` rather than hardcoding `~/.claude`, `~/.cursor`,
   etc. — this keeps the test harness and platform overrides working.
+- **TUI reuses command logic, never duplicates it**: the TUI wizards and
+  the Migrate tab call `performInit`, `performKeyAdd`, `performKeyRotate`,
+  `performMigrate`, and `performSkillRemove` directly. Adding new TUI
+  features must not fork business logic — encryption, reconciliation,
+  sanitiser, and migration invariants live in one place.
+- **`destroy` never imports `AgentPaths`**: the agent-files-never-touched
+  invariant for `agentsync destroy` is enforced by construction (no
+  `AgentPaths.*` reference anywhere in `src/commands/destroy.ts`) and by
+  test (three sha256+mtime assertions in `destroy.test.ts` covering each
+  scope). A future PR that adds that import without a documented reason
+  should be rejected at review — the invariant is the entire safety story
+  for that command.
 - **Errors over fallbacks**: prefer surfacing reconciliation, encryption,
   or daemon-IPC failures with actionable guidance over silent retries or
   defaults.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ bunx --package @chrisleekr/agentsync agentsync --version
 
 ## Quickstart
 
+The fastest way in is the interactive TUI. Running `agentsync` with no
+arguments opens a tabbed dashboard that lets you browse the vault, inspect
+local agent content per agent, trigger push/pull, and migrate configuration
+between agents:
+
+```bash
+# Open the TUI (or use the explicit alias `agentsync tui`)
+agentsync
+```
+
+In a non-interactive shell (CI, piped output) bare `agentsync` falls back to
+the `status` text output so scripts are not broken.
+
+The flag-driven CLI is still the canonical scripting surface:
+
 ```bash
 # Initialise a vault and the local machine key
 agentsync init --remote git@github.com:<you>/agentsync-vault.git --branch main
@@ -53,6 +68,7 @@ The full quickstart, command reference, and architecture model live at the docum
 
 | Command | Why you run it |
 |---|---|
+| *(bare)* / `tui` | Open the interactive TUI: vault browser, per-agent local view, push/pull, and migrate. |
 | `init` | Create the local vault workspace, machine key, config, and initial remote state. |
 | `push` | Snapshot local agent configs, sanitise secrets, encrypt artefacts, and push to Git. |
 | `pull` | Pull the latest vault state and apply decrypted artefacts locally. |
@@ -62,6 +78,7 @@ The full quickstart, command reference, and architecture model live at the docum
 | `key` | Add recipients or rotate the local machine key. |
 | `skill` | Remove a skill from the vault explicitly. |
 | `migrate` | Translate configuration between agent formats locally. |
+| `destroy` | Wipe the local vault clone (default) or the remote vault contents via a normal commit. **Local agent files (`~/.claude`, `~/.cursor`, …) are never touched.** |
 
 Full flag tables and caveats: [Commands](https://chrisleekr.github.io/agentsync/commands/).
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@clack/prompts": "^1.2.0",
         "@iarna/toml": "^2.2.5",
+        "@opentui/core": "^0.2.10",
         "age-encryption": "^0.3.0",
         "citty": "^0.2.2",
         "picocolors": "^1.1.1",
@@ -62,6 +63,20 @@
 
     "@noble/post-quantum": ["@noble/post-quantum@0.5.4", "", { "dependencies": { "@noble/curves": "~2.0.0", "@noble/hashes": "~2.0.0" } }, "sha512-leww0zzIirrvwaYMPI9fj6aRIlA/c6Y0/lifQQ1YOOyHEr0MNH3yYpjXeiVG+tWdPps4XxGclFWX2INPO3Yo5w=="],
 
+    "@opentui/core": ["@opentui/core@0.2.10", "", { "dependencies": { "bun-ffi-structs": "0.2.2", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.2.10", "@opentui/core-darwin-x64": "0.2.10", "@opentui/core-linux-arm64": "0.2.10", "@opentui/core-linux-x64": "0.2.10", "@opentui/core-win32-arm64": "0.2.10", "@opentui/core-win32-x64": "0.2.10" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-oviCtx0jYjc7F8X2b8+0IkQLg6WH47Nwl6CFeZo5dU0k6OpSbTbi07ZleObaiECAp+S1YLhAtVdgzHU7hBZlaw=="],
+
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.2.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+lbDDj42Og+UtTZEwlHhGXichmOlkxSqn0J+Jqjat5/Tt5oZykj1NZjFIQ7ZSz4Miz7EmZwgYKE2CyOmmm9MoQ=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.2.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-5iAoA0aqMWWAQ93nh8Bb0ipwt9h+tvEFc88+YO9St43uUJ+XrXcmMj3T8wtl6dSu/SN0UoDWNaUMHUmtykiPtg=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.2.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-EnrkxgH5K76Oi/Br1UHPZblXG5P60snmtySfnxuVaeECNZrbTkV6BV/A0WoBeWshJweGbx1D+eTF+sEEjQCi8w=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.2.10", "", { "os": "linux", "cpu": "x64" }, "sha512-fI+r3kCPqIxsWwPVGpKUQy4zHK8y+jkDRCwa3UbaUy48RQ44jMuf2RhVhmi4xmCvSc8UPJBbYsw1tLuh9kmXjg=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.2.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-8F4z2hIRgkVWcr6CMVeJ9N4+1rmURPt2Pq2GBPko8ch6rxHR+a//KD1MfphyuLTHBS1tJ4vfZSWSoiaESImtrA=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.2.10", "", { "os": "win32", "cpu": "x64" }, "sha512-Ki+qNBlIFW5K2wcG/RHrlPp7yEQKXeiNX3mlje25iwX62Ac5w391HBpOmUjbPoq20McPyDRnhbLfbXQSPtickg=="],
+
     "@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
 
     "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
@@ -72,6 +87,10 @@
 
     "age-encryption": ["age-encryption@0.3.0", "", { "dependencies": { "@noble/ciphers": "^2.1.1", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@noble/post-quantum": "^0.5.3", "@scure/base": "^2.0.0" } }, "sha512-vDhGGp5ZXpbKL6oc3FEBjGhyepr/0SwIWmia6CcPXvYcxGBSQNcDdMv9m2yVOkjjYuJEmtGEhOojIUcjrj0cEw=="],
 
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
+
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
@@ -80,11 +99,17 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "lefthook": ["lefthook@2.1.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.6", "lefthook-darwin-x64": "2.1.6", "lefthook-freebsd-arm64": "2.1.6", "lefthook-freebsd-x64": "2.1.6", "lefthook-linux-arm64": "2.1.6", "lefthook-linux-x64": "2.1.6", "lefthook-openbsd-arm64": "2.1.6", "lefthook-openbsd-x64": "2.1.6", "lefthook-windows-arm64": "2.1.6", "lefthook-windows-x64": "2.1.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q=="],
 
@@ -108,6 +133,8 @@
 
     "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
 
+    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
@@ -120,13 +147,21 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
     "tar": ["tar@7.5.15", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
+
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
   }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,11 +193,14 @@ flowchart LR
     Pull["pull"]:::step
     Timer["Periodic pull timer"]:::step
     Ipc["IPC server"]:::step
-    Client["agentsync CLI"]:::local
+    Cli["agentsync CLI"]:::local
+    Tui["agentsync TUI"]:::local
 
     Watcher --> Debounce --> Queue
     Timer --> Queue
-    Client -->|status / push / pull| Ipc --> Queue
+    Cli -->|status / push / pull| Ipc
+    Tui -->|status poll 1.5s, push, pull| Ipc
+    Ipc --> Queue
     Queue --> Push
     Queue --> Pull
 
@@ -207,6 +210,10 @@ flowchart LR
 ```
 
 </div>
+
+The IPC server accepts multiple concurrent clients. A TUI session and a
+flag-driven CLI invocation can be open at the same time without conflicting
+because every request goes through the same sync queue.
 
 Key invariants:
 
@@ -253,3 +260,22 @@ If you are reading the code, this is the rough mapping from concept to module. K
 | Path resolution | `src/config/paths.ts` |
 | Config schema (`agentsync.toml`) | `src/config/schema.ts` |
 | Vault format migrations | `src/migrate/` |
+| Interactive TUI (bare `agentsync`) | `src/commands/tui/` |
+
+## Compiled-binary packaging
+
+The TUI uses [OpenTUI](https://github.com/anomalyco/opentui), whose
+TypeScript wrapper around a native Zig core is loaded through `bun:ffi` at
+runtime. Three packaging consequences follow:
+
+- `bun run build` (the compiled binary at `dist/agentsync`) runs through
+  `scripts/build.ts`, which first executes `bun install --os="*" --cpu="*"
+  @opentui/core@<v>` so every platform's optional native dependency is
+  resolved into `node_modules` before `bun build --compile` embeds the
+  matching one into bunfs.
+- `bun run build:package` (the npm-published bundle at `dist/cli.js`)
+  externalises `@opentui/core` so the single-file bundle stays a single
+  file. npm consumers receive `@opentui/core` as a runtime dependency
+  declared in `package.json`.
+- Local development (`bun run src/cli.ts`) needs neither step — Bun
+  resolves the native lib for the host platform on first import.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,10 +23,19 @@ bunx --package @chrisleekr/agentsync agentsync <command> [options]
 
 When developing from source, replace the binary call with `bun run src/cli.ts`. The flags are identical.
 
+## Two ways to use agentsync
+
+- **Interactive**: run `agentsync` (no subcommand) to open the [TUI](#tui). It
+  is the right entry point for everyday browsing, sync, and migration.
+- **Scripted**: every subcommand below runs unchanged from a shell, CI, or a
+  wrapper script. Bare `agentsync` in a non-TTY context falls back to
+  `status` text output so existing pipelines are not affected.
+
 ## Command index
 
 | Command | Purpose |
 |---|---|
+| [*(bare)* / `tui`](#tui) | Open the interactive tab-based TUI. |
 | [`init`](#init) | Bootstrap the vault, machine key, and config. |
 | [`push`](#push) | Snapshot, sanitise, encrypt, and fast-forward to the vault. |
 | [`pull`](#pull) | Fetch the vault, decrypt, and apply locally. |
@@ -36,6 +45,57 @@ When developing from source, replace the binary call with `bun run src/cli.ts`. 
 | [`key`](#key) | Add a recipient or rotate the current machine key. |
 | [`skill`](#skill) | Remove a skill from the vault. |
 | [`migrate`](#migrate) | Translate configuration between agent formats. |
+| [`destroy`](#destroy) | Wipe the local vault clone or the remote vault contents (via commit). |
+
+## tui
+
+**Why**: Browse the vault, inspect what each local agent has on disk, trigger
+push / pull, and run cross-agent migrations from a single interactive screen.
+
+**Usage**:
+
+```bash
+agentsync           # bare invocation opens the TUI on a real terminal
+agentsync tui       # explicit alias, same behaviour
+```
+
+**Tabs**:
+
+| Tab | What it shows |
+|---|---|
+| 1 Dashboard | Daemon health (pid, uptime, last error), vault state, agent summary, init / key-rotate launchers. |
+| 2 Vault | All encrypted entries grouped by agent. Multi-select skills with `space`; bulk-remove with `x`. |
+| 3 Agents | Per-agent local file tree (`~/.claude`, `~/.cursor`, `~/.codex`, `~/.copilot`, VS Code user dir). |
+| 4 Migrate | From / To / Type form. Preview is mandatory before Apply enables. |
+| 5 Activity | Session-only ring buffer of TUI actions. |
+
+**Global keys** (any tab):
+
+| Key | Action |
+|---|---|
+| `1` – `5` | Jump to tab |
+| `Tab` / `Shift-Tab` | Cycle tabs |
+| `p` | Push vault (queues an IPC `push` to the daemon) |
+| `l` | Pull vault |
+| `r` | Refresh current tab |
+| `?` | Toggle the keymap overlay |
+| `q` / `Ctrl-C` | Quit, restoring the terminal |
+
+**Outcome**: every state change is additive on the same data the CLI
+subcommands operate on. Push / pull go through the same daemon IPC the
+`status` and `daemon` subcommands use; migrate calls the same planner as
+`agentsync migrate`; bulk skill removal calls the same `performSkillRemove`
+that `agentsync skill remove` does, once per selected skill.
+
+**Caveats**:
+
+- The TUI is interactive-only. In a non-TTY context (piped stdin/stdout,
+  `nohup`, CI runners) bare `agentsync` deliberately falls back to text
+  `status` output so existing scripts continue to work.
+- The activity log is session-scoped — closing the TUI discards history.
+- Push / pull require the daemon to be running. If the daemon is offline,
+  the footer shows `daemon ● offline` and `p` / `l` surface an inline
+  notice rather than queueing a request that cannot be served.
 
 ## Conventions
 
@@ -269,6 +329,70 @@ agentsync migrate --from <agent> --to <agent|all> [--type <type>] [--name <file>
 
 - `migrate` operates on **local files only**. No vault initialisation is required.
 - See [Migrate](migrate.md) for the full support matrix per config type, MCP transport translation rules, and per-agent quirks.
+
+## destroy
+
+**Why**: Reset vault state when you want to start over — either by removing
+the local clone (`--scope=local`), wiping the remote contents via a normal
+commit (`--scope=remote`), or both (`--scope=all`).
+
+> **Agent files are never touched.** `agentsync destroy` does not read,
+> modify, or delete a single byte under `~/.claude/`, `~/.cursor/`,
+> `~/.codex/`, `~/.copilot/`, or your VS Code user directory, regardless
+> of scope. This guarantee is enforced by code (no `AgentPaths.*` import
+> in `src/commands/destroy.ts`) and by test (three sha256+mtime
+> invariants in `destroy.test.ts`).
+
+**Usage**:
+
+```bash
+agentsync destroy                       # local-only, default
+agentsync destroy --scope=remote        # wipe remote via commit
+agentsync destroy --scope=all           # both
+```
+
+**Flags**:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--scope` | `local` | One of `local`, `remote`, `all`. `local` removes the local vault dir. `remote` pushes a commit that `git rm -rf`s every tracked file on the remote — not a force-push, so history stays intact and `git revert` recovers the data on machines that still have it. `all` does both, remote first. |
+| `--force` | `false` | Bypass the agentsync.toml safety check. Use when destroying a half-initialised vault that never got a config file written. Does **not** bypass the three confirmation gates. |
+| `--yes` | `false` | Skip all three confirmation gates. Intended for scripted use; the command otherwise requires an interactive TTY. |
+
+**Confirmation gates** (when `--yes` is not passed):
+
+1. **Preview** — prints the exact paths that will be removed and lists
+   every category of file that will **not** be touched (including local
+   agent installations). Press `y` to advance, anything else to abort.
+2. **Typed phrase** — type the exact string the preview tells you to:
+   - `--scope=local`: type `DESTROY`.
+   - `--scope=remote` / `--scope=all`: type `DESTROY <branch>@<remote-fragment>`,
+     where the fragment is the last two path segments of the remote URL
+     (e.g. `DESTROY main@chrisleekr/agentsync-vault`). This forces you to
+     read the remote URL off the preview before you can confirm.
+3. **Final y/n** — last chance. Anything other than `y` aborts.
+
+**Outcome**:
+
+| Scope | After destroy |
+|---|---|
+| `local` | `~/.agentsync/vault/` is gone. `~/.agentsync/key.txt`, the daemon, the remote, and every `~/.<agent>/` directory are unchanged. Re-init from the same remote restores the clone. |
+| `remote` | Remote branch has a new commit, `destroy: clear vault content`, that removes every previously-tracked file. Local vault dir keeps its `.git/` history. Other machines that still have the data can `git revert <sha>` to recover. |
+| `all` | Both of the above. Remote is wiped first so a failed push does not leave you with a wiped local that cannot reach the remote. |
+
+**Caveats**:
+
+- Other recipients are affected by `--scope=remote` / `--scope=all`. Their
+  next `agentsync pull` will see an empty vault and lose their
+  `agentsync.toml` config — they will need to re-init.
+- The daemon stays running after a local destroy. Its next sync attempt
+  will fail until re-init. Run `agentsync daemon stop` if you want it
+  quiet in the meantime.
+- `key.txt` is preserved across every scope. Re-init from the same remote
+  reuses the existing identity so you stay a recipient. Delete the key
+  manually (`rm ~/.agentsync/key.txt`) if you really need a key wipe.
+- Refuses to run in a non-TTY context without `--yes`, to protect against
+  accidental destroys from piped scripts.
 
 ## Exit codes
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -80,6 +80,42 @@ Rules:
 
 Versioning is semver. The pre-1.0 caveat in [Home](index.md#project-status) applies until 1.0 lands.
 
+## Working on the TUI
+
+The interactive TUI lives in `src/commands/tui/`. The boundary is strict:
+
+- `app.ts` owns the renderer lifecycle, the tab router, and the global key
+  router. Tabs and wizards do not touch the renderer directly.
+- Each tab module exposes `renderXxx(renderer, host, state)` and, where it
+  is interactive, `onXxxKey(key, state): boolean` — `true` means the state
+  changed and a rerender is needed.
+- All business logic is reused from the existing command modules
+  (`performInit`, `performKeyAdd`, `performKeyRotate`, `performMigrate`,
+  `performSkillRemove`). The TUI must not fork encryption, reconciliation,
+  sanitiser, or migration rules.
+
+Local development:
+
+```bash
+bun run src/cli.ts          # bare invocation opens the TUI
+bun run src/cli.ts tui      # explicit alias
+echo '' | bun run src/cli.ts # forces the non-TTY fallback (status text)
+```
+
+Compiled binary verification (`dist/agentsync`):
+
+```bash
+bun run build               # runs scripts/build.ts (with --os=* --cpu=*)
+./dist/agentsync            # macOS Gatekeeper may kill an unsigned binary;
+                            #   prefer `bun install -g @chrisleekr/agentsync`
+                            #   or run via source for development.
+```
+
+The npm-published bundle (`dist/cli.js`) externalises `@opentui/core` so
+the single-file bundle stays a single file. Consumers pick up the native
+TUI dependency from the `dependencies` block in `package.json` at install
+time.
+
 ## Doc ownership
 
 Single source of truth for which file owns which concept. The docs-mirror CI check (`scripts/check-docs-mirror.ts`, wired into `bun run check`) parses this table and fails the PR if drift appears.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,10 @@ The GitHub Release record is the canonical source for the version you are instal
 
 Five steps from zero to a working sync.
 
+> Tip: once you have run `init` once, running `agentsync` with no arguments
+> opens an interactive TUI that covers vault browsing, per-agent local view,
+> push/pull, and migrate. See [Commands → tui](commands.md#tui).
+
 1. **Create an empty Git repo** to act as the vault. A private GitHub or GitLab repo works. Nothing in it will ever contain plaintext.
 2. **Initialise on the first machine.** `agentsync init` generates an age keypair, registers it as a recipient, writes `agentsync.toml`, and clones the empty vault.
 
@@ -72,6 +76,7 @@ Detailed flag, outcome, and caveat tables live in [Commands](commands.md).
 - **Fast-forward only.** Reconciliation never merges silently. If two machines diverge, AgentSync stops and prints a recovery path.
 - **Sanitiser is a hard gate.** Literal secrets and never-sync paths abort the push before any bytes leave the machine.
 - **Skill removal is explicit.** `pull` is additive by design so an in-progress local edit cannot be wiped by a remote that omits it. `agentsync skill remove` is the only command that deletes vault entries.
+- **Interactive TUI.** Running `agentsync` with no subcommand opens a tabbed UI to browse the vault, inspect per-agent local content, trigger push/pull, and migrate config — without memorising flags.
 
 ## Where to go next
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -2,9 +2,18 @@
 
 ## Overview
 
-The `agentsync migrate` command translates configuration from one AI agent's format to another. It reads local agent config files, transforms them through format-specific translators, and writes the result to the target agent's config location.
+Translate configuration from one AI agent's format to another. The migrator reads local agent config files, transforms them through format-specific translators, and writes the result to the target agent's config location.
 
-No vault initialisation is required — `migrate` operates on local files only.
+No vault initialisation is required — migration operates on local files only.
+
+## Two ways to run a migration
+
+- **Interactive (TUI)**: run `agentsync`, press `4` for the Migrate tab,
+  pick From / To / Type, press Shift-P to preview, then Shift-A to apply.
+  Apply is disabled until a preview that matches the current form has been
+  rendered, so an accidental keystroke cannot trigger an unreviewed write.
+- **Scripted (CLI)**: use the flags below from a shell or CI. The TUI
+  calls the same planner internally, so the dry-run output is identical.
 
 ## Command
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,6 +6,20 @@ Run AgentSync in production for your own laptops: install the daemon, rotate key
 
 This page owns day-2 concerns. It is the single home for the daemon install procedure on each OS, the key-rotation runbook, and the troubleshooting catalogue. The architectural model behind these flows lives in [Architecture](architecture.md); the command flag reference lives in [Commands](commands.md).
 
+## Daily ops in the TUI
+
+Run `agentsync` with no arguments for an interactive view of daemon health,
+vault state, agent file deltas, and pending sync activity. The TUI keeps a
+1.5-second poll on the daemon IPC `status` command, so the dashboard reflects
+live state without you re-running `agentsync status`.
+
+The flag-driven equivalents still work when you need scripted output:
+
+- `agentsync status` — text comparison of local files vs the decrypted
+  vault.
+- `agentsync daemon status` — daemon health only.
+- `agentsync doctor` — local environment, key, vault, and daemon checks.
+
 ## Daemon
 
 The daemon is a long-running process that watches your enabled agent paths and pushes on change. It debounces rapid edits, serialises sync operations through a queue so two pushes can never race, and runs periodic pulls at a configurable interval.
@@ -129,6 +143,42 @@ If `pull` cannot decrypt or `doctor` reports a missing key:
 
 If the key is gone and was never backed up, the vault cannot be recovered for that machine. Generate a new identity with `init`, have the new public key added by an existing machine, then `pull`.
 
+### Reset a vault
+
+When you want to throw away vault state and start over, reach for
+[`agentsync destroy`](commands.md#destroy) rather than `rm -rf`.
+
+> **Agent files are never touched.** Every `agentsync destroy` scope
+> leaves `~/.claude/`, `~/.cursor/`, `~/.codex/`, `~/.copilot/`, and your
+> VS Code user directory byte-for-byte unchanged. This is guaranteed by
+> code and asserted by test — `destroy` only ever operates on the vault
+> directory and the configured remote.
+
+Decide the scope first:
+
+- **Local clone is corrupted, remote is fine** → `agentsync destroy`
+  (default `--scope=local`). Removes `~/.agentsync/vault/`, keeps
+  `key.txt`. Then re-init from the same remote.
+- **You want every machine to start fresh, including the remote** →
+  `agentsync destroy --scope=remote`. Adds a commit to the remote that
+  removes every tracked file (not a force-push — history is preserved
+  and other recipients can `git revert` if they still have a copy).
+- **Both** → `agentsync destroy --scope=all`. Remote is wiped first so a
+  failed push does not leave you with a wiped local that cannot reach
+  the remote.
+
+Before running, back the vault up if you might still want it:
+
+```bash
+cp -r ~/.agentsync/vault ~/.agentsync/vault.bak.$(date +%s)
+```
+
+Three confirmation gates must pass: preview prompt → typed phrase
+(`DESTROY` for local, `DESTROY <branch>@<remote-fragment>` for remote /
+all) → final y/n. The command refuses to run in a non-TTY shell without
+`--yes`. See [Commands → destroy](commands.md#destroy) for the full flag
+and behaviour reference.
+
 ## Troubleshooting catalogue
 
 ### `status` shows local-only or vault-only entries
@@ -198,3 +248,33 @@ Common causes:
 - Git authentication is not set up for the remote. AgentSync uses your existing Git credentials.
 
 Run `agentsync doctor` for a focused report, then re-run `init`.
+
+### TUI does not open / falls back to text output
+
+Bare `agentsync` deliberately falls back to printing `status` output when
+stdout is not a TTY. This happens under `nohup`, inside `script(1)`, when
+piped to another process, or in CI runners. Force the TUI from a
+non-interactive context by running `agentsync tui` with a real terminal
+allocated by the shell (e.g. `script -q /dev/null agentsync tui`); the
+fallback exists specifically to protect scripts that depend on text output.
+
+### Terminal looks broken after the TUI crashed
+
+The TUI installs SIGINT / SIGTERM / exit handlers that restore the terminal
+on shutdown. A hard kill (`kill -9` on the bun process) can bypass that and
+leave the terminal in raw mode. Recover with:
+
+```bash
+reset
+# or, if `reset` is unavailable:
+tput reset
+```
+
+### `dist/agentsync` exits 137 on macOS
+
+This is the macOS Gatekeeper killing the unsigned compiled binary on first
+launch. It is a pre-existing issue with the compiled distribution and is
+not caused by the TUI dependency. The supported install method is `bun
+install -g @chrisleekr/agentsync`, which ships the bundled `dist/cli.js`
+through Bun and is not subject to Gatekeeper. Code signing for the
+compiled binary is tracked separately from the TUI work.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -19,8 +19,8 @@
 [data-md-color-scheme="slate"] .mermaid .nodeLabel span,
 [data-md-color-scheme="slate"] .mermaid foreignObject p,
 [data-md-color-scheme="slate"] .mermaid foreignObject span {
-  color: #ffffff !important;
-  fill: #ffffff !important;
+  color: #ffffff;
+  fill: #ffffff;
 }
 
 /* Safety net for any future diagram that omits classDef and falls back
@@ -30,16 +30,16 @@
 [data-md-color-scheme="slate"] .mermaid .node polygon[fill="#ECECFF"],
 [data-md-color-scheme="slate"] .mermaid .node rect[fill="#fff5ad"],
 [data-md-color-scheme="slate"] .mermaid .node polygon[fill="#fff5ad"] {
-  fill: #34495e !important;
-  stroke: #1a252f !important;
+  fill: #34495e;
+  stroke: #1a252f;
 }
 
 /* Edge labels need a background that matches the page in dark mode.
    Without this they sit on a white pill that breaks the dark theme. */
 [data-md-color-scheme="slate"] .mermaid .edgeLabel,
 [data-md-color-scheme="slate"] .mermaid .edgeLabel rect {
-  background-color: var(--md-default-bg-color) !important;
-  fill: var(--md-default-bg-color) !important;
+  background-color: var(--md-default-bg-color);
+  fill: var(--md-default-bg-color);
 }
 
 /* Light-mode label color for our dark-fill diagrams.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun build --compile src/cli.ts --outfile dist/agentsync",
+    "build": "bun run scripts/build.ts",
     "build:package": "bun run scripts/build-package.ts",
     "pack:dry-run": "bun run build:package && npm pack --dry-run --json --ignore-scripts",
     "typecheck": "bunx tsc --noEmit",
@@ -63,6 +63,7 @@
   "dependencies": {
     "@clack/prompts": "^1.2.0",
     "@iarna/toml": "^2.2.5",
+    "@opentui/core": "^0.2.10",
     "age-encryption": "^0.3.0",
     "citty": "^0.2.2",
     "picocolors": "^1.1.1",

--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -5,11 +5,18 @@ const packageEntry = join(process.cwd(), "dist", "cli.js");
 const packageEntryTmp = `${packageEntry}.tmp`;
 const shebang = "#!/usr/bin/env bun\n";
 
+// `@opentui/core` ships a native Zig core loaded via bun:ffi from
+// platform-specific optionalDependencies (.dylib / .so / .dll). Bundling
+// the JS into a single `dist/cli.js` would force Bun to copy those native
+// files as adjacent outputs, breaking the single-file npm contract. Mark
+// it external so npm pulls it in at install time alongside the bundle.
 const buildResult = Bun.spawnSync([
   process.execPath,
   "build",
   "--target",
   "bun",
+  "--external",
+  "@opentui/core",
   "src/cli.ts",
   "--outfile",
   packageEntryTmp,

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env bun
+import { $ } from "bun";
+import pkg from "../package.json";
+
+const opentuiVersion = pkg.dependencies["@opentui/core"];
+if (!opentuiVersion) {
+  process.exit(1);
+}
+
+// Pre-install every platform's native @opentui/core lib so bun compile can
+// pick the matching one out of node_modules. Without this, an install on a
+// different machine architecture than the release target would silently skip
+// the optionalDependencies for the target platform.
+await $`bun install --os="*" --cpu="*" @opentui/core@${opentuiVersion}`;
+
+await $`bun build --compile src/cli.ts --outfile dist/agentsync`;

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -4,6 +4,9 @@ import pkg from "../package.json";
 
 const opentuiVersion = pkg.dependencies["@opentui/core"];
 if (!opentuiVersion) {
+  console.error(
+    "build failed: @opentui/core is missing from package.json dependencies; add it before building.",
+  );
   process.exit(1);
 }
 

--- a/src/agents/__tests__/_apply.test.ts
+++ b/src/agents/__tests__/_apply.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { encryptString, generateIdentity, identityToRecipient } from "../../core/encryptor";
 import { type ApplyPlan, defineFileArtifact, readAgeFiles, runApplyPlan } from "../_apply";
 
@@ -15,22 +15,21 @@ async function setupKey(): Promise<void> {
 }
 
 async function writeEncrypted(absPath: string, plaintext: string): Promise<void> {
-  await mkdir(absPath.replace(/[^/]+$/, ""), { recursive: true });
+  mkdirSync(dirname(absPath), { recursive: true });
   const armored = await encryptString(plaintext, [recipient]);
-  await writeFile(absPath, armored, "utf8");
+  writeFileSync(absPath, armored, "utf8");
 }
 
 beforeEach(async () => {
   workDir = join(tmpdir(), `agentsync-apply-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  await mkdir(workDir, { recursive: true });
+  mkdirSync(workDir, { recursive: true });
   await setupKey();
 });
 
-afterEach(async () => {
+afterEach(() => {
   // Best-effort cleanup; OS temp will reclaim if this fails.
-  const { rm } = await import("node:fs/promises");
   try {
-    await rm(workDir, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
   } catch {
     // ignore
   }
@@ -43,9 +42,9 @@ describe("readAgeFiles", () => {
   });
 
   test("filters non-matching suffixes", async () => {
-    await writeFile(join(workDir, "a.age"), "x");
-    await writeFile(join(workDir, "b.txt"), "y");
-    await writeFile(join(workDir, "c.tar.age"), "z");
+    writeFileSync(join(workDir, "a.age"), "x");
+    writeFileSync(join(workDir, "b.txt"), "y");
+    writeFileSync(join(workDir, "c.tar.age"), "z");
     const ageOnly = await readAgeFiles(workDir, ".age");
     expect(ageOnly.map((f) => f.name).sort()).toEqual(["a.age", "c.tar.age"]);
     const tarOnly = await readAgeFiles(workDir, ".tar.age");
@@ -234,7 +233,7 @@ describe("runApplyPlan DirArtifact", () => {
 describe("runApplyPlan EscapeHatch", () => {
   test("custom directive receives the resolved agent vault dir", async () => {
     const vaultDir = workDir;
-    await mkdir(join(vaultDir, "demo", "plugins"), { recursive: true });
+    mkdirSync(join(vaultDir, "demo", "plugins"), { recursive: true });
     let captured = "";
     const plan: ApplyPlan = {
       agent: "demo",
@@ -292,7 +291,7 @@ describe("runApplyPlan warnOnUnknownTopLevel", () => {
     // exception when the unknown file co-exists).
     await runApplyPlan(plan, vaultDir, identity, false);
     // sanity: vault still contains both files (we didn't accidentally write or remove)
-    const remaining = await readdir(join(vaultDir, "demo"));
+    const remaining = readdirSync(join(vaultDir, "demo"));
     expect(remaining.sort()).toEqual(["known.age", "unknown.age"]);
   });
 });

--- a/src/agents/__tests__/_apply.test.ts
+++ b/src/agents/__tests__/_apply.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { encryptString, generateIdentity, identityToRecipient } from "../../core/encryptor";
+import { type ApplyPlan, defineFileArtifact, readAgeFiles, runApplyPlan } from "../_apply";
+
+let workDir = "";
+let identity = "";
+let recipient = "";
+
+async function setupKey(): Promise<void> {
+  identity = await generateIdentity();
+  recipient = await identityToRecipient(identity);
+}
+
+async function writeEncrypted(absPath: string, plaintext: string): Promise<void> {
+  await mkdir(absPath.replace(/[^/]+$/, ""), { recursive: true });
+  const armored = await encryptString(plaintext, [recipient]);
+  await writeFile(absPath, armored, "utf8");
+}
+
+beforeEach(async () => {
+  workDir = join(tmpdir(), `agentsync-apply-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(workDir, { recursive: true });
+  await setupKey();
+});
+
+afterEach(async () => {
+  // Best-effort cleanup; OS temp will reclaim if this fails.
+  const { rm } = await import("node:fs/promises");
+  try {
+    await rm(workDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe("readAgeFiles", () => {
+  test("returns empty for a missing directory", async () => {
+    const out = await readAgeFiles(join(workDir, "missing"));
+    expect(out).toEqual([]);
+  });
+
+  test("filters non-matching suffixes", async () => {
+    await writeFile(join(workDir, "a.age"), "x");
+    await writeFile(join(workDir, "b.txt"), "y");
+    await writeFile(join(workDir, "c.tar.age"), "z");
+    const ageOnly = await readAgeFiles(workDir, ".age");
+    expect(ageOnly.map((f) => f.name).sort()).toEqual(["a.age", "c.tar.age"]);
+    const tarOnly = await readAgeFiles(workDir, ".tar.age");
+    expect(tarOnly.map((f) => f.name)).toEqual(["c.tar.age"]);
+  });
+});
+
+describe("runApplyPlan FileArtifact", () => {
+  test("decrypts and invokes apply for a matching vaultName", async () => {
+    const vaultDir = workDir;
+    const target = join(vaultDir, "demo", "foo.md.age");
+    await writeEncrypted(target, "hello world");
+    const received: string[] = [];
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        defineFileArtifact({
+          vaultName: "foo.md.age",
+          dryRunLabel: "[dry-run] [demo] would apply foo.md",
+          apply: async (decrypted) => {
+            received.push(decrypted);
+          },
+        }),
+      ],
+    };
+    await runApplyPlan(plan, vaultDir, identity, false);
+    expect(received).toEqual(["hello world"]);
+  });
+
+  test("dry-run does NOT invoke apply and does NOT decrypt", async () => {
+    const vaultDir = workDir;
+    await writeEncrypted(join(vaultDir, "demo", "foo.md.age"), "should-not-leak");
+    let calls = 0;
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        defineFileArtifact({
+          vaultName: "foo.md.age",
+          dryRunLabel: "[dry-run] [demo] would apply foo.md",
+          apply: async () => {
+            calls += 1;
+          },
+        }),
+      ],
+    };
+    await runApplyPlan(plan, vaultDir, identity, true);
+    expect(calls).toBe(0);
+  });
+
+  test("enabled() = false silently skips even when the file exists", async () => {
+    const vaultDir = workDir;
+    await writeEncrypted(join(vaultDir, "demo", "gated.json.age"), "content");
+    let invoked = false;
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        defineFileArtifact({
+          vaultName: "gated.json.age",
+          dryRunLabel: "[dry-run] [demo] would apply gated",
+          apply: async () => {
+            invoked = true;
+          },
+          enabled: () => false,
+        }),
+      ],
+    };
+    await runApplyPlan(plan, vaultDir, identity, false);
+    expect(invoked).toBe(false);
+  });
+
+  test("missing top-level file is silently skipped (no error)", async () => {
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        defineFileArtifact({
+          vaultName: "absent.md.age",
+          dryRunLabel: "[dry-run] [demo] would apply absent",
+          apply: async () => {
+            throw new Error("must not run");
+          },
+        }),
+      ],
+    };
+    await runApplyPlan(plan, workDir, identity, false);
+  });
+});
+
+describe("runApplyPlan DirArtifact", () => {
+  test("decrypts every matching entry and strips the suffix", async () => {
+    const vaultDir = workDir;
+    await writeEncrypted(join(vaultDir, "demo", "commands", "foo.md.age"), "FOO");
+    await writeEncrypted(join(vaultDir, "demo", "commands", "bar.md.age"), "BAR");
+    const seen: { name: string; body: string }[] = [];
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        {
+          kind: "dir",
+          subdir: "commands",
+          suffix: ".age",
+          dryRunVerb: "would write command:",
+          apply: async (name, body) => {
+            seen.push({ name, body });
+          },
+        },
+      ],
+    };
+    await runApplyPlan(plan, vaultDir, identity, false);
+    expect(seen.sort((a, b) => a.name.localeCompare(b.name))).toEqual([
+      { name: "bar.md", body: "BAR" },
+      { name: "foo.md", body: "FOO" },
+    ]);
+  });
+
+  test("`match` filter rejects non-matching files before decrypt", async () => {
+    const vaultDir = workDir;
+    await writeEncrypted(join(vaultDir, "demo", "instr", "x.instructions.md.age"), "OK");
+    await writeEncrypted(join(vaultDir, "demo", "instr", "y.other.age"), "SKIP");
+    const calls: string[] = [];
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        {
+          kind: "dir",
+          subdir: "instr",
+          suffix: ".age",
+          match: (n) => n.endsWith(".instructions.md.age"),
+          dryRunVerb: "would write:",
+          apply: async (name) => {
+            calls.push(name);
+          },
+        },
+      ],
+    };
+    await runApplyPlan(plan, vaultDir, identity, false);
+    expect(calls).toEqual(["x.instructions.md"]);
+  });
+
+  test("`filter` skips with a reason and never invokes apply", async () => {
+    const vaultDir = workDir;
+    await writeEncrypted(join(vaultDir, "demo", "skills", "valid.tar.age"), "GOOD");
+    await writeEncrypted(join(vaultDir, "demo", "skills", "bad.tar.age"), "BAD");
+    const applied: string[] = [];
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        {
+          kind: "dir",
+          subdir: "skills",
+          suffix: ".tar.age",
+          dryRunVerb: "would extract:",
+          apply: async (name) => {
+            applied.push(name);
+          },
+          filter: (name) => (name === "bad" ? { reason: "rejected for tests" } : null),
+        },
+      ],
+    };
+    await runApplyPlan(plan, vaultDir, identity, false);
+    expect(applied).toEqual(["valid"]);
+  });
+
+  test("`.tar.age` suffix strips correctly", async () => {
+    const vaultDir = workDir;
+    await writeEncrypted(join(vaultDir, "demo", "skills", "foo.tar.age"), "PAYLOAD");
+    const seen: string[] = [];
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        {
+          kind: "dir",
+          subdir: "skills",
+          suffix: ".tar.age",
+          dryRunVerb: "would extract:",
+          apply: async (name) => {
+            seen.push(name);
+          },
+        },
+      ],
+    };
+    await runApplyPlan(plan, vaultDir, identity, false);
+    expect(seen).toEqual(["foo"]);
+  });
+});
+
+describe("runApplyPlan EscapeHatch", () => {
+  test("custom directive receives the resolved agent vault dir", async () => {
+    const vaultDir = workDir;
+    await mkdir(join(vaultDir, "demo", "plugins"), { recursive: true });
+    let captured = "";
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        {
+          kind: "custom",
+          run: async (agentVaultDir) => {
+            captured = agentVaultDir;
+          },
+        },
+      ],
+    };
+    await runApplyPlan(plan, vaultDir, identity, false);
+    expect(captured).toBe(join(vaultDir, "demo"));
+  });
+
+  test("custom directive receives dryRun=true when applicable", async () => {
+    const observed: { value: boolean | null } = { value: null };
+    const plan: ApplyPlan = {
+      agent: "demo",
+      directives: [
+        {
+          kind: "custom",
+          run: async (_dir, _key, dryRun) => {
+            observed.value = dryRun;
+          },
+        },
+      ],
+    };
+    await runApplyPlan(plan, workDir, identity, true);
+    expect(observed.value).toBe(true);
+  });
+});
+
+describe("runApplyPlan warnOnUnknownTopLevel", () => {
+  test("does not throw when an unknown top-level file is present", async () => {
+    const vaultDir = workDir;
+    await writeEncrypted(join(vaultDir, "demo", "known.age"), "ok");
+    await writeEncrypted(join(vaultDir, "demo", "unknown.age"), "ok");
+    const plan: ApplyPlan = {
+      agent: "demo",
+      warnOnUnknownTopLevel: true,
+      directives: [
+        defineFileArtifact({
+          vaultName: "known.age",
+          dryRunLabel: "[dry-run] [demo] would apply known",
+          apply: async () => {
+            // no-op
+          },
+        }),
+      ],
+    };
+    // Side effect is a log.warn — we just assert the call doesn't throw and
+    // the recognised directive still ran (proved below by absence of
+    // exception when the unknown file co-exists).
+    await runApplyPlan(plan, vaultDir, identity, false);
+    // sanity: vault still contains both files (we didn't accidentally write or remove)
+    const remaining = await readdir(join(vaultDir, "demo"));
+    expect(remaining.sort()).toEqual(["known.age", "unknown.age"]);
+  });
+});

--- a/src/agents/_apply.ts
+++ b/src/agents/_apply.ts
@@ -1,0 +1,155 @@
+import { readdir, readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { log } from "@clack/prompts";
+import { decryptString } from "../core/encryptor";
+
+/** Read .age (or .tar.age) files from a vault subdirectory, ignoring missing dirs. */
+export async function readAgeFiles(
+  dir: string,
+  suffix: ".age" | ".tar.age" = ".age",
+): Promise<{ name: string; fullPath: string }[]> {
+  try {
+    const names = await readdir(dir);
+    return names
+      .filter((name) => name.endsWith(suffix))
+      .map((name) => ({ name, fullPath: join(dir, name) }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Apply a single decrypted top-level file to disk via a handler. Skipped
+ * silently when `enabled()` returns false (used by claude marketplace).
+ */
+export interface FileArtifact {
+  kind: "file";
+  /** Exact basename inside the agent's vault root, e.g. "CLAUDE.md.age". */
+  vaultName: string;
+  /** Single line emitted in dry-run mode. */
+  dryRunLabel: string;
+  apply: (decrypted: string) => Promise<void>;
+  /** Optional gate (e.g. config.claudePlugins.syncMarketplace). */
+  enabled?: () => boolean;
+}
+
+/**
+ * Apply every .age (or .tar.age) entry in a subdirectory. Each entry's
+ * basename (sans suffix) becomes the handler's first argument.
+ */
+export interface DirArtifact {
+  kind: "dir";
+  subdir: string;
+  suffix: ".age" | ".tar.age";
+  /**
+   * Optional name predicate applied BEFORE suffix-stripping. Useful when an
+   * adapter cares only about a specific compound suffix (e.g. copilot's
+   * `*.instructions.md.age`) — return false for any vault file that should
+   * be silently skipped.
+   */
+  match?: (fileName: string) => boolean;
+  /** Dry-run prefix: `[dry-run] [<agent>] <dryRunVerb> <basename>` */
+  dryRunVerb: string;
+  apply: (name: string, decrypted: string) => Promise<void>;
+  /** Optional pre-decrypt filter on the stripped basename. */
+  filter?: (name: string) => null | { reason: string };
+}
+
+/**
+ * Opaque escape hatch for adapters whose layout doesn't fit the file/dir
+ * pattern (currently: Claude's nested plugins subtree).
+ */
+export interface EscapeHatch {
+  kind: "custom";
+  run: (agentVaultDir: string, key: string, dryRun: boolean) => Promise<void>;
+}
+
+export type ApplyDirective = FileArtifact | DirArtifact | EscapeHatch;
+
+export interface ApplyPlan {
+  agent: string;
+  directives: ApplyDirective[];
+  /**
+   * When true, top-level .age files in the agent vault root that don't match
+   * any `FileArtifact.vaultName` are logged as `Unrecognised vault file
+   * skipped`. Cursor opts in to surface drift between adapter versions; other
+   * adapters keep the silent default.
+   */
+  warnOnUnknownTopLevel?: boolean;
+}
+
+/**
+ * Walk the vault, decrypt each artifact in the order the plan lists them,
+ * and dispatch to the directive that owns the basename. Missing
+ * subdirectories are silently skipped — the snapshot side may not have
+ * produced them on this machine, and that's not an error.
+ */
+export async function runApplyPlan(
+  plan: ApplyPlan,
+  vaultDir: string,
+  key: string,
+  dryRun: boolean,
+): Promise<void> {
+  const agentVaultDir = join(vaultDir, plan.agent);
+
+  // Top-level .age files are scanned once, then matched against each
+  // FileArtifact in plan order. This preserves the existing behaviour where
+  // an unrecognised top-level file is silently skipped.
+  const topFiles = await readAgeFiles(agentVaultDir, ".age");
+  const fileByName = new Map(topFiles.map((f) => [f.name, f.fullPath]));
+  if (plan.warnOnUnknownTopLevel) {
+    const known = new Set(
+      plan.directives.filter((d): d is FileArtifact => d.kind === "file").map((d) => d.vaultName),
+    );
+    for (const { name } of topFiles) {
+      if (!known.has(name)) log.warn(`[${plan.agent}] Unrecognised vault file skipped: ${name}`);
+    }
+  }
+
+  for (const d of plan.directives) {
+    if (d.kind === "file") {
+      const fullPath = fileByName.get(d.vaultName);
+      if (!fullPath) continue;
+      if (d.enabled && !d.enabled()) continue;
+      if (dryRun) {
+        log.info(d.dryRunLabel);
+        continue;
+      }
+      const encrypted = await readFile(fullPath, "utf8");
+      const decrypted = await decryptString(encrypted, key);
+      await d.apply(decrypted);
+    } else if (d.kind === "dir") {
+      const files = await readAgeFiles(join(agentVaultDir, d.subdir), d.suffix);
+      for (const { name, fullPath } of files) {
+        if (d.match && !d.match(name)) continue;
+        const bareName = basename(name, d.suffix === ".tar.age" ? ".tar.age" : ".age");
+        if (d.filter) {
+          const skip = d.filter(bareName);
+          if (skip) {
+            log.warn(`[${plan.agent}] Skipping ${d.subdir}/${name}: ${skip.reason}`);
+            continue;
+          }
+        }
+        if (dryRun) {
+          log.info(`[dry-run] [${plan.agent}] ${d.dryRunVerb} ${bareName}`);
+          continue;
+        }
+        const encrypted = await readFile(fullPath, "utf8");
+        const decrypted = await decryptString(encrypted, key);
+        await d.apply(bareName, decrypted);
+      }
+    } else {
+      await d.run(agentVaultDir, key, dryRun);
+    }
+  }
+}
+
+/**
+ * Helper that builds a top-level `FileArtifact` with a default dry-run
+ * label of `[dry-run] [<agent>] would apply <vaultName-without-.age>`.
+ * Callers can override `dryRunLabel` when the existing string has been
+ * stable in logs and users rely on it.
+ */
+export function defineFileArtifact(d: Omit<FileArtifact, "kind">): FileArtifact {
+  return { kind: "file", ...d };
+}

--- a/src/agents/claude/index.ts
+++ b/src/agents/claude/index.ts
@@ -1,7 +1,6 @@
 import { mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { log } from "@clack/prompts";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
 import { denormalizeFromVault, denormalizeStringFromVault } from "../../core/path-portability";
@@ -396,23 +395,7 @@ export async function applyClaudeMarketplace(content: string): Promise<void> {
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
 
-import { basename } from "node:path";
-import { decryptString } from "../../core/encryptor";
-
-/** Read encrypted files from a vault subdirectory, ignoring missing directories. */
-async function readAgeFiles(dir: string): Promise<{ name: string; fullPath: string }[]> {
-  try {
-    const names = await readdir(dir);
-    return names
-      .filter((name) => name.endsWith(".age"))
-      .map((name) => ({
-        name,
-        fullPath: join(dir, name),
-      }));
-  } catch {
-    return [];
-  }
-}
+import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
 
 /** Decrypt and apply all Claude vault artifacts to the local machine. */
 export async function applyClaudeVault(
@@ -422,120 +405,79 @@ export async function applyClaudeVault(
   config: AgentSyncConfig,
 ): Promise<void> {
   const syncMarketplace = config.claudePlugins?.syncMarketplace ?? false;
-  const claudeDir = join(vaultDir, "claude");
-  const files = await readAgeFiles(claudeDir);
-
-  for (const { name, fullPath } of files) {
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-
-    if (name === "CLAUDE.md.age") {
-      if (dryRun) {
-        log.info("[dry-run] [claude] would apply CLAUDE.md");
-        continue;
-      }
-      await applyClaudeMd(decrypted);
-    } else if (name === "settings.hooks.json.age") {
-      if (dryRun) {
-        log.info("[dry-run] [claude] would apply claude/settings.hooks.json");
-        continue;
-      }
-      await applyClaudeHooks(decrypted);
-    } else if (name === "claude.json.age") {
-      if (dryRun) {
-        log.info("[dry-run] [claude] would apply ~/.claude.json mcpServers");
-        continue;
-      }
-      await applyClaudeMcp(decrypted);
-    } else if (name === "marketplace.json.age") {
-      // Symmetric to the snapshot side: only apply when the user has opted in.
-      // A vault that contains a marketplace.json.age is silently ignored on
-      // any machine where syncMarketplace is not set, so opting out is the
-      // safe default and never blocks pulls.
-      if (!syncMarketplace) {
-        continue;
-      }
-      if (dryRun) {
-        log.info("[dry-run] [claude] would apply ~/.claude/.claude-plugin/marketplace.json");
-        continue;
-      }
-      await applyClaudeMarketplace(decrypted);
-    }
-  }
-
-  // Commands sub-directory
-  const commandFiles = await readAgeFiles(join(claudeDir, "commands"));
-  for (const { name, fullPath } of commandFiles) {
-    if (!name.endsWith(".md.age")) continue;
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    const commandName = basename(name, ".age");
-    if (dryRun) {
-      log.info(`[dry-run] [claude] would write command: ${commandName}`);
-    } else {
-      await applyClaudeCommand(commandName, decrypted);
-    }
-  }
-
-  // Agents sub-directory
-  const agentFiles = await readAgeFiles(join(claudeDir, "agents"));
-  for (const { name, fullPath } of agentFiles) {
-    if (!name.endsWith(".md.age")) continue;
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    const agentName = basename(name, ".age");
-    if (dryRun) {
-      log.info(`[dry-run] [claude] would write agent: ${agentName}`);
-    } else {
-      await applyClaudeAgent(agentName, decrypted);
-    }
-  }
-
-  // Rules sub-directory — mirrors commands/agents handling.
-  const ruleFiles = await readAgeFiles(join(claudeDir, "rules"));
-  for (const { name, fullPath } of ruleFiles) {
-    if (!name.endsWith(".md.age")) continue;
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    const ruleName = basename(name, ".age");
-    if (dryRun) {
-      log.info(`[dry-run] [claude] would write rule: ${ruleName}`);
-    } else {
-      await applyClaudeRule(ruleName, decrypted);
-    }
-  }
-
-  // Skills sub-directory — stored as <name>.tar.age. Mirrors the
-  // Copilot apply path: each entry is decrypted, then the inner base64 tar
-  // is extracted into ~/.claude/skills/<name>/ via applyClaudeSkill.
-  const skillFiles = await readAgeFiles(join(claudeDir, "skills"));
-  for (const { name, fullPath } of skillFiles) {
-    if (!name.endsWith(".tar.age")) continue;
-    const skillName = basename(name, ".tar.age");
-    try {
-      validateSkillName(skillName);
-    } catch (err) {
-      if (err instanceof InvalidSkillNameError) {
-        log.warn(`[claude] Skipping vault skill with invalid name '${name}': ${err.reason}`);
-        continue;
-      }
-      throw err;
-    }
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    if (dryRun) {
-      log.info(`[dry-run] [claude] would extract skill: ${skillName}`);
-      continue;
-    }
-    await applyClaudeSkill(skillName, decrypted);
-  }
-
-  // Plugins sub-tree (issue #31). Vault layout:
-  //   claude/plugins/<plugin>/plugin.json.age
-  //   claude/plugins/<plugin>/commands/<file>.md.age
-  //   claude/plugins/<plugin>/agents/<file>.md.age
-  //   claude/plugins/<plugin>/hooks/<file>.json.age
-  //   claude/plugins/<plugin>/mcp.json.age
-  //   claude/plugins/<plugin>/skills/<skill>.tar.age
-  await applyClaudePluginsDir(join(claudeDir, "plugins"), key, dryRun);
+  const plan: ApplyPlan = {
+    agent: "claude",
+    directives: [
+      defineFileArtifact({
+        vaultName: "CLAUDE.md.age",
+        dryRunLabel: "[dry-run] [claude] would apply CLAUDE.md",
+        apply: applyClaudeMd,
+      }),
+      defineFileArtifact({
+        vaultName: "settings.hooks.json.age",
+        dryRunLabel: "[dry-run] [claude] would apply claude/settings.hooks.json",
+        apply: applyClaudeHooks,
+      }),
+      defineFileArtifact({
+        vaultName: "claude.json.age",
+        dryRunLabel: "[dry-run] [claude] would apply ~/.claude.json mcpServers",
+        apply: applyClaudeMcp,
+      }),
+      defineFileArtifact({
+        vaultName: "marketplace.json.age",
+        dryRunLabel: "[dry-run] [claude] would apply ~/.claude/.claude-plugin/marketplace.json",
+        apply: applyClaudeMarketplace,
+        // Symmetric to snapshot: opting out silently ignores a vault entry on
+        // machines that haven't enabled syncMarketplace.
+        enabled: () => syncMarketplace,
+      }),
+      {
+        kind: "dir",
+        subdir: "commands",
+        suffix: ".age",
+        dryRunVerb: "would write command:",
+        apply: applyClaudeCommand,
+      },
+      {
+        kind: "dir",
+        subdir: "agents",
+        suffix: ".age",
+        dryRunVerb: "would write agent:",
+        apply: applyClaudeAgent,
+      },
+      {
+        kind: "dir",
+        subdir: "rules",
+        suffix: ".age",
+        dryRunVerb: "would write rule:",
+        apply: applyClaudeRule,
+      },
+      {
+        kind: "dir",
+        subdir: "skills",
+        suffix: ".tar.age",
+        dryRunVerb: "would extract skill:",
+        apply: applyClaudeSkill,
+        filter: (name) => {
+          try {
+            validateSkillName(name);
+            return null;
+          } catch (err) {
+            if (err instanceof InvalidSkillNameError) {
+              return { reason: `invalid skill name — ${err.reason}` };
+            }
+            throw err;
+          }
+        },
+      },
+      {
+        kind: "custom",
+        // Plugins live in a nested per-plugin tree (commands/, agents/, hooks/,
+        // mcp.json, skills/) so they don't fit the file/dir directive shape.
+        run: (agentVaultDir, decKey, dry) =>
+          applyClaudePluginsDir(join(agentVaultDir, "plugins"), decKey, dry),
+      },
+    ],
+  };
+  await runApplyPlan(plan, vaultDir, key, dryRun);
 }

--- a/src/agents/codex/index.ts
+++ b/src/agents/codex/index.ts
@@ -1,7 +1,6 @@
 import { mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { log } from "@clack/prompts";
 import * as TOML from "@iarna/toml";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
@@ -204,23 +203,7 @@ export async function applyCodexSkill(skillName: string, base64Tar: string): Pro
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
 
-import { basename } from "node:path";
-import { decryptString } from "../../core/encryptor";
-
-/** Read encrypted files from a vault subdirectory, ignoring missing directories. */
-async function readAgeFiles(dir: string): Promise<{ name: string; fullPath: string }[]> {
-  try {
-    const names = await readdir(dir);
-    return names
-      .filter((name) => name.endsWith(".age"))
-      .map((name) => ({
-        name,
-        fullPath: join(dir, name),
-      }));
-  } catch {
-    return [];
-  }
-}
+import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
 
 /** Decrypt and apply all Codex vault artifacts to the local machine. */
 export async function applyCodexVault(
@@ -229,69 +212,50 @@ export async function applyCodexVault(
   dryRun: boolean,
   _config?: AgentSyncConfig,
 ): Promise<void> {
-  const codexDir = join(vaultDir, "codex");
-  const files = await readAgeFiles(codexDir);
-
-  for (const { name, fullPath } of files) {
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-
-    if (name === "AGENTS.md.age") {
-      if (dryRun) {
-        log.info("[dry-run] [codex] would apply AGENTS.md");
-        continue;
-      }
-      await applyCodexAgentsMd(decrypted);
-    } else if (name === "AGENTS.override.md.age") {
-      if (dryRun) {
-        log.info("[dry-run] [codex] would apply AGENTS.override.md");
-        continue;
-      }
-      await applyCodexAgentsOverrideMd(decrypted);
-    } else if (name === "config.toml.age") {
-      if (dryRun) {
-        log.info("[dry-run] [codex] would apply config.toml");
-        continue;
-      }
-      await applyCodexConfig(decrypted);
-    }
-  }
-
-  const ruleFiles = await readAgeFiles(join(codexDir, "rules"));
-  for (const { name, fullPath } of ruleFiles) {
-    if (!name.endsWith(".md.age")) continue;
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    const ruleName = basename(name, ".age");
-    if (dryRun) {
-      log.info(`[dry-run] [codex] would write rule: ${ruleName}`);
-    } else {
-      await applyCodexRule(ruleName, decrypted);
-    }
-  }
-
-  // Skills sub-directory — stored as <name>.tar.age. Mirrors the
-  // Claude/Copilot apply path: each entry is decrypted, then the inner base64
-  // tar is extracted into ~/.codex/skills/<name>/ via applyCodexSkill.
-  const skillFiles = await readAgeFiles(join(codexDir, "skills"));
-  for (const { name, fullPath } of skillFiles) {
-    if (!name.endsWith(".tar.age")) continue;
-    const skillName = basename(name, ".tar.age");
-    try {
-      validateSkillName(skillName);
-    } catch (err) {
-      if (err instanceof InvalidSkillNameError) {
-        log.warn(`[codex] Skipping vault skill with invalid name '${name}': ${err.reason}`);
-        continue;
-      }
-      throw err;
-    }
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    if (dryRun) {
-      log.info(`[dry-run] [codex] would extract skill: ${skillName}`);
-      continue;
-    }
-    await applyCodexSkill(skillName, decrypted);
-  }
+  const plan: ApplyPlan = {
+    agent: "codex",
+    directives: [
+      defineFileArtifact({
+        vaultName: "AGENTS.md.age",
+        dryRunLabel: "[dry-run] [codex] would apply AGENTS.md",
+        apply: applyCodexAgentsMd,
+      }),
+      defineFileArtifact({
+        vaultName: "AGENTS.override.md.age",
+        dryRunLabel: "[dry-run] [codex] would apply AGENTS.override.md",
+        apply: applyCodexAgentsOverrideMd,
+      }),
+      defineFileArtifact({
+        vaultName: "config.toml.age",
+        dryRunLabel: "[dry-run] [codex] would apply config.toml",
+        apply: applyCodexConfig,
+      }),
+      {
+        kind: "dir",
+        subdir: "rules",
+        suffix: ".age",
+        dryRunVerb: "would write rule:",
+        apply: applyCodexRule,
+      },
+      {
+        kind: "dir",
+        subdir: "skills",
+        suffix: ".tar.age",
+        dryRunVerb: "would extract skill:",
+        apply: applyCodexSkill,
+        filter: (name) => {
+          try {
+            validateSkillName(name);
+            return null;
+          } catch (err) {
+            if (err instanceof InvalidSkillNameError) {
+              return { reason: `invalid skill name — ${err.reason}` };
+            }
+            throw err;
+          }
+        },
+      },
+    ],
+  };
+  await runApplyPlan(plan, vaultDir, key, dryRun);
 }

--- a/src/agents/copilot/index.ts
+++ b/src/agents/copilot/index.ts
@@ -1,6 +1,5 @@
 import { mkdir, readdir } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
-import { log } from "@clack/prompts";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
 import { shouldNeverSync } from "../../core/sanitizer";
@@ -195,23 +194,7 @@ export async function applyCopilotAgent(fileName: string, content: string): Prom
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
 
-import { readdir as _readdir, readFile } from "node:fs/promises";
-import { decryptString } from "../../core/encryptor";
-
-/** Read encrypted files from a vault subdirectory, ignoring missing directories. */
-async function readAgeFiles(dir: string): Promise<{ name: string; fullPath: string }[]> {
-  try {
-    const names = await _readdir(dir);
-    return names
-      .filter((name) => name.endsWith(".age"))
-      .map((name) => ({
-        name,
-        fullPath: join(dir, name),
-      }));
-  } catch {
-    return [];
-  }
-}
+import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
 
 /** Decrypt and apply all Copilot vault artifacts to the local machine. */
 export async function applyCopilotVault(
@@ -220,90 +203,65 @@ export async function applyCopilotVault(
   dryRun: boolean,
   _config?: AgentSyncConfig,
 ): Promise<void> {
-  const copilotDir = join(vaultDir, "copilot");
-  const files = await readAgeFiles(copilotDir);
-
-  for (const { name, fullPath } of files) {
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-
-    if (name === "instructions.md.age") {
-      if (dryRun) {
-        log.info("[dry-run] [copilot] would apply instructions");
-        continue;
-      }
-      await applyCopilotInstructions(decrypted);
-    }
-  }
-
-  // instructions/ sub-directory
-  const instrFiles = await readAgeFiles(join(copilotDir, "instructions"));
-  for (const { name, fullPath } of instrFiles) {
-    if (!name.endsWith(".instructions.md.age")) continue;
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    const fileName = basename(name, ".age");
-    if (dryRun) {
-      log.info(`[dry-run] [copilot] would write instruction: ${fileName}`);
-      continue;
-    }
-    await applyCopilotInstructionFile(fileName, decrypted);
-  }
-
-  // prompts/ sub-directory
-  const promptFiles = await readAgeFiles(join(copilotDir, "prompts"));
-  for (const { name, fullPath } of promptFiles) {
-    if (!name.endsWith(".prompt.md.age")) continue;
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    const fileName = basename(name, ".age");
-    if (dryRun) {
-      log.info(`[dry-run] [copilot] would write prompt: ${fileName}`);
-      continue;
-    }
-    await applyCopilotPrompt(fileName, decrypted);
-  }
-
-  // skills/ sub-directory — stored as <name>.tar.age
-  const skillFiles = await readAgeFiles(join(copilotDir, "skills"));
-  for (const { name, fullPath } of skillFiles) {
-    if (!name.endsWith(".tar.age")) continue;
-    const skillName = basename(name, ".tar.age");
-    try {
-      validateSkillName(skillName);
-    } catch (err) {
-      if (err instanceof InvalidSkillNameError) {
-        log.warn(`[copilot] Skipping vault skill with invalid name '${name}': ${err.reason}`);
-        continue;
-      }
-      throw err;
-    }
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    if (dryRun) {
-      log.info(`[dry-run] [copilot] would extract skill: ${skillName}`);
-      continue;
-    }
-    await applyCopilotSkill(skillName, decrypted);
-  }
-
-  // agents/ sub-directory — stored as <name>.agent.md.age
-  const agentFiles = await readAgeFiles(join(copilotDir, "agents"));
-  for (const { name, fullPath } of agentFiles) {
-    if (!name.endsWith(".agent.md.age")) continue;
-    const fileName = basename(name, ".age");
-    try {
-      validateCopilotAgentFileName(fileName);
-    } catch {
-      log.warn(`[copilot] Skipping vault agent with invalid name '${name}'`);
-      continue;
-    }
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    if (dryRun) {
-      log.info(`[dry-run] [copilot] would write agent: ${fileName}`);
-      continue;
-    }
-    await applyCopilotAgent(fileName, decrypted);
-  }
+  const plan: ApplyPlan = {
+    agent: "copilot",
+    directives: [
+      defineFileArtifact({
+        vaultName: "instructions.md.age",
+        dryRunLabel: "[dry-run] [copilot] would apply instructions",
+        apply: applyCopilotInstructions,
+      }),
+      {
+        kind: "dir",
+        subdir: "instructions",
+        suffix: ".age",
+        match: (name) => name.endsWith(".instructions.md.age"),
+        dryRunVerb: "would write instruction:",
+        apply: applyCopilotInstructionFile,
+      },
+      {
+        kind: "dir",
+        subdir: "prompts",
+        suffix: ".age",
+        match: (name) => name.endsWith(".prompt.md.age"),
+        dryRunVerb: "would write prompt:",
+        apply: applyCopilotPrompt,
+      },
+      {
+        kind: "dir",
+        subdir: "skills",
+        suffix: ".tar.age",
+        dryRunVerb: "would extract skill:",
+        apply: applyCopilotSkill,
+        filter: (name) => {
+          try {
+            validateSkillName(name);
+            return null;
+          } catch (err) {
+            if (err instanceof InvalidSkillNameError) {
+              return { reason: `invalid skill name — ${err.reason}` };
+            }
+            throw err;
+          }
+        },
+      },
+      {
+        kind: "dir",
+        subdir: "agents",
+        suffix: ".age",
+        match: (name) => name.endsWith(".agent.md.age"),
+        dryRunVerb: "would write agent:",
+        apply: applyCopilotAgent,
+        filter: (name) => {
+          try {
+            validateCopilotAgentFileName(name);
+            return null;
+          } catch {
+            return { reason: "invalid copilot agent filename" };
+          }
+        },
+      },
+    ],
+  };
+  await runApplyPlan(plan, vaultDir, key, dryRun);
 }

--- a/src/agents/cursor/index.ts
+++ b/src/agents/cursor/index.ts
@@ -1,7 +1,6 @@
 import { mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
-import { log } from "@clack/prompts";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
 import { denormalizeStringFromVault, normalizeStringForVault } from "../../core/path-portability";
@@ -167,22 +166,7 @@ export async function applyCursorSkill(skillName: string, base64Tar: string): Pr
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
 
-import { decryptString } from "../../core/encryptor";
-
-/** Read encrypted files from a vault subdirectory, ignoring missing directories. */
-async function readAgeFiles(dir: string): Promise<{ name: string; fullPath: string }[]> {
-  try {
-    const names = await readdir(dir);
-    return names
-      .filter((name) => name.endsWith(".age"))
-      .map((name) => ({
-        name,
-        fullPath: join(dir, name),
-      }));
-  } catch {
-    return [];
-  }
-}
+import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
 
 /** Decrypt and apply all Cursor vault artifacts to the local machine. */
 export async function applyCursorVault(
@@ -191,68 +175,46 @@ export async function applyCursorVault(
   dryRun: boolean,
   _config?: AgentSyncConfig,
 ): Promise<void> {
-  const cursorDir = join(vaultDir, "cursor");
-  const files = await readAgeFiles(cursorDir);
-
-  for (const { name, fullPath } of files) {
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-
-    if (name === "user-rules.md.age") {
-      if (dryRun) {
-        log.info("[dry-run] [cursor] would apply user-rules");
-        continue;
-      }
-      await applyCursorRules(decrypted);
-    } else if (name === "mcp.json.age") {
-      if (dryRun) {
-        log.info("[dry-run] [cursor] would apply mcp.json");
-        continue;
-      }
-      await applyCursorMcp(decrypted);
-    } else {
-      log.warn(`[cursor] Unrecognised vault file skipped: ${name}`);
-    }
-  }
-
-  // Commands sub-directory
-  const commandFiles = await readAgeFiles(join(cursorDir, "commands"));
-  for (const { name, fullPath } of commandFiles) {
-    if (!name.endsWith(".md.age")) continue;
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    const commandName = basename(name, ".age");
-    if (dryRun) {
-      log.info(`[dry-run] [cursor] would write command: ${commandName}`);
-    } else {
-      await applyCursorCommand(commandName, decrypted);
-    }
-  }
-
-  // Skills sub-directory — stored as <name>.tar.age. Mirrors the
-  // Claude/Codex/Copilot apply path: each entry is decrypted, then the inner
-  // base64 tar is extracted into ~/.cursor/skills/<name>/ via applyCursorSkill.
-  // The top-level unrecognised-file warning above is inspecting only top-level
-  // cursor/*.age files, so cursor/skills/*.tar.age never triggers it.
-  const skillFiles = await readAgeFiles(join(cursorDir, "skills"));
-  for (const { name, fullPath } of skillFiles) {
-    if (!name.endsWith(".tar.age")) continue;
-    const skillName = basename(name, ".tar.age");
-    try {
-      validateSkillName(skillName);
-    } catch (err) {
-      if (err instanceof InvalidSkillNameError) {
-        log.warn(`[cursor] Skipping vault skill with invalid name '${name}': ${err.reason}`);
-        continue;
-      }
-      throw err;
-    }
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-    if (dryRun) {
-      log.info(`[dry-run] [cursor] would extract skill: ${skillName}`);
-      continue;
-    }
-    await applyCursorSkill(skillName, decrypted);
-  }
+  const plan: ApplyPlan = {
+    agent: "cursor",
+    warnOnUnknownTopLevel: true,
+    directives: [
+      defineFileArtifact({
+        vaultName: "user-rules.md.age",
+        dryRunLabel: "[dry-run] [cursor] would apply user-rules",
+        apply: applyCursorRules,
+      }),
+      defineFileArtifact({
+        vaultName: "mcp.json.age",
+        dryRunLabel: "[dry-run] [cursor] would apply mcp.json",
+        apply: applyCursorMcp,
+      }),
+      {
+        kind: "dir",
+        subdir: "commands",
+        suffix: ".age",
+        dryRunVerb: "would write command:",
+        apply: applyCursorCommand,
+      },
+      {
+        kind: "dir",
+        subdir: "skills",
+        suffix: ".tar.age",
+        dryRunVerb: "would extract skill:",
+        apply: applyCursorSkill,
+        filter: (name) => {
+          try {
+            validateSkillName(name);
+            return null;
+          } catch (err) {
+            if (err instanceof InvalidSkillNameError) {
+              return { reason: `invalid skill name — ${err.reason}` };
+            }
+            throw err;
+          }
+        },
+      },
+    ],
+  };
+  await runApplyPlan(plan, vaultDir, key, dryRun);
 }

--- a/src/agents/vscode/index.ts
+++ b/src/agents/vscode/index.ts
@@ -1,12 +1,9 @@
-import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
-import { log } from "@clack/prompts";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
-import { decryptString } from "../../core/encryptor";
 import { denormalizeStringFromVault } from "../../core/path-portability";
 import { sanitizeAndNormalizeJson } from "../../core/sanitizer";
+import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
 import {
   atomicWrite,
   collect,
@@ -44,22 +41,6 @@ export async function applyVsCodeMcp(mcpJsonContent: string): Promise<void> {
 
 // ─── Apply (pull side) ────────────────────────────────────────────────────────
 
-/** Read encrypted files from a vault subdirectory, ignoring missing directories. */
-async function readAgeFiles(dir: string): Promise<{ name: string; fullPath: string }[]> {
-  try {
-    const { readdir } = await import("node:fs/promises");
-    const names = await readdir(dir);
-    return names
-      .filter((name) => name.endsWith(".age"))
-      .map((name) => ({
-        name,
-        fullPath: join(dir, name),
-      }));
-  } catch {
-    return [];
-  }
-}
-
 /** Decrypt and apply all VS Code vault artifacts to the local machine. */
 export async function applyVsCodeVault(
   vaultDir: string,
@@ -67,19 +48,15 @@ export async function applyVsCodeVault(
   dryRun: boolean,
   _config?: AgentSyncConfig,
 ): Promise<void> {
-  const vsCodeDir = join(vaultDir, "vscode");
-  const files = await readAgeFiles(vsCodeDir);
-
-  for (const { name, fullPath } of files) {
-    const encrypted = await readFile(fullPath, "utf8");
-    const decrypted = await decryptString(encrypted, key);
-
-    if (name === "mcp.json.age") {
-      if (dryRun) {
-        log.info("[dry-run] [vscode] would apply mcp.json");
-        continue;
-      }
-      await applyVsCodeMcp(decrypted);
-    }
-  }
+  const plan: ApplyPlan = {
+    agent: "vscode",
+    directives: [
+      defineFileArtifact({
+        vaultName: "mcp.json.age",
+        dryRunLabel: "[dry-run] [vscode] would apply mcp.json",
+        apply: applyVsCodeMcp,
+      }),
+    ],
+  };
+  await runApplyPlan(plan, vaultDir, key, dryRun);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { defineCommand, runMain } from "citty";
 import { daemonCommand } from "./commands/daemon";
+import { destroyCommand } from "./commands/destroy";
 import { doctorCommand } from "./commands/doctor";
 import { initCommand } from "./commands/init";
 import { keyCommand } from "./commands/key";
@@ -9,6 +10,7 @@ import { pullCommand } from "./commands/pull";
 import { pushCommand } from "./commands/push";
 import { skillCommand } from "./commands/skill";
 import { statusCommand } from "./commands/status";
+import { tuiCommand } from "./commands/tui";
 
 /** Root CLI command that wires every user-facing subcommand into a single entry point. */
 const main = defineCommand({
@@ -27,7 +29,28 @@ const main = defineCommand({
     key: keyCommand,
     migrate: migrateCommand,
     skill: skillCommand,
+    destroy: destroyCommand,
+    tui: tuiCommand,
   },
 });
 
-await runMain(main);
+const userArgs = process.argv.slice(2);
+
+if (userArgs.length === 0) {
+  // Bare `agentsync` opens the TUI on a real terminal. In a pipe, redirect to
+  // a non-interactive context, or in CI, we deliberately fall back to the
+  // existing `status` text output so scripts that depend on the previous
+  // no-args behaviour are not broken.
+  if (process.stdout.isTTY) {
+    const { runTui } = await import("./commands/tui");
+    await runTui();
+  } else {
+    await statusCommand.run?.({
+      args: { verbose: false },
+      rawArgs: [],
+      cmd: {} as never,
+    } as never);
+  }
+} else {
+  await runMain(main);
+}

--- a/src/commands/__tests__/destroy.test.ts
+++ b/src/commands/__tests__/destroy.test.ts
@@ -1,0 +1,536 @@
+/**
+ * src/commands/__tests__/destroy.test.ts
+ *
+ * Covers every DestroyResult branch and — most importantly — asserts the
+ * hard safety guarantee that destroy never touches local agent files. The
+ * three "agent files untouched" tests at the bottom are the regression net
+ * for that invariant. If a future change pulls AgentPaths into destroy.ts
+ * and starts walking ~/.claude/ for any reason, those tests fail loudly.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import { Writable } from "node:stream";
+import {
+  createBareRepo,
+  createMachineFixture,
+  createTmpDir,
+  runGit,
+  seedVaultRepo,
+  type TestMachineFixture,
+} from "../../test-helpers/fixtures";
+import { __TEST_ONLY, destroyCommand, performDestroy } from "../destroy";
+
+/** Build an `ask` callback that returns the seeded answers in order. */
+function scriptedAsk(answers: string[]): (prompt: string) => Promise<string> {
+  let i = 0;
+  return async () => {
+    if (i >= answers.length) throw new Error(`scriptedAsk exhausted (no answer #${i + 1})`);
+    return answers[i++];
+  };
+}
+
+/** Discard-style stdout that collects writes for assertion. */
+function fakeStdout(): NodeJS.WritableStream & { output: string } {
+  const chunks: string[] = [];
+  const w = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  }) as unknown as NodeJS.WritableStream & { output: string };
+  Object.defineProperty(w, "output", { get: () => chunks.join("") });
+  return w;
+}
+
+const RUNTIME_ENV_KEYS = ["AGENTSYNC_VAULT_DIR", "AGENTSYNC_KEY_PATH", "AGENTSYNC_MACHINE"];
+
+async function withMachineEnv<T>(machine: TestMachineFixture, run: () => Promise<T>): Promise<T> {
+  const saved = Object.fromEntries(RUNTIME_ENV_KEYS.map((key) => [key, process.env[key]]));
+  process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+  process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+  process.env.AGENTSYNC_MACHINE = machine.machineName;
+  try {
+    return await run();
+  } finally {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(require("node:fs").readFileSync(path)).digest("hex");
+}
+
+interface AgentFingerprint {
+  path: string;
+  sha: string;
+  mtimeMs: number;
+}
+
+/**
+ * Seed minimal placeholder files for each agent at paths derived from
+ * AGENTSYNC_AGENT_ROOT (a test-only env var consumed nowhere by the real
+ * code — these files exist purely to confirm `destroy` does not walk
+ * unrelated directories). We use a per-test agent root rather than
+ * touching the real ~/.claude etc. so the test is hermetic.
+ */
+function seedAgentFiles(agentRoot: string): AgentFingerprint[] {
+  const fixtures = [
+    [".claude", "CLAUDE.md", "# project memory\nstays untouched\n"],
+    [".cursor/rules", "global.mdc", "# cursor global rule\nstays untouched\n"],
+    [".codex", "AGENTS.md", "# codex agents\nstays untouched\n"],
+    [".copilot", "copilot-instructions.md", "# copilot\nstays untouched\n"],
+  ] as const;
+
+  const prints: AgentFingerprint[] = [];
+  for (const [dir, file, content] of fixtures) {
+    const full = join(agentRoot, dir);
+    mkdirSync(full, { recursive: true });
+    const path = join(full, file);
+    writeFileSync(path, content, "utf8");
+    prints.push({ path, sha: sha256File(path), mtimeMs: statSync(path).mtimeMs });
+  }
+  return prints;
+}
+
+function assertAgentFilesUntouched(prints: AgentFingerprint[]): void {
+  for (const p of prints) {
+    const after = statSync(p.path);
+    expect(after.mtimeMs).toBe(p.mtimeMs);
+    expect(sha256File(p.path)).toBe(p.sha);
+  }
+}
+
+describe("performDestroy", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  test("--scope=local with --yes removes vault dir and keeps key.txt", async () => {
+    const root = join(tmpDir, "local-yes");
+    mkdirSync(root, { recursive: true });
+    const bareRepo = await createBareRepo(root);
+    const machine = await createMachineFixture(root, "alpha");
+    seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+    const result = await withMachineEnv(machine, () =>
+      performDestroy({ scope: "local", yes: true }),
+    );
+
+    expect(result.status).toBe("removed-local");
+    expect(await stat(machine.vaultDir).catch(() => null)).toBeNull();
+    expect((await stat(machine.keyPath)).isFile()).toBe(true);
+  });
+
+  test("--scope=remote with --yes commits and pushes the wipe", async () => {
+    const root = join(tmpDir, "remote-yes");
+    mkdirSync(root, { recursive: true });
+    const bareRepo = await createBareRepo(root);
+    const machine = await createMachineFixture(root, "alpha");
+    seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+    // seedVaultRepo already commits agentsync.toml and .gitignore, which is
+    // enough content for the wipe step to have something to remove.
+    const headBefore = runGit(["rev-parse", "HEAD"], bareRepo);
+
+    const result = await withMachineEnv(machine, () =>
+      performDestroy({ scope: "remote", yes: true }),
+    );
+
+    expect(result.status).toBe("removed-remote");
+    const headAfter = runGit(["rev-parse", "HEAD"], bareRepo);
+    expect(headAfter).not.toBe(headBefore);
+
+    // Sibling clone confirms the wipe propagated.
+    const sibling = join(root, "sibling-clone");
+    runGit(["clone", "--branch", "main", bareRepo, sibling]);
+    expect(await stat(join(sibling, "agentsync.toml")).catch(() => null)).toBeNull();
+    expect((await stat(join(sibling, ".git"))).isDirectory()).toBe(true);
+  });
+
+  test("--scope=all with --yes wipes remote and removes local", async () => {
+    const root = join(tmpDir, "all-yes");
+    mkdirSync(root, { recursive: true });
+    const bareRepo = await createBareRepo(root);
+    const machine = await createMachineFixture(root, "alpha");
+    seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+    const headBefore = runGit(["rev-parse", "HEAD"], bareRepo);
+
+    const result = await withMachineEnv(machine, () => performDestroy({ scope: "all", yes: true }));
+
+    expect(result.status).toBe("removed-all");
+    expect(await stat(machine.vaultDir).catch(() => null)).toBeNull();
+    expect(runGit(["rev-parse", "HEAD"], bareRepo)).not.toBe(headBefore);
+  });
+
+  test("returns not-found when vault dir does not exist", async () => {
+    const machine: TestMachineFixture = {
+      machineName: "ghost",
+      vaultDir: join(tmpDir, "ghost-vault"),
+      keyPath: join(tmpDir, "ghost-key.txt"),
+      identity: "AGE-SECRET-KEY-1NEVERUSED",
+      recipient: "age1never",
+    };
+
+    const result = await withMachineEnv(machine, () =>
+      performDestroy({ scope: "local", yes: true }),
+    );
+
+    expect(result.status).toBe("not-found");
+  });
+
+  test("returns not-an-agentsync-vault when dir exists but lacks agentsync.toml", async () => {
+    const machine = await createMachineFixture(tmpDir, "stray");
+    // vaultDir exists from createMachineFixture but never seeded with toml.
+
+    const result = await withMachineEnv(machine, () =>
+      performDestroy({ scope: "local", yes: true }),
+    );
+
+    expect(result.status).toBe("not-an-agentsync-vault");
+    expect((await stat(machine.vaultDir)).isDirectory()).toBe(true);
+  });
+
+  test("--force bypasses the agentsync.toml check", async () => {
+    const machine = await createMachineFixture(tmpDir, "force-test");
+    writeFileSync(join(machine.vaultDir, "stray.txt"), "x", "utf8");
+
+    const result = await withMachineEnv(machine, () =>
+      performDestroy({ scope: "local", yes: true, force: true }),
+    );
+
+    expect(result.status).toBe("removed-local");
+    expect(await stat(machine.vaultDir).catch(() => null)).toBeNull();
+  });
+
+  test("non-TTY without --yes returns non-tty-without-yes", async () => {
+    const root = join(tmpDir, "non-tty");
+    mkdirSync(root, { recursive: true });
+    const bareRepo = await createBareRepo(root);
+    const machine = await createMachineFixture(root, "alpha");
+    seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+    // process.stdin in this test runner is not a TTY.
+    const result = await withMachineEnv(machine, () =>
+      performDestroy({ scope: "local", yes: false }),
+    );
+
+    expect(result.status).toBe("non-tty-without-yes");
+    // Vault dir must still exist.
+    expect((await stat(machine.vaultDir)).isDirectory()).toBe(true);
+  });
+
+  test("second remote destroy after first wipe surfaces not-an-agentsync-vault", async () => {
+    const root = join(tmpDir, "empty-remote");
+    mkdirSync(root, { recursive: true });
+    const bareRepo = await createBareRepo(root);
+    const machine = await createMachineFixture(root, "alpha");
+    seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+    // First destroy clears the remote and removes agentsync.toml from the
+    // working tree (the commit removes everything tracked).
+    const first = await withMachineEnv(machine, () =>
+      performDestroy({ scope: "remote", yes: true }),
+    );
+    expect(first.status).toBe("removed-remote");
+
+    // A follow-up destroy now sees a vault dir without agentsync.toml. The
+    // safety check correctly refuses without --force — this is the documented
+    // idempotency contract: a clean remote yields a clear "nothing to do here"
+    // signal rather than performing another empty commit.
+    const second = await withMachineEnv(machine, () =>
+      performDestroy({ scope: "remote", yes: true }),
+    );
+    expect(second.status).toBe("not-an-agentsync-vault");
+  });
+
+  describe("confirmation gates", () => {
+    test("gate 1 'n' aborts at gate 1 without touching the vault", async () => {
+      const root = join(tmpDir, "gate1-n");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const ask = scriptedAsk(["n"]);
+      const stdout = fakeStdout();
+      const result = await withMachineEnv(machine, () =>
+        performDestroy({ scope: "local", ask, stdout, isInteractive: true }),
+      );
+
+      expect(result.status).toBe("aborted-by-user");
+      if (result.status === "aborted-by-user") expect(result.gate).toBe(1);
+      expect((await stat(machine.vaultDir)).isDirectory()).toBe(true);
+      // Preview text mentions the agent-file guarantee verbatim.
+      expect(stdout.output).toContain("YOUR LOCAL AGENT FILES");
+    });
+
+    test("gate 2 wrong phrase aborts at gate 2", async () => {
+      const root = join(tmpDir, "gate2-mismatch");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const ask = scriptedAsk(["y", "destroy"]); // lowercase != "DESTROY"
+      const stdout = fakeStdout();
+      const result = await withMachineEnv(machine, () =>
+        performDestroy({ scope: "local", ask, stdout, isInteractive: true }),
+      );
+
+      expect(result.status).toBe("aborted-by-user");
+      if (result.status === "aborted-by-user") expect(result.gate).toBe(2);
+      expect((await stat(machine.vaultDir)).isDirectory()).toBe(true);
+    });
+
+    test("gate 3 'n' aborts at gate 3", async () => {
+      const root = join(tmpDir, "gate3-n");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const ask = scriptedAsk(["y", "DESTROY", "n"]);
+      const stdout = fakeStdout();
+      const result = await withMachineEnv(machine, () =>
+        performDestroy({ scope: "local", ask, stdout, isInteractive: true }),
+      );
+
+      expect(result.status).toBe("aborted-by-user");
+      if (result.status === "aborted-by-user") expect(result.gate).toBe(3);
+      expect((await stat(machine.vaultDir)).isDirectory()).toBe(true);
+    });
+
+    test("all three gates pass → removed-local", async () => {
+      const root = join(tmpDir, "all-gates-pass");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const ask = scriptedAsk(["y", "DESTROY", "y"]);
+      const stdout = fakeStdout();
+      const result = await withMachineEnv(machine, () =>
+        performDestroy({ scope: "local", ask, stdout, isInteractive: true }),
+      );
+
+      expect(result.status).toBe("removed-local");
+      expect(await stat(machine.vaultDir).catch(() => null)).toBeNull();
+    });
+
+    test("remote-scope gate 1 'n' aborts and renders the remote preview", async () => {
+      const root = join(tmpDir, "remote-gate1");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const ask = scriptedAsk(["n"]);
+      const stdout = fakeStdout();
+      const result = await withMachineEnv(machine, () =>
+        performDestroy({ scope: "remote", ask, stdout, isInteractive: true }),
+      );
+
+      expect(result.status).toBe("aborted-by-user");
+      // Remote preview text must mention the commit-not-force-push mechanic.
+      expect(stdout.output).toContain("not force-push");
+      expect(stdout.output).toContain("registered recipient");
+      // Sibling clone confirms remote was not touched.
+      const headBefore = runGit(["rev-parse", "HEAD"], bareRepo);
+      expect(headBefore.length).toBeGreaterThan(0);
+    });
+
+    test("all-scope gate 1 renders both previews", async () => {
+      const root = join(tmpDir, "all-gate1");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const ask = scriptedAsk(["n"]);
+      const stdout = fakeStdout();
+      await withMachineEnv(machine, () =>
+        performDestroy({ scope: "all", ask, stdout, isInteractive: true }),
+      );
+      // Both previews share the agent-files guarantee header.
+      expect(stdout.output).toContain("local vault teardown");
+      expect(stdout.output).toContain("remote vault teardown");
+    });
+
+    test("remote-scope phrase includes branch and remote fragment", () => {
+      const cfg = {
+        version: "1",
+        recipients: { a: "age1xxx" },
+        agents: {
+          claude: true,
+          cursor: true,
+          codex: true,
+          copilot: true,
+          vscode: false,
+        },
+        remote: { url: "git@github.com:chrisleekr/agentsync-vault.git", branch: "main" },
+        sync: { debounceMs: 300, autoPush: true, autoPull: true, pullIntervalMs: 300_000 },
+      } as unknown as Parameters<typeof __TEST_ONLY.expectedPhrase>[1];
+
+      expect(__TEST_ONLY.expectedPhrase("remote", cfg)).toBe(
+        "DESTROY main@chrisleekr/agentsync-vault",
+      );
+      expect(__TEST_ONLY.expectedPhrase("all", cfg)).toBe(
+        "DESTROY main@chrisleekr/agentsync-vault",
+      );
+      expect(__TEST_ONLY.expectedPhrase("local", cfg)).toBe("DESTROY");
+    });
+
+    test("parseRemoteFragment handles https, ssh, and short URLs", () => {
+      expect(__TEST_ONLY.parseRemoteFragment("https://github.com/me/vault.git")).toBe("me/vault");
+      expect(__TEST_ONLY.parseRemoteFragment("git@github.com:me/vault.git")).toBe("me/vault");
+      expect(__TEST_ONLY.parseRemoteFragment("vault")).toBe("vault");
+    });
+  });
+
+  describe("citty wrapper exit codes", () => {
+    test("invalid --scope produces exit 1", async () => {
+      const before = process.exitCode;
+      process.exitCode = 0;
+      await destroyCommand.run?.({
+        args: { scope: "garbage", force: false, yes: true },
+        rawArgs: [],
+        cmd: {} as never,
+      } as never);
+      expect(process.exitCode).toBe(1);
+      process.exitCode = before;
+    });
+
+    test("removed-local result keeps exit 0", async () => {
+      const root = join(tmpDir, "citty-removed-local");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const before = process.exitCode;
+      process.exitCode = 0;
+      await withMachineEnv(machine, () =>
+        destroyCommand.run?.({
+          args: { scope: "local", force: false, yes: true },
+          rawArgs: [],
+          cmd: {} as never,
+        } as never),
+      );
+      expect(process.exitCode).toBe(0);
+      process.exitCode = before;
+    });
+
+    test("not-an-agentsync-vault produces exit 1", async () => {
+      const machine = await createMachineFixture(tmpDir, "stray-citty");
+      const before = process.exitCode;
+      process.exitCode = 0;
+      await withMachineEnv(machine, () =>
+        destroyCommand.run?.({
+          args: { scope: "local", force: false, yes: true },
+          rawArgs: [],
+          cmd: {} as never,
+        } as never),
+      );
+      expect(process.exitCode).toBe(1);
+      process.exitCode = before;
+    });
+
+    test("not-found result keeps exit 0", async () => {
+      const home = join(tmpDir, "ghost-home");
+      const saved = {
+        AGENTSYNC_VAULT_DIR: process.env.AGENTSYNC_VAULT_DIR,
+        AGENTSYNC_KEY_PATH: process.env.AGENTSYNC_KEY_PATH,
+      };
+      process.env.AGENTSYNC_VAULT_DIR = join(home, "vault");
+      process.env.AGENTSYNC_KEY_PATH = join(home, "key.txt");
+      const before = process.exitCode;
+      process.exitCode = 0;
+      await destroyCommand.run?.({
+        args: { scope: "local", force: false, yes: true },
+        rawArgs: [],
+        cmd: {} as never,
+      } as never);
+      expect(process.exitCode).toBe(0);
+      process.exitCode = before;
+      if (saved.AGENTSYNC_VAULT_DIR === undefined) delete process.env.AGENTSYNC_VAULT_DIR;
+      else process.env.AGENTSYNC_VAULT_DIR = saved.AGENTSYNC_VAULT_DIR;
+      if (saved.AGENTSYNC_KEY_PATH === undefined) delete process.env.AGENTSYNC_KEY_PATH;
+      else process.env.AGENTSYNC_KEY_PATH = saved.AGENTSYNC_KEY_PATH;
+    });
+  });
+
+  describe("agent-file safety guarantee", () => {
+    test("local scope leaves seeded agent files byte-for-byte identical", async () => {
+      const root = join(tmpDir, "agent-untouched-local");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const agentRoot = join(root, "fake-home");
+      const prints = seedAgentFiles(agentRoot);
+
+      const result = await withMachineEnv(machine, () =>
+        performDestroy({ scope: "local", yes: true }),
+      );
+
+      expect(result.status).toBe("removed-local");
+      assertAgentFilesUntouched(prints);
+    });
+
+    test("remote scope leaves seeded agent files byte-for-byte identical", async () => {
+      const root = join(tmpDir, "agent-untouched-remote");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const agentRoot = join(root, "fake-home");
+      const prints = seedAgentFiles(agentRoot);
+
+      const result = await withMachineEnv(machine, () =>
+        performDestroy({ scope: "remote", yes: true }),
+      );
+
+      expect(result.status).toBe("removed-remote");
+      assertAgentFilesUntouched(prints);
+    });
+
+    test("all scope leaves seeded agent files byte-for-byte identical", async () => {
+      const root = join(tmpDir, "agent-untouched-all");
+      mkdirSync(root, { recursive: true });
+      const bareRepo = await createBareRepo(root);
+      const machine = await createMachineFixture(root, "alpha");
+      seedVaultRepo({ machine, bareRepoPath: bareRepo });
+
+      const agentRoot = join(root, "fake-home");
+      const prints = seedAgentFiles(agentRoot);
+
+      const result = await withMachineEnv(machine, () =>
+        performDestroy({ scope: "all", yes: true }),
+      );
+
+      expect(result.status).toBe("removed-all");
+      assertAgentFilesUntouched(prints);
+    });
+  });
+});

--- a/src/commands/__tests__/destroy.test.ts
+++ b/src/commands/__tests__/destroy.test.ts
@@ -10,8 +10,24 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { stat } from "node:fs/promises";
+import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+
+/**
+ * Async-shaped stat-via-fs (NOT fs/promises) so this test's fs probes do not
+ * resolve through any node:fs/promises mock that other test files may have
+ * registered (e.g. installer-linux.test.ts). Existing call sites use
+ * `await stat(...).catch(() => null)` — preserve that shape by returning a
+ * promise; throw on ENOENT so the .catch() branch handles missing paths.
+ */
+async function stat(path: string): Promise<{ isDirectory: () => boolean; isFile: () => boolean }> {
+  if (!existsSync(path)) {
+    const err = new Error(`ENOENT: ${path}`) as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  }
+  return statSync(path);
+}
+
 import { join } from "node:path";
 import { Writable } from "node:stream";
 import {

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -1,4 +1,4 @@
-import { readdir, rm, stat } from "node:fs/promises";
+import { lstat, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { log } from "@clack/prompts";
@@ -128,7 +128,7 @@ export async function performDestroy(options: DestroyOptions): Promise<DestroyRe
   // "not-found" so destroy is a no-op when the user has never run init.
   let vaultExists = false;
   try {
-    const info = await stat(runtime.vaultDir);
+    const info = await lstat(runtime.vaultDir);
     vaultExists = info.isDirectory();
   } catch (err) {
     if (!isFileNotFoundError(err)) {
@@ -412,8 +412,17 @@ async function unlinkAllTrackedContent(vaultDir: string): Promise<void> {
     for (const name of entries) {
       if (name === ".git") continue;
       const full = join(dir, name);
-      const info = await stat(full).catch(() => null);
+      // lstat (not stat) so a symlink in the vault tree is identified as a
+      // symlink and unlinked in place — never followed. Following a symlink
+      // would let a malicious vault entry escape the subtree and delete
+      // files anywhere on disk, breaking the agent-files-never-touched
+      // invariant that the entire destroy command exists to uphold.
+      const info = await lstat(full).catch(() => null);
       if (!info) continue;
+      if (info.isSymbolicLink()) {
+        await rm(full, { force: true });
+        continue;
+      }
       if (info.isDirectory()) {
         await walk(full);
         // Best-effort remove the now-empty directory so `git status` sees a

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -1,0 +1,543 @@
+import { readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { log } from "@clack/prompts";
+import { defineCommand } from "citty";
+import { loadConfig, resolveConfigPath } from "../config/loader";
+import type { AgentSyncConfig } from "../config/schema";
+import { GitClient, GitReconciliationError } from "../core/git";
+import { isFileNotFoundError, resolveRuntimeContext } from "./shared";
+
+// Warning-text constants live at module top so docs/tests reference the same
+// strings the command prints. A divergence between any of them is a test or
+// docs bug — never a runtime drift.
+
+const LOCAL_PREVIEW_TEMPLATE = (vaultDir: string, remote: string) =>
+  `
+⚠  agentsync destroy — local vault teardown
+
+This will permanently REMOVE:
+  ${vaultDir}    encrypted artefacts, agentsync.toml,
+                                            .gitignore, the local git clone
+
+This will NOT touch:
+  ~/.claude/, ~/.cursor/, ~/.codex/         YOUR LOCAL AGENT FILES are completely
+  ~/.copilot/, VS Code user dir             off-limits to this command — every
+                                            file in these directories stays exactly
+                                            as it is on disk.
+  <agentsync home>/key.txt                  Your age private key.
+  agentsync daemon installation             The daemon process and its service
+                                            descriptor. Next sync after destroy
+                                            will fail — run \`agentsync daemon
+                                            stop\` if you want it quiet.
+  ${remote}    The remote repository.
+
+After destroy you can re-init from the same remote with:
+  agentsync init --remote <url> --branch <branch>
+`.trimEnd();
+
+const REMOTE_PREVIEW_TEMPLATE = (
+  remote: string,
+  branch: string,
+  vaultDir: string,
+  recipientCount: number,
+) =>
+  `
+⚠  agentsync destroy — remote vault teardown (via commit, not force-push)
+
+This will:
+  - Pull and reconcile against the remote first
+  - git rm -rf every tracked file in the vault working tree
+  - Commit  "destroy: clear vault content"
+  - Push to: ${remote} (branch: ${branch})
+
+This will NOT touch:
+  ~/.claude/, ~/.cursor/, ~/.codex/         YOUR LOCAL AGENT FILES are completely
+  ~/.copilot/, VS Code user dir             off-limits to this command — every
+                                            file in these directories stays exactly
+                                            as it is on disk.
+  ${vaultDir}    The LOCAL vault clone — pass
+                                            --scope=all if you also want it gone.
+  <agentsync home>/key.txt                  Your age private key.
+  ${remote}    The repository itself (only its
+                                            tracked content, via a normal commit).
+                                            .git history is preserved.
+
+Effects on other machines:
+  - Next \`agentsync pull\` will see an empty vault and lose their
+    agentsync.toml config. They will need to re-init.
+  - History is preserved. Any machine that has not yet pulled can
+    \`git revert <destroy-commit>\` to recover the data.
+  - This vault has ${recipientCount} registered recipient(s); ALL of them are affected.
+`.trimEnd();
+
+const DESTROY_COMMIT_MESSAGE = "destroy: clear vault content";
+
+export type DestroyScope = "local" | "remote" | "all";
+
+export type DestroyResult =
+  | { status: "removed-local"; path: string }
+  | { status: "removed-remote"; commitSha: string | null; branch: string; remote: string }
+  | {
+      status: "removed-all";
+      localPath: string;
+      commitSha: string | null;
+      branch: string;
+      remote: string;
+    }
+  | { status: "not-found"; path: string }
+  | { status: "not-an-agentsync-vault"; path: string }
+  | { status: "remote-diverged"; error: string }
+  | { status: "remote-push-failed"; error: string; commitSha: string | null }
+  | { status: "aborted-by-user"; gate: 1 | 2 | 3 }
+  | { status: "non-tty-without-yes" }
+  | { status: "failed"; error: string };
+
+export interface DestroyOptions {
+  scope: DestroyScope;
+  /** Bypass the agentsync.toml presence check. */
+  force?: boolean;
+  /** Skip all three confirmation gates. Intended for tests / scripted use. */
+  yes?: boolean;
+  /**
+   * Async prompt callback. Defaults to a readline interface on
+   * `process.stdin`. Tests can inject a function that returns scripted
+   * answers without dealing with stream plumbing.
+   */
+  ask?: (prompt: string) => Promise<string>;
+  /** Optional stdout override for testing. Default writes to process.stdout. */
+  stdout?: NodeJS.WritableStream;
+  /**
+   * Override the non-TTY guard for testing. When undefined, the guard reads
+   * `process.stdin.isTTY` (the production default).
+   */
+  isInteractive?: boolean;
+}
+
+/**
+ * Wipe vault state at the configured scope. Returns a discriminated result —
+ * does not throw and never calls `process.exit` so non-CLI callers (tests,
+ * future TUI gating) can react to outcomes without parsing log output.
+ */
+export async function performDestroy(options: DestroyOptions): Promise<DestroyResult> {
+  const runtime = await resolveRuntimeContext();
+  const stdout = options.stdout ?? process.stdout;
+  const interactive = options.isInteractive ?? Boolean(process.stdin.isTTY);
+
+  // Stat the vault dir before doing anything else. ENOENT short-circuits to
+  // "not-found" so destroy is a no-op when the user has never run init.
+  let vaultExists = false;
+  try {
+    const info = await stat(runtime.vaultDir);
+    vaultExists = info.isDirectory();
+  } catch (err) {
+    if (!isFileNotFoundError(err)) {
+      return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  if (!vaultExists) {
+    return { status: "not-found", path: runtime.vaultDir };
+  }
+
+  // Safety check: refuse to destroy a directory that does not look like an
+  // agentsync vault. AGENTSYNC_VAULT_DIR pointing at a stray path would
+  // otherwise let this command wipe unrelated data.
+  let config: AgentSyncConfig | null = null;
+  try {
+    config = await loadConfig(resolveConfigPath(runtime.vaultDir));
+  } catch {
+    config = null;
+  }
+
+  if (!config && !options.force) {
+    return { status: "not-an-agentsync-vault", path: runtime.vaultDir };
+  }
+
+  if (!options.yes && !interactive) {
+    return { status: "non-tty-without-yes" };
+  }
+
+  // Remote-scope checks: refuse early on divergence so the user is not left
+  // in a half-destroyed state.
+  if (options.scope === "remote" || options.scope === "all") {
+    if (!config) {
+      return {
+        status: "failed",
+        error: "Cannot run --scope=remote without a vault config (agentsync.toml).",
+      };
+    }
+    const probe = new GitClient(runtime.vaultDir);
+    try {
+      await probe.reconcileWithRemote({
+        remote: "origin",
+        branch: config.remote.branch,
+        allowMissingRemote: true,
+      });
+    } catch (err) {
+      if (err instanceof GitReconciliationError) {
+        return { status: "remote-diverged", error: err.message };
+      }
+      return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  // Confirmation gates. `--yes` skips all three.
+  if (!options.yes) {
+    const { ask, cleanup } = options.ask
+      ? { ask: options.ask, cleanup: () => undefined }
+      : buildReadlineAsk();
+    try {
+      const gate1 = await runGate1(options.scope, runtime.vaultDir, config, ask, stdout);
+      if (!gate1) return { status: "aborted-by-user", gate: 1 };
+
+      const phrase = expectedPhrase(options.scope, config);
+      const gate2 = await runGate2(phrase, ask, stdout);
+      if (!gate2) return { status: "aborted-by-user", gate: 2 };
+
+      const gate3 = await runGate3(options.scope, ask, stdout);
+      if (!gate3) return { status: "aborted-by-user", gate: 3 };
+    } finally {
+      cleanup();
+    }
+  }
+
+  // Execute. Remote first when --scope=all so a push failure does not leave
+  // us with a wiped local that can no longer reach the remote.
+  let remoteOutcome: { commitSha: string | null; pushed: boolean } | null = null;
+  if (options.scope === "remote" || options.scope === "all") {
+    if (!config) {
+      return { status: "failed", error: "Cannot run --scope=remote without a vault config." };
+    }
+    const out = await wipeRemoteContent(runtime.vaultDir, config);
+    if (out.status !== "ok") return out.result;
+    remoteOutcome = { commitSha: out.commitSha, pushed: true };
+  }
+
+  if (options.scope === "local" || options.scope === "all") {
+    try {
+      await rm(runtime.vaultDir, { recursive: true, force: true });
+    } catch (err) {
+      return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  if (options.scope === "local") {
+    return { status: "removed-local", path: runtime.vaultDir };
+  }
+  // config is guaranteed non-null on the remote / all paths because the
+  // early-return at the top of the remote block fails fast when it is
+  // missing. Narrow the type once here so the return objects do not need
+  // non-null assertions on every field access.
+  if (!config) {
+    return { status: "failed", error: "Internal: config missing on remote scope path" };
+  }
+  if (options.scope === "remote") {
+    return {
+      status: "removed-remote",
+      commitSha: remoteOutcome?.commitSha ?? null,
+      branch: config.remote.branch,
+      remote: config.remote.url,
+    };
+  }
+  return {
+    status: "removed-all",
+    localPath: runtime.vaultDir,
+    commitSha: remoteOutcome?.commitSha ?? null,
+    branch: config.remote.branch,
+    remote: config.remote.url,
+  };
+}
+
+function expectedPhrase(scope: DestroyScope, config: AgentSyncConfig | null): string {
+  if (scope === "local" || !config) return "DESTROY";
+  const branch = config.remote.branch;
+  const fragment = parseRemoteFragment(config.remote.url);
+  return `DESTROY ${branch}@${fragment}`;
+}
+
+/**
+ * Extract the last two path components of a Git remote URL so the typed-phrase
+ * gate forces the user to read the remote off the preview before they can
+ * type it. Falls back to the raw URL if the parse fails — better a long
+ * phrase than no friction.
+ */
+function parseRemoteFragment(url: string): string {
+  const cleaned = url.replace(/\.git$/, "");
+  const segments = cleaned.split(/[/:]/).filter((s) => s.length > 0);
+  if (segments.length >= 2) return segments.slice(-2).join("/");
+  return cleaned;
+}
+
+type AskFn = (prompt: string) => Promise<string>;
+
+async function runGate1(
+  scope: DestroyScope,
+  vaultDir: string,
+  config: AgentSyncConfig | null,
+  ask: AskFn,
+  stdout: NodeJS.WritableStream,
+): Promise<boolean> {
+  const remote = config?.remote.url ?? "<remote not configured>";
+  const branch = config?.remote.branch ?? "<branch not configured>";
+  const recipientCount = config ? Object.keys(config.recipients).length : 0;
+
+  if (scope === "local" || scope === "all") {
+    stdout.write(`${LOCAL_PREVIEW_TEMPLATE(vaultDir, remote)}\n`);
+  }
+  if (scope === "remote" || scope === "all") {
+    stdout.write(`${REMOTE_PREVIEW_TEMPLATE(remote, branch, vaultDir, recipientCount)}\n`);
+  }
+
+  const answer = (await ask("\nContinue? (y/N) ")).trim().toLowerCase();
+  return answer === "y" || answer === "yes";
+}
+
+async function runGate2(
+  expected: string,
+  ask: AskFn,
+  _stdout: NodeJS.WritableStream,
+): Promise<boolean> {
+  const line = await ask(`\nType ${expected} (exact, case-sensitive) to confirm: `);
+  return line === expected;
+}
+
+async function runGate3(
+  scope: DestroyScope,
+  ask: AskFn,
+  stdout: NodeJS.WritableStream,
+): Promise<boolean> {
+  const action =
+    scope === "local"
+      ? "the vault directory will be removed"
+      : scope === "remote"
+        ? "the remote will be wiped via a commit + push"
+        : "the remote will be wiped AND the local vault directory will be removed";
+  stdout.write(`\nLast chance. After this prompt, ${action}.`);
+  const answer = (await ask("\nConfirm? (y/N) ")).trim().toLowerCase();
+  return answer === "y" || answer === "yes";
+}
+
+function buildReadlineAsk(): {
+  ask: (prompt: string) => Promise<string>;
+  cleanup: () => void;
+} {
+  const rl = createInterface({ input: process.stdin, terminal: false });
+  return {
+    ask: (prompt: string) =>
+      new Promise((resolve) => {
+        rl.question(prompt, (answer) => resolve(answer));
+      }),
+    cleanup: () => rl.close(),
+  };
+}
+
+type WipeRemoteResult =
+  | { status: "ok"; commitSha: string | null }
+  | { status: "err"; result: DestroyResult };
+
+async function wipeRemoteContent(
+  vaultDir: string,
+  config: AgentSyncConfig,
+): Promise<WipeRemoteResult> {
+  const git = new GitClient(vaultDir);
+
+  // Walk the working tree and unlink every regular file except inside .git/.
+  // `git add -A` (via GitClient.addAll → commit) then stages all the
+  // deletions for the commit. If nothing changed we short-circuit to a
+  // noop "already empty" success result.
+  try {
+    await unlinkAllTrackedContent(vaultDir);
+  } catch (err) {
+    return {
+      status: "err",
+      result: { status: "failed", error: err instanceof Error ? err.message : String(err) },
+    };
+  }
+
+  let committed = false;
+  try {
+    committed = await git.commit({ message: DESTROY_COMMIT_MESSAGE });
+  } catch (err) {
+    return {
+      status: "err",
+      result: { status: "failed", error: err instanceof Error ? err.message : String(err) },
+    };
+  }
+
+  if (!committed) {
+    return { status: "ok", commitSha: null };
+  }
+
+  let sha: string | null = null;
+  try {
+    sha = await readHeadShortSha(vaultDir);
+  } catch {
+    sha = null;
+  }
+
+  try {
+    await git.push("origin", config.remote.branch, []);
+  } catch (err) {
+    return {
+      status: "err",
+      result: {
+        status: "remote-push-failed",
+        error: err instanceof Error ? err.message : String(err),
+        commitSha: sha,
+      },
+    };
+  }
+
+  return { status: "ok", commitSha: sha };
+}
+
+/**
+ * Walk the working tree and unlink every regular file under `vaultDir`
+ * except inside `.git/`. This intentionally removes BOTH tracked and
+ * untracked files: a vault clone is meant to contain only AgentSync-managed
+ * encrypted artifacts, and a `destroy` invocation should leave nothing
+ * unencrypted behind. `git add -A` afterwards captures the deletions in a
+ * single commit so recovery via `git revert` reproduces the prior tracked
+ * state — untracked detritus is not recoverable by git in either direction.
+ */
+async function unlinkAllTrackedContent(vaultDir: string): Promise<void> {
+  async function walk(dir: string): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (name === ".git") continue;
+      const full = join(dir, name);
+      const info = await stat(full).catch(() => null);
+      if (!info) continue;
+      if (info.isDirectory()) {
+        await walk(full);
+        // Best-effort remove the now-empty directory so `git status` sees a
+        // clean tree. `git rm -rf` does this implicitly; we do it explicitly.
+        await rm(full, { recursive: true, force: true }).catch(() => undefined);
+      } else if (info.isFile()) {
+        await rm(full, { force: true });
+      }
+    }
+  }
+  await walk(vaultDir);
+}
+
+async function readHeadShortSha(repoDir: string): Promise<string | null> {
+  const result = Bun.spawnSync(["git", "-C", repoDir, "rev-parse", "--short=7", "HEAD"]);
+  if (result.exitCode !== 0) return null;
+  const out = new TextDecoder().decode(result.stdout).trim();
+  return out.length > 0 ? out : null;
+}
+
+/** Thin citty wrapper around `performDestroy`. Translates results into log
+ * output and sets `process.exitCode` on non-success branches. */
+export const destroyCommand = defineCommand({
+  meta: {
+    name: "destroy",
+    description: "Wipe local vault clone and/or remote vault contents",
+  },
+  args: {
+    scope: {
+      type: "string",
+      description: "What to destroy: local (default), remote, or all",
+      default: "local",
+    },
+    force: {
+      type: "boolean",
+      description: "Bypass the agentsync.toml safety check (still prompts unless --yes)",
+      default: false,
+    },
+    yes: {
+      type: "boolean",
+      description: "Skip all three confirmation gates. Intended for scripted use.",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const scope = String(args.scope) as DestroyScope;
+    if (scope !== "local" && scope !== "remote" && scope !== "all") {
+      log.error(`Invalid --scope: ${args.scope}. Expected one of: local, remote, all.`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const result = await performDestroy({
+      scope,
+      force: Boolean(args.force),
+      yes: Boolean(args.yes),
+    });
+
+    switch (result.status) {
+      case "removed-local":
+        log.success(`Local vault removed: ${result.path}`);
+        log.info(
+          "Daemon installation, key.txt, and your local agent files are untouched. " +
+            "Run `agentsync daemon stop` if you want the daemon quiet until re-init.",
+        );
+        return;
+      case "removed-remote":
+        if (result.commitSha) {
+          log.success(
+            `Remote vault wiped via commit ${result.commitSha} on ${result.branch} at ${result.remote}.`,
+          );
+        } else {
+          log.success(`Remote vault already empty (no tracked content to remove).`);
+        }
+        log.info(
+          "Other recipients can `git revert` this commit if they still have a copy of the data.",
+        );
+        return;
+      case "removed-all":
+        log.success(
+          `Remote wiped (commit ${result.commitSha ?? "none"} on ${result.branch}) and local vault removed at ${result.localPath}.`,
+        );
+        return;
+      case "not-found":
+        log.info(`No vault to destroy at ${result.path}. Nothing to do.`);
+        return;
+      case "not-an-agentsync-vault":
+        log.error(
+          `Refusing to destroy ${result.path}: no agentsync.toml found.\nThis does not look like an agentsync vault. If it is, pass --force.`,
+        );
+        process.exitCode = 1;
+        return;
+      case "remote-diverged":
+        log.error(`Remote diverged — refusing to destroy:\n${result.error}`);
+        log.info("See docs/operations.md#recover-from-divergence for the recovery path.");
+        process.exitCode = 1;
+        return;
+      case "remote-push-failed":
+        log.error(
+          `Destroy commit ${result.commitSha ?? "(none)"} created locally but push failed: ${result.error}`,
+        );
+        process.exitCode = 1;
+        return;
+      case "aborted-by-user":
+        log.info(`Aborted at gate ${result.gate}. No state changed.`);
+        return;
+      case "non-tty-without-yes":
+        log.error(
+          "Refusing to destroy in a non-interactive shell without --yes. Run in a terminal or pass --yes to confirm.",
+        );
+        process.exitCode = 1;
+        return;
+      case "failed":
+        log.error(result.error);
+        process.exitCode = 1;
+        return;
+    }
+  },
+});
+
+export const __TEST_ONLY = {
+  parseRemoteFragment,
+  expectedPhrase,
+  LOCAL_PREVIEW_TEMPLATE,
+  REMOTE_PREVIEW_TEMPLATE,
+  DESTROY_COMMIT_MESSAGE,
+};

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -23,19 +23,26 @@ const DEFAULT_SYNC = {
   pullIntervalMs: 300_000,
 };
 
-/**
- * Load or create the local age keypair so init can register this machine as a
- * recipient. Returns `isNew` so the caller can (a) defer the "generated" /
- * "loaded" log line until after init has actually committed to keeping the key
- * and (b) roll back a freshly written `key.txt` without touching a pre-existing
- * one if a later step fails.
- *
- * Contract on failure: if this function throws, the on-disk state of `path` is
- * either unchanged (pre-existing key preserved, or no key ever written) or
- * has been best-effort cleaned up. The caller's `isNew` rollback only fires
- * after a successful return, so any failure mid-generate-and-write must be
- * handled locally or the orphan key.txt is invisible to the outer recovery.
- */
+/** Discriminated result of a `performInit` invocation — lets non-CLI callers
+ * (e.g. the TUI init wizard) react to outcomes without parsing log output. */
+export type InitResult =
+  | {
+      status: "success";
+      vaultDir: string;
+      joinedExistingVault: boolean;
+      recipient: string;
+      machineName: string;
+      keyIsNew: boolean;
+      privateKeyPath: string;
+    }
+  | { status: "remote-probe-failed"; error: string }
+  | { status: "failed"; error: string; keyRolledBack: boolean };
+
+export interface InitOptions {
+  remote: string;
+  branch: string;
+}
+
 async function ensureKeypair(
   path: string,
 ): Promise<{ identity: string; recipient: string; isNew: boolean }> {
@@ -45,11 +52,8 @@ async function ensureKeypair(
     return { identity, recipient, isNew: false };
   } catch (err) {
     // Only auto-generate when key.txt is genuinely absent. Other read errors
-    // (EACCES on a locked-down key, a malformed file from a previous corrupt
-    // write, an unreadable mount) must surface as failures — silently
-    // overwriting them would destroy a key the user may still be able to
-    // recover and rebind every recipient to fresh material the user did not
-    // consent to.
+    // (EACCES on a locked-down key, malformed file, unreadable mount) surface
+    // as failures so we never overwrite material the user may still recover.
     if (!isFileNotFoundError(err)) throw err;
   }
 
@@ -59,16 +63,6 @@ async function ensureKeypair(
     const recipient = await identityToRecipient(identity);
     return { identity, recipient, isNew: true };
   } catch (err) {
-    // writeFile may have written partial data before rejecting (per Node docs,
-    // the call performs multiple internal writes and is best-effort on abort),
-    // and identityToRecipient can throw on a freshly written key. Either way,
-    // the file we just created — full, partial, or empty — must not survive
-    // as an "existing key" that the next init silently loads. `force: true`
-    // swallows ENOENT for the case where writeFile failed before opening the
-    // file. A real rm failure (EBUSY/EACCES/EROFS) is surfaced as a warn:
-    // the original write/recipient error is still the root cause, but the
-    // user needs to know an orphan key.txt may remain on disk so a naive
-    // retry does not silently inherit it.
     try {
       await rm(path, { force: true });
     } catch (rmErr) {
@@ -78,6 +72,127 @@ async function ensureKeypair(
       );
     }
     throw err;
+  }
+}
+
+/**
+ * Bootstrap a vault, local key material, and the initial git remote wiring.
+ * Returns a discriminated {@link InitResult} so both the CLI wrapper and the
+ * TUI wizard can render their own feedback. Never calls `process.exit*` —
+ * callers decide whether to set an exit code.
+ */
+export async function performInit(options: InitOptions): Promise<InitResult> {
+  const runtime = await resolveRuntimeContext();
+
+  // Probe the remote BEFORE writing any local artifacts. An unreachable or
+  // auth-blocked remote must abort with no on-disk state so a retry against
+  // a different URL does not silently inherit an orphan key or empty vault.
+  const probeClient = new GitClient(resolveAgentSyncHome());
+  let remoteState: Awaited<ReturnType<GitClient["inspectRemoteBranch"]>>;
+  try {
+    remoteState = await probeClient.inspectRemoteBranch(options.remote, options.branch);
+  } catch (err) {
+    return {
+      status: "remote-probe-failed",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  await mkdir(runtime.vaultDir, { recursive: true });
+  let git = new GitClient(runtime.vaultDir);
+
+  let keyIsNew = false;
+  try {
+    const { recipient, isNew } = await ensureKeypair(runtime.privateKeyPath);
+    keyIsNew = isNew;
+
+    const repoInitialized = await git.isInitialized();
+
+    if (!repoInitialized) {
+      if (remoteState.exists) {
+        git = await GitClient.clone(options.remote, runtime.vaultDir, options.branch);
+      } else {
+        await git.init();
+        await git.setHeadBranch(options.branch);
+        await git.ensureRemote("origin", options.remote);
+      }
+    } else {
+      await git.ensureRemote("origin", options.remote);
+      await git.reconcileWithRemote({
+        remote: "origin",
+        branch: options.branch,
+        allowMissingRemote: true,
+      });
+    }
+
+    const configPath = resolveConfigPath(runtime.vaultDir);
+
+    let existing = null;
+    try {
+      existing = await loadConfig(configPath);
+    } catch {
+      existing = null;
+    }
+
+    const joinedExistingVault =
+      existing !== null && existing.recipients[runtime.machineName] !== recipient;
+
+    const config = {
+      version: existing?.version ?? "1",
+      recipients: {
+        ...(existing?.recipients ?? {}),
+        [runtime.machineName]: recipient,
+      },
+      agents: existing?.agents ?? DEFAULT_AGENTS,
+      remote: {
+        url: options.remote,
+        branch: options.branch,
+      },
+      sync: existing?.sync ?? DEFAULT_SYNC,
+      claudePlugins: existing?.claudePlugins ?? { syncMarketplace: false },
+    };
+
+    await writeConfig(configPath, config);
+
+    const gitignorePath = join(runtime.vaultDir, ".gitignore");
+    await writeFile(gitignorePath, "*.tmp\n", "utf8");
+
+    const committed = await git.commit({ message: `init: ${runtime.machineName}` });
+    if (committed) {
+      await git.push("origin", options.branch, remoteState.exists ? [] : ["--set-upstream"]);
+    }
+
+    return {
+      status: "success",
+      vaultDir: runtime.vaultDir,
+      joinedExistingVault,
+      recipient,
+      machineName: runtime.machineName,
+      keyIsNew,
+      privateKeyPath: runtime.privateKeyPath,
+    };
+  } catch (err) {
+    // The remote probe passed but a later step failed. If we generated the
+    // key on this invocation, delete it so a retry is not bound to material
+    // that never made it into a successful init. A pre-existing key is
+    // preserved untouched.
+    let keyRolledBack = false;
+    if (keyIsNew) {
+      try {
+        await rm(runtime.privateKeyPath, { force: true });
+        keyRolledBack = true;
+      } catch (rmErr) {
+        const rmMessage = rmErr instanceof Error ? rmErr.message : String(rmErr);
+        log.warn(
+          `Failed to roll back freshly generated key at ${runtime.privateKeyPath}: ${rmMessage}.\nRemove key.txt manually before retrying.`,
+        );
+      }
+    }
+    return {
+      status: "failed",
+      error: err instanceof Error ? err.message : String(err),
+      keyRolledBack,
+    };
   }
 }
 
@@ -101,155 +216,42 @@ export const initCommand = defineCommand({
   },
   async run({ args }) {
     log.info("Initializing AgentSync");
+    const result = await performInit({ remote: args.remote, branch: args.branch });
 
-    const runtime = await resolveRuntimeContext();
-
-    // Probe the remote BEFORE writing any local artifacts (key.txt or even
-    // the vault directory itself). An unreachable or auth-blocked remote
-    // must abort with no on-disk state inside `runtime.vaultDir` so a retry
-    // against a different URL does not silently inherit an orphan key or
-    // an empty vault dir that was created for a never-completed init.
-    //
-    // The probe needs a cwd to run `git -C <cwd> ls-remote` against, but
-    // does not need a git repo. `resolveRuntimeContext` has already created
-    // the agentsync home (the parent of the default vault dir), which is
-    // always a valid cwd regardless of whether `AGENTSYNC_VAULT_DIR`
-    // overrides the vault location.
-    const probeClient = new GitClient(resolveAgentSyncHome());
-    let remoteState: Awaited<ReturnType<GitClient["inspectRemoteBranch"]>>;
-    try {
-      remoteState = await probeClient.inspectRemoteBranch(args.remote, args.branch);
-    } catch (err) {
-      log.error(err instanceof Error ? err.message : String(err));
+    if (result.status === "remote-probe-failed") {
+      log.error(result.error);
       process.exitCode = 1;
       return;
     }
 
-    await mkdir(runtime.vaultDir, { recursive: true });
-    let git = new GitClient(runtime.vaultDir);
-
-    // `keyIsNew` is declared outside the try so the catch can tell whether
-    // this invocation generated the key (and is allowed to delete it) or
-    // inherited one from a previous successful init (which must be preserved).
-    // It is only set to true after `ensureKeypair` returns successfully —
-    // partial-write and post-write failures inside `ensureKeypair` clean up
-    // their own orphan file locally (see its contract above), since this
-    // catch cannot observe `isNew` for a call that threw.
-    let keyIsNew = false;
-    try {
-      const { recipient, isNew } = await ensureKeypair(runtime.privateKeyPath);
-      keyIsNew = isNew;
-
-      const repoInitialized = await git.isInitialized();
-
-      if (!repoInitialized) {
-        if (remoteState.exists) {
-          git = await GitClient.clone(args.remote, runtime.vaultDir, args.branch);
-          log.info(`Joined existing remote vault history from ${args.remote}.`);
-        } else {
-          await git.init();
-          await git.setHeadBranch(args.branch);
-          await git.ensureRemote("origin", args.remote);
-        }
-      } else {
-        await git.ensureRemote("origin", args.remote);
-        await git.reconcileWithRemote({
-          remote: "origin",
-          branch: args.branch,
-          allowMissingRemote: true,
-        });
+    if (result.status === "failed") {
+      if (result.keyRolledBack) {
+        log.info("Rolled back freshly generated keypair.");
       }
-
-      const configPath = resolveConfigPath(runtime.vaultDir);
-
-      let existing = null;
-      try {
-        existing = await loadConfig(configPath);
-      } catch {
-        existing = null;
-      }
-
-      const joinedExistingVault =
-        existing !== null && existing.recipients[runtime.machineName] !== recipient;
-
-      const config = {
-        version: existing?.version ?? "1",
-        recipients: {
-          ...(existing?.recipients ?? {}),
-          [runtime.machineName]: recipient,
-        },
-        agents: existing?.agents ?? DEFAULT_AGENTS,
-        remote: {
-          url: args.remote,
-          branch: args.branch,
-        },
-        sync: existing?.sync ?? DEFAULT_SYNC,
-        claudePlugins: existing?.claudePlugins ?? { syncMarketplace: false },
-      };
-
-      await writeConfig(configPath, config);
-
-      const gitignorePath = join(runtime.vaultDir, ".gitignore");
-      await writeFile(gitignorePath, "*.tmp\n", "utf8");
-
-      const committed = await git.commit({ message: `init: ${runtime.machineName}` });
-      if (committed) {
-        await git.push("origin", args.branch, remoteState.exists ? [] : ["--set-upstream"]);
-        log.info("Vault pushed to remote.");
-      }
-
-      // Defer the keypair status log until every fallible step above has
-      // succeeded. Reporting "New age keypair generated, back it up now"
-      // earlier risks the user copying a key into a password manager seconds
-      // before the catch block rolls it back, leaving them with a backup
-      // that no longer matches anything on disk.
-      if (keyIsNew) {
-        log.warn(
-          `New age keypair generated.\n  Public key : ${recipient}\n  Private key: ${runtime.privateKeyPath}\n  ⚠  Back up your private key in a password manager now. It cannot be recovered.`,
-        );
-      } else {
-        log.info(`Loaded existing keypair — public key: ${recipient}`);
-      }
-
-      log.success(`Initialized vault at ${runtime.vaultDir}`);
-
-      if (joinedExistingVault) {
-        // The new machine wrote its pubkey into the recipient set but cannot
-        // re-encrypt existing .age artifacts itself (no decryption key). An
-        // existing recipient must run `key add` to grant read access.
-        log.warn(
-          [
-            "This machine is registered but cannot decrypt the existing vault yet.",
-            "An existing recipient must run on a machine that can decrypt the vault:",
-            `  agentsync key add ${runtime.machineName} ${recipient}`,
-            "Until that runs, `agentsync pull` on this machine will fail.",
-          ].join("\n"),
-        );
-      }
-    } catch (err) {
-      // The remote probe above passed, so the failure here is in keypair
-      // generation, clone/init, reconcile, config write, commit, or push. If
-      // we generated the key on this invocation, delete it so a retry is not
-      // bound to material that never made it into a successful init. A
-      // pre-existing key (one a previous successful init committed to) is
-      // preserved untouched.
-      if (keyIsNew) {
-        try {
-          await rm(runtime.privateKeyPath, { force: true });
-          log.info(`Rolled back freshly generated keypair at ${runtime.privateKeyPath}.`);
-        } catch (rmErr) {
-          // Surface rm failures (EBUSY/EACCES/EROFS) as a warning instead of
-          // letting them propagate and mask the real init error below. The
-          // hint tells the user that an orphan key.txt may still be on disk
-          // and a naive retry would silently inherit it.
-          const rmMessage = rmErr instanceof Error ? rmErr.message : String(rmErr);
-          log.warn(
-            `Failed to roll back freshly generated key at ${runtime.privateKeyPath}: ${rmMessage}.\nRemove key.txt manually before retrying.`,
-          );
-        }
-      }
-      log.error(err instanceof Error ? err.message : String(err));
+      log.error(result.error);
       process.exitCode = 1;
+      return;
+    }
+
+    if (result.keyIsNew) {
+      log.warn(
+        `New age keypair generated.\n  Public key : ${result.recipient}\n  Private key: ${result.privateKeyPath}\n  ⚠  Back up your private key in a password manager now. It cannot be recovered.`,
+      );
+    } else {
+      log.info(`Loaded existing keypair — public key: ${result.recipient}`);
+    }
+
+    log.success(`Initialized vault at ${result.vaultDir}`);
+
+    if (result.joinedExistingVault) {
+      log.warn(
+        [
+          "This machine is registered but cannot decrypt the existing vault yet.",
+          "An existing recipient must run on a machine that can decrypt the vault:",
+          `  agentsync key add ${result.machineName} ${result.recipient}`,
+          "Until that runs, `agentsync pull` on this machine will fail.",
+        ].join("\n"),
+      );
     }
   },
 });

--- a/src/commands/key.ts
+++ b/src/commands/key.ts
@@ -38,6 +38,173 @@ async function findAgeFiles(dir: string): Promise<string[]> {
   return results;
 }
 
+/** Discriminated result of a `performKeyAdd` invocation. */
+export type KeyAddResult =
+  | { status: "success"; name: string; recipientCount: number }
+  | { status: "invalid-key"; error: string }
+  | { status: "name-conflict"; name: string }
+  | { status: "failed"; error: string };
+
+/** Discriminated result of a `performKeyRotate` invocation. */
+export type KeyRotateResult =
+  | {
+      status: "success";
+      machineName: string;
+      newRecipient: string;
+      privateKeyPath: string;
+    }
+  | { status: "not-in-recipients"; error: string }
+  | { status: "failed"; error: string };
+
+/**
+ * Add an age recipient to the vault and re-encrypt every `.age` artefact for
+ * the full recipient set. Returns a typed result so non-CLI callers can render
+ * their own feedback.
+ */
+export async function performKeyAdd(options: {
+  name: string;
+  pubkey: string;
+}): Promise<KeyAddResult> {
+  const parsed = AgePublicKeySchema.safeParse(options.pubkey);
+  if (!parsed.success) {
+    return { status: "invalid-key", error: parsed.error.issues[0].message };
+  }
+
+  const runtime = await resolveRuntimeContext();
+  const configPath = resolveConfigPath(runtime.vaultDir);
+  const config = await loadVaultConfigOrExit(runtime.vaultDir);
+
+  if (config.recipients[options.name] && config.recipients[options.name] !== options.pubkey) {
+    return { status: "name-conflict", name: options.name };
+  }
+
+  try {
+    const git = new GitClient(runtime.vaultDir);
+    const reconciliation = await git.reconcileWithRemote({
+      remote: "origin",
+      branch: config.remote.branch,
+      allowMissingRemote: true,
+    });
+    const refreshedConfig = await loadConfig(configPath);
+
+    // Idempotent on matching pubkey: the joining machine's `init` already
+    // wrote its own entry to recipients on the remote.
+    if (
+      refreshedConfig.recipients[options.name] &&
+      refreshedConfig.recipients[options.name] !== options.pubkey
+    ) {
+      return { status: "name-conflict", name: options.name };
+    }
+
+    refreshedConfig.recipients[options.name] = options.pubkey;
+    await writeConfig(configPath, refreshedConfig);
+
+    const key = await loadPrivateKey(runtime.privateKeyPath);
+    const allRecipients = Object.values(refreshedConfig.recipients);
+    const ageFiles = await findAgeFiles(runtime.vaultDir);
+
+    for (const filePath of ageFiles) {
+      const encrypted = await readFile(filePath, "utf8");
+      const decrypted = await decryptString(encrypted, key);
+      const reEncrypted = await encryptString(decrypted, allRecipients);
+      await writeFile(filePath, reEncrypted, "utf8");
+    }
+
+    await git.addAll();
+    const committed = await git.commit({ message: `key: add recipient ${options.name}` });
+    if (committed) {
+      await git.push(
+        "origin",
+        refreshedConfig.remote.branch,
+        reconciliation.status === "remote-missing" ? ["--set-upstream"] : [],
+      );
+    }
+
+    return { status: "success", name: options.name, recipientCount: allRecipients.length };
+  } catch (err) {
+    return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Generate a new local age identity, re-encrypt every vault artefact for the
+ * updated recipient set, persist the new key locally, and push the rotation.
+ */
+export async function performKeyRotate(): Promise<KeyRotateResult> {
+  const runtime = await resolveRuntimeContext();
+  const configPath = resolveConfigPath(runtime.vaultDir);
+  const initialConfig = await loadVaultConfigOrExit(runtime.vaultDir);
+  const oldKey = await loadPrivateKey(runtime.privateKeyPath);
+
+  try {
+    const git = new GitClient(runtime.vaultDir);
+    const reconciliation = await git.reconcileWithRemote({
+      remote: "origin",
+      branch: initialConfig.remote.branch,
+      allowMissingRemote: true,
+    });
+    const config = await loadConfig(configPath);
+    const oldRecipient = await identityToRecipient(oldKey);
+
+    const machineEntry = Object.entries(config.recipients).find(([, pub]) => pub === oldRecipient);
+
+    if (!machineEntry) {
+      return {
+        status: "not-in-recipients",
+        error:
+          "Could not find the current machine's public key in config.recipients. " +
+          "Cannot determine which recipient to rotate.",
+      };
+    }
+
+    const [machineName] = machineEntry;
+    const newIdentity = await generateIdentity();
+    const newRecipient = await identityToRecipient(newIdentity);
+
+    const nextConfig = structuredClone(config);
+    nextConfig.recipients[machineName] = newRecipient;
+    const allRecipients = Object.values(nextConfig.recipients);
+    const ageFiles = await findAgeFiles(runtime.vaultDir);
+    const rewrittenFiles = new Map<string, string>();
+
+    for (const filePath of ageFiles) {
+      const encrypted = await readFile(filePath, "utf8");
+      const decrypted = await decryptString(encrypted, oldKey);
+      const reEncrypted = await encryptString(decrypted, allRecipients);
+      rewrittenFiles.set(filePath, reEncrypted);
+    }
+
+    for (const [filePath, reEncrypted] of rewrittenFiles) {
+      await writeFile(filePath, reEncrypted, "utf8");
+    }
+
+    await writeFile(runtime.privateKeyPath, `${newIdentity}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await writeConfig(configPath, nextConfig);
+
+    await git.addAll();
+    const committed = await git.commit({ message: `key: rotate ${machineName}` });
+    if (committed) {
+      await git.push(
+        "origin",
+        nextConfig.remote.branch,
+        reconciliation.status === "remote-missing" ? ["--set-upstream"] : [],
+      );
+    }
+
+    return {
+      status: "success",
+      machineName,
+      newRecipient,
+      privateKeyPath: runtime.privateKeyPath,
+    };
+  } catch (err) {
+    return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 /** Manage recipients and local age key rotation for an existing vault. */
 export const keyCommand = defineCommand({
   meta: {
@@ -60,78 +227,31 @@ export const keyCommand = defineCommand({
         },
       },
       async run({ args }) {
-        const name = args.name as string;
-        const pubkey = args.pubkey as string;
+        const result = await performKeyAdd({
+          name: String(args.name),
+          pubkey: String(args.pubkey),
+        });
 
-        const parsed = AgePublicKeySchema.safeParse(pubkey);
-        if (!parsed.success) {
-          log.error(`Invalid key: ${parsed.error.issues[0].message}`);
-          process.exitCode = 1;
-          return;
-        }
-
-        const runtime = await resolveRuntimeContext();
-        const configPath = resolveConfigPath(runtime.vaultDir);
-        const config = await loadVaultConfigOrExit(runtime.vaultDir);
-
-        if (config.recipients[name] && config.recipients[name] !== pubkey) {
-          log.error(`Recipient '${name}' already exists. Use a different name or remove it first.`);
-          process.exitCode = 1;
-          return;
-        }
-
-        try {
-          const git = new GitClient(runtime.vaultDir);
-          const reconciliation = await git.reconcileWithRemote({
-            remote: "origin",
-            branch: config.remote.branch,
-            allowMissingRemote: true,
-          });
-          const refreshedConfig = await loadConfig(configPath);
-
-          // Idempotent on matching pubkey: the joining machine's `init` already
-          // wrote its own entry to recipients on the remote, so the existing
-          // recipient running `key add` will see the name present with the
-          // same pubkey. The required work is to re-encrypt the vault for the
-          // full recipient set, not to insert a new entry.
-          if (refreshedConfig.recipients[name] && refreshedConfig.recipients[name] !== pubkey) {
+        switch (result.status) {
+          case "success":
+            log.success(
+              `Added recipient '${result.name}'. Vault re-encrypted for ${result.recipientCount} recipient(s).`,
+            );
+            return;
+          case "invalid-key":
+            log.error(`Invalid key: ${result.error}`);
+            process.exitCode = 1;
+            return;
+          case "name-conflict":
             log.error(
-              `Recipient '${name}' already exists. Use a different name or remove it first.`,
+              `Recipient '${result.name}' already exists. Use a different name or remove it first.`,
             );
             process.exitCode = 1;
             return;
-          }
-
-          refreshedConfig.recipients[name] = pubkey;
-          await writeConfig(configPath, refreshedConfig);
-
-          const key = await loadPrivateKey(runtime.privateKeyPath);
-          const allRecipients = Object.values(refreshedConfig.recipients);
-          const ageFiles = await findAgeFiles(runtime.vaultDir);
-
-          for (const filePath of ageFiles) {
-            const encrypted = await readFile(filePath, "utf8");
-            const decrypted = await decryptString(encrypted, key);
-            const reEncrypted = await encryptString(decrypted, allRecipients);
-            await writeFile(filePath, reEncrypted, "utf8");
-          }
-
-          await git.addAll();
-          const committed = await git.commit({ message: `key: add recipient ${name}` });
-          if (committed) {
-            await git.push(
-              "origin",
-              refreshedConfig.remote.branch,
-              reconciliation.status === "remote-missing" ? ["--set-upstream"] : [],
-            );
-          }
-
-          log.success(
-            `Added recipient '${name}'. Vault re-encrypted for ${allRecipients.length} recipient(s).`,
-          );
-        } catch (err) {
-          log.error(err instanceof Error ? err.message : String(err));
-          process.exitCode = 1;
+          case "failed":
+            log.error(result.error);
+            process.exitCode = 1;
+            return;
         }
       },
     }),
@@ -139,77 +259,22 @@ export const keyCommand = defineCommand({
     rotate: defineCommand({
       meta: { description: "Generate a new local age identity and re-encrypt the vault" },
       async run() {
-        const runtime = await resolveRuntimeContext();
-        const configPath = resolveConfigPath(runtime.vaultDir);
-        const initialConfig = await loadVaultConfigOrExit(runtime.vaultDir);
-        const oldKey = await loadPrivateKey(runtime.privateKeyPath);
+        const result = await performKeyRotate();
 
-        try {
-          const git = new GitClient(runtime.vaultDir);
-          const reconciliation = await git.reconcileWithRemote({
-            remote: "origin",
-            branch: initialConfig.remote.branch,
-            allowMissingRemote: true,
-          });
-          const config = await loadConfig(configPath);
-          const oldRecipient = await identityToRecipient(oldKey);
-
-          const machineEntry = Object.entries(config.recipients).find(
-            ([, pub]) => pub === oldRecipient,
-          );
-
-          if (!machineEntry) {
-            log.error(
-              "Could not find the current machine's public key in config.recipients. " +
-                "Cannot determine which recipient to rotate.",
-            );
+        switch (result.status) {
+          case "success":
+            log.success(`Rotated key for '${result.machineName}'.`);
+            log.info(`New public key: ${result.newRecipient}`);
+            log.warn(`Remember to back up: ${result.privateKeyPath}`);
+            return;
+          case "not-in-recipients":
+            log.error(result.error);
             process.exitCode = 1;
             return;
-          }
-
-          const [machineName] = machineEntry;
-          const newIdentity = await generateIdentity();
-          const newRecipient = await identityToRecipient(newIdentity);
-
-          const nextConfig = structuredClone(config);
-          nextConfig.recipients[machineName] = newRecipient;
-          const allRecipients = Object.values(nextConfig.recipients);
-          const ageFiles = await findAgeFiles(runtime.vaultDir);
-          const rewrittenFiles = new Map<string, string>();
-
-          for (const filePath of ageFiles) {
-            const encrypted = await readFile(filePath, "utf8");
-            const decrypted = await decryptString(encrypted, oldKey);
-            const reEncrypted = await encryptString(decrypted, allRecipients);
-            rewrittenFiles.set(filePath, reEncrypted);
-          }
-
-          for (const [filePath, reEncrypted] of rewrittenFiles) {
-            await writeFile(filePath, reEncrypted, "utf8");
-          }
-
-          await writeFile(runtime.privateKeyPath, `${newIdentity}\n`, {
-            encoding: "utf8",
-            mode: 0o600,
-          });
-          await writeConfig(configPath, nextConfig);
-
-          await git.addAll();
-          const committed = await git.commit({ message: `key: rotate ${machineName}` });
-          if (committed) {
-            await git.push(
-              "origin",
-              nextConfig.remote.branch,
-              reconciliation.status === "remote-missing" ? ["--set-upstream"] : [],
-            );
-          }
-
-          log.success(`Rotated key for '${machineName}'.`);
-          log.info(`New public key: ${newRecipient}`);
-          log.warn(`Remember to back up: ${runtime.privateKeyPath}`);
-        } catch (err) {
-          log.error(err instanceof Error ? err.message : String(err));
-          process.exitCode = 1;
+          case "failed":
+            log.error(result.error);
+            process.exitCode = 1;
+            return;
         }
       },
     }),

--- a/src/commands/tui/__tests__/cross-tab.test.ts
+++ b/src/commands/tui/__tests__/cross-tab.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { countRunning, createInitialState } from "../state";
+import { createStore } from "../store";
+
+describe("cross-tab visibility", () => {
+  test("operation started on Migrate is visible from Dashboard render path without polling", () => {
+    const store = createStore(createInitialState());
+    store.runOperation("migrate", "apply x→y@global-rules", () => new Promise(() => {}));
+
+    // Simulate a user pressing "1" to switch to dashboard.
+    store.dispatch((d) => {
+      d.activeTab = "dashboard";
+    });
+
+    // Dashboard render path reads countRunning(state) — the running op must be
+    // observable right now, not after the next 1.5s poll.
+    const running = countRunning(store.getState());
+    expect(running).toBe(1);
+  });
+
+  test("multiple in-flight operations from different tabs all counted", () => {
+    const store = createStore(createInitialState());
+    store.runOperation("migrate-preview", "preview", () => new Promise(() => {}));
+    store.runOperation("vault-load", "load vault", () => new Promise(() => {}));
+    store.runOperation("agents-load", "load agents", () => new Promise(() => {}));
+    expect(countRunning(store.getState())).toBe(3);
+  });
+
+  test("completed operations stop counting in countRunning", async () => {
+    const store = createStore(createInitialState());
+    store.runOperation("pull", "pull", async () => ({ ok: true }));
+    expect(countRunning(store.getState())).toBe(1);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(countRunning(store.getState())).toBe(0);
+  });
+
+  test("migrate preview onSuccess hook updates state.migrate visible cross-tab", async () => {
+    const store = createStore(createInitialState());
+    store.runOperation(
+      "migrate-preview",
+      "preview",
+      async () => ({ migrated: [], skipped: [], errors: [] }),
+      {
+        onSuccess: (draft) => {
+          draft.migrate.preview = "no-op";
+          draft.migrate.previewKey = "claude→cursor@global-rules";
+        },
+      },
+    );
+    await new Promise((r) => setTimeout(r, 5));
+    // Even if active tab is dashboard, migrate slice is updated.
+    store.dispatch((d) => {
+      d.activeTab = "dashboard";
+    });
+    expect(store.getState().migrate.preview).toBe("no-op");
+    expect(store.getState().migrate.previewKey).toBe("claude→cursor@global-rules");
+  });
+});

--- a/src/commands/tui/__tests__/store.test.ts
+++ b/src/commands/tui/__tests__/store.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { createInitialState } from "../state";
+import { createStore } from "../store";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+} {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createStore.runOperation", () => {
+  test("writes inFlight on start synchronously, observable before opFn resolves", () => {
+    const store = createStore(createInitialState());
+    const d = deferred<{ done: true }>();
+    const id = store.runOperation("push", "push via daemon", () => d.promise);
+    const snap = store.getState().inFlight[id];
+    expect(snap).toBeDefined();
+    expect(snap.phase).toBe("running");
+    expect(snap.kind).toBe("push");
+    expect(snap.label).toBe("push via daemon");
+    expect(snap.finishedAt).toBeNull();
+    d.resolve({ done: true });
+  });
+
+  test("onSuccess runs in same dispatch as terminal phase write", async () => {
+    const store = createStore(createInitialState());
+    const id = store.runOperation("vault-load", "load", async () => [1, 2, 3], {
+      onSuccess: (draft, result) => {
+        const arr = result as number[];
+        draft.vault.entries = arr.map((n) => ({
+          agent: "x",
+          path: `${n}`,
+          absolutePath: `/x/${n}`,
+          size: n,
+          isSkill: false,
+        }));
+      },
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    const op = store.getState().inFlight[id];
+    expect(op.phase).toBe("ok");
+    expect(store.getState().vault.entries.length).toBe(3);
+  });
+
+  test("onError sees the thrown error and terminal phase = error", async () => {
+    const store = createStore(createInitialState());
+    const captured: { msg: string | null } = { msg: null };
+    const id = store.runOperation(
+      "migrate",
+      "apply x",
+      async () => {
+        throw new Error("boom");
+      },
+      {
+        onError: (_draft, err) => {
+          captured.msg = err.message;
+        },
+      },
+    );
+    await new Promise((r) => setTimeout(r, 5));
+    const op = store.getState().inFlight[id];
+    expect(op.phase).toBe("error");
+    expect(op.error).toBe("boom");
+    expect(captured.msg).toBe("boom");
+  });
+
+  test("subscriber fires at least twice: on start and on terminal", async () => {
+    const store = createStore(createInitialState());
+    let n = 0;
+    store.subscribe(() => {
+      n += 1;
+    });
+    store.runOperation("pull", "pull", async () => ({ ok: true }));
+    expect(n).toBeGreaterThanOrEqual(1);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(n).toBeGreaterThanOrEqual(2);
+  });
+
+  test("activityKind pushes start and ok entries with matching messages", async () => {
+    const store = createStore(createInitialState());
+    store.runOperation("vault-load", "scan", async () => 1, { activityKind: "info" });
+    expect(store.getState().activity[0]).toMatchObject({ status: "running", kind: "info" });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(store.getState().activity[0]).toMatchObject({ status: "ok", kind: "info" });
+  });
+
+  test("eviction removes inFlight slot after evictAfterMs", async () => {
+    const store = createStore(createInitialState());
+    const id = store.runOperation("vault-load", "v", async () => 1, { evictAfterMs: 10 });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(store.getState().inFlight[id]).toBeDefined();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(store.getState().inFlight[id]).toBeUndefined();
+  });
+
+  test("opSeq increments monotonically across operations", () => {
+    const store = createStore(createInitialState());
+    const a = store.runOperation("push", "a", () => new Promise(() => {}));
+    const b = store.runOperation("push", "b", () => new Promise(() => {}));
+    expect(a).not.toBe(b);
+    expect(store.getState().opSeq).toBe(2);
+  });
+});
+
+describe("createStore.dispose", () => {
+  test("cancels pending eviction timers", async () => {
+    const store = createStore(createInitialState());
+    const id = store.runOperation("vault-load", "v", async () => 1, { evictAfterMs: 50 });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(store.getState().inFlight[id]).toBeDefined();
+    store.dispose();
+    await new Promise((r) => setTimeout(r, 100));
+    // Eviction would have fired by now — dispose must have cancelled it.
+    expect(store.getState().inFlight[id]).toBeDefined();
+  });
+
+  test("post-dispose dispatch is a no-op", () => {
+    const store = createStore(createInitialState());
+    store.dispose();
+    let fired = 0;
+    store.subscribe(() => {
+      fired += 1;
+    });
+    store.dispatch((d) => {
+      d.activeTab = "vault";
+    });
+    expect(store.getState().activeTab).toBe("dashboard");
+    expect(fired).toBe(0);
+  });
+
+  test("is idempotent", () => {
+    const store = createStore(createInitialState());
+    store.dispose();
+    store.dispose();
+  });
+});
+
+describe("createStore.dispatch", () => {
+  test("mutator changes state and notifies subscribers", () => {
+    const store = createStore(createInitialState());
+    let fired = 0;
+    store.subscribe(() => {
+      fired += 1;
+    });
+    store.dispatch((d) => {
+      d.activeTab = "vault";
+    });
+    expect(store.getState().activeTab).toBe("vault");
+    expect(fired).toBe(1);
+  });
+
+  test("subscribe returns disposer that detaches", () => {
+    const store = createStore(createInitialState());
+    let fired = 0;
+    const off = store.subscribe(() => {
+      fired += 1;
+    });
+    store.dispatch((d) => {
+      d.activeTab = "vault";
+    });
+    off();
+    store.dispatch((d) => {
+      d.activeTab = "agents";
+    });
+    expect(fired).toBe(1);
+  });
+});

--- a/src/commands/tui/app.ts
+++ b/src/commands/tui/app.ts
@@ -1,5 +1,6 @@
 import type { CliRenderer, KeyEvent } from "@opentui/core";
 import { BoxRenderable, createCliRenderer, TextRenderable } from "@opentui/core";
+import { version as pkgVersion } from "../../../package.json";
 import { TuiIpcClient } from "./lib/ipc-client";
 import {
   type AppState,
@@ -60,7 +61,12 @@ export async function runApp(): Promise<void> {
   }
 
   const renderer = await createCliRenderer({
-    exitOnCtrlC: true,
+    // false: route Ctrl+C through the manual SIGINT handler so `quitResolver`
+    // fires, the `finally` block runs `teardown(renderer)` + `store.dispose()`,
+    // and pending eviction timers are cancelled. With `true` here, OpenTUI's
+    // own SIGINT handler can call `renderer.destroy()` and `process.exit()`
+    // before the finally block, leaking the store's pendingTimers set.
+    exitOnCtrlC: false,
     targetFps: 30,
     backgroundColor: PALETTE.bg,
   });
@@ -309,7 +315,7 @@ function makeTitleBar(renderer: CliRenderer): TextRenderable {
 function renderTitleBar(host: TextRenderable, _state: AppState): void {
   const now = new Date();
   const time = now.toTimeString().slice(0, 8);
-  host.content = ` agentsync · v0.1.6 · ${time}`;
+  host.content = ` agentsync · v${pkgVersion} · ${time}`;
 }
 
 function makeTabBar(renderer: CliRenderer): TextRenderable {

--- a/src/commands/tui/app.ts
+++ b/src/commands/tui/app.ts
@@ -1,0 +1,480 @@
+import type { CliRenderer, KeyEvent } from "@opentui/core";
+import { BoxRenderable, createCliRenderer, TextRenderable } from "@opentui/core";
+import { TuiIpcClient } from "./lib/ipc-client";
+import {
+  type AppState,
+  type ContextAction,
+  countRunning,
+  createInitialState,
+  setToast,
+  TAB_IDS,
+  type TabId,
+} from "./state";
+import { createStore, type Store } from "./store";
+import { renderActivity } from "./tabs/activity";
+import { ensureAgentsLoaded, onAgentsKey, renderAgents } from "./tabs/agents";
+import { renderDashboard } from "./tabs/dashboard";
+import { onMigrateKey, renderMigrate } from "./tabs/migrate";
+import { ensureVaultLoaded, onVaultKey, renderVault } from "./tabs/vault";
+
+const POLL_INTERVAL_MS = 1500;
+
+const TAB_LABELS: Record<TabId, string> = {
+  dashboard: "Dashboard",
+  vault: "Vault",
+  agents: "Agents",
+  migrate: "Migrate",
+  activity: "Activity",
+};
+
+const PALETTE = {
+  bg: "#0b0d10",
+  panelBg: "#11151a",
+  border: "#3b4252",
+  borderFocus: "#88c0d0",
+  text: "#d8dee9",
+  textDim: "#6c7886",
+  accent: "#88c0d0",
+  good: "#a3be8c",
+  warn: "#ebcb8b",
+  bad: "#bf616a",
+  tabActiveBg: "#2e3440",
+  tabActiveText: "#eceff4",
+} as const;
+
+interface AppContext {
+  renderer: CliRenderer;
+  store: Store;
+  ipc: TuiIpcClient;
+  rerender: () => void;
+}
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let toastTimer: ReturnType<typeof setInterval> | null = null;
+let dataRefreshTimer: ReturnType<typeof setInterval> | null = null;
+
+export async function runApp(): Promise<void> {
+  if (!process.stdout.isTTY) {
+    process.stderr.write("agentsync TUI requires an interactive terminal.\n");
+    return;
+  }
+
+  const renderer = await createCliRenderer({
+    exitOnCtrlC: true,
+    targetFps: 30,
+    backgroundColor: PALETTE.bg,
+  });
+
+  const store = createStore(createInitialState());
+  const ipc = new TuiIpcClient();
+
+  const root = new BoxRenderable(renderer, {
+    flexDirection: "column",
+    width: "100%",
+    height: "100%",
+    backgroundColor: PALETTE.bg,
+  });
+  renderer.root.add(root);
+
+  const titleBar = makeTitleBar(renderer);
+  const tabBar = makeTabBar(renderer);
+  const contentHost = new BoxRenderable(renderer, {
+    flexGrow: 1,
+    flexDirection: "column",
+    backgroundColor: PALETTE.panelBg,
+    width: "100%",
+  });
+  const actionBar = new TextRenderable(renderer, {
+    height: 1,
+    width: "100%",
+    fg: PALETTE.textDim,
+    bg: PALETTE.bg,
+    content: "",
+  });
+  const footer = makeFooter(renderer);
+
+  root.add(titleBar);
+  root.add(tabBar);
+  root.add(contentHost);
+  root.add(actionBar);
+  root.add(footer);
+
+  const ctx: AppContext = {
+    renderer,
+    store,
+    ipc,
+    rerender: () => {
+      const state = store.getState();
+      renderTitleBar(titleBar, state);
+      renderTabBar(tabBar, state);
+      renderActiveTab(renderer, contentHost, store, ctx);
+      renderActionBar(actionBar, contextActionsForTab(state));
+      renderFooter(footer, state);
+    },
+  };
+
+  store.subscribe(() => ctx.rerender());
+  ctx.rerender();
+
+  const pollOnce = async () => {
+    const status = await ipc.status().catch(() => null);
+    store.dispatch((draft) => {
+      if (status) {
+        if (draft.daemon.status?.pid !== status.pid) {
+          draft.daemon.pidObservedAt = Date.now();
+        }
+        draft.daemon.online = true;
+        draft.daemon.status = status;
+        draft.daemon.lastError = status.lastError ?? null;
+      } else {
+        draft.daemon.online = false;
+        draft.daemon.status = null;
+        draft.daemon.pidObservedAt = null;
+      }
+    });
+  };
+  await pollOnce();
+  pollTimer = setInterval(pollOnce, POLL_INTERVAL_MS);
+
+  toastTimer = setInterval(() => {
+    const s = store.getState();
+    if (s.toast && s.toast.expiresAt < Date.now()) {
+      store.dispatch((d) => {
+        d.toast = null;
+      });
+    }
+  }, 500);
+
+  dataRefreshTimer = setInterval(() => ctx.rerender(), 30_000);
+
+  let quitResolver: () => void = () => {};
+  const quitPromise = new Promise<void>((res) => {
+    quitResolver = res;
+  });
+
+  const onKey = (key: KeyEvent) => handleKey(key, ctx, quitResolver);
+  renderer.keyInput.on("keypress", onKey);
+
+  const onSignal = () => quitResolver();
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  renderer.start();
+
+  try {
+    await quitPromise;
+  } finally {
+    teardown(renderer);
+    store.dispose();
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
+  }
+}
+
+function teardown(renderer: CliRenderer): void {
+  if (pollTimer) clearInterval(pollTimer);
+  if (toastTimer) clearInterval(toastTimer);
+  if (dataRefreshTimer) clearInterval(dataRefreshTimer);
+  pollTimer = null;
+  toastTimer = null;
+  dataRefreshTimer = null;
+  try {
+    renderer.destroy();
+  } catch {
+    // best-effort
+  }
+}
+
+function handleKey(key: KeyEvent, ctx: AppContext, quit: () => void): void {
+  if (key.name === "q" || (key.ctrl && key.name === "c")) {
+    quit();
+    return;
+  }
+
+  if (key.name >= "1" && key.name <= "5") {
+    const idx = Number(key.name) - 1;
+    if (idx >= 0 && idx < TAB_IDS.length) {
+      ctx.store.dispatch((d) => {
+        d.activeTab = TAB_IDS[idx];
+        d.selection.clear();
+      });
+      return;
+    }
+  }
+  if (key.name === "tab") {
+    ctx.store.dispatch((d) => {
+      const cur = TAB_IDS.indexOf(d.activeTab);
+      d.activeTab = TAB_IDS[(cur + (key.shift ? -1 : 1) + TAB_IDS.length) % TAB_IDS.length];
+    });
+    return;
+  }
+
+  if (key.name === "p" && !key.shift) {
+    invokeDaemonOp("push", ctx);
+    return;
+  }
+  if (key.name === "l" && !key.shift) {
+    invokeDaemonOp("pull", ctx);
+    return;
+  }
+
+  if (key.name === "r" && !key.shift) {
+    ctx.rerender();
+    return;
+  }
+
+  if (key.name === "?" || (key.shift && key.name === "/")) {
+    ctx.store.dispatch((d) => {
+      d.helpOpen = !d.helpOpen;
+    });
+    return;
+  }
+
+  if (ctx.store.getState().helpOpen) {
+    ctx.store.dispatch((d) => {
+      d.helpOpen = false;
+    });
+    return;
+  }
+
+  delegateTabKey(key, ctx);
+}
+
+function invokeDaemonOp(op: "push" | "pull", ctx: AppContext): void {
+  if (!ctx.store.getState().daemon.online) {
+    ctx.store.dispatch((d) =>
+      setToast(d, `Daemon offline — start with "agentsync daemon start"`, "error"),
+    );
+    return;
+  }
+  ctx.store.runOperation(
+    op,
+    `${op} via daemon`,
+    async () => {
+      const result = op === "push" ? await ctx.ipc.push() : await ctx.ipc.pull();
+      if (!result.ok) throw new Error(result.error ?? "unknown");
+      return result;
+    },
+    {
+      activityKind: op,
+      toastOnStart: { text: `Queued ${op}…`, level: "info" },
+      successToast: `${op} queued`,
+      errorToastPrefix: op,
+    },
+  );
+}
+
+function delegateTabKey(key: KeyEvent, ctx: AppContext): void {
+  const tab = ctx.store.getState().activeTab;
+  switch (tab) {
+    case "vault":
+      onVaultKey(key, ctx.store);
+      break;
+    case "agents":
+      onAgentsKey(key, ctx.store);
+      break;
+    case "migrate":
+      onMigrateKey(key, ctx.store);
+      break;
+    case "activity":
+      if (key.name === "c") {
+        ctx.store.dispatch((d) => {
+          d.activity = [];
+        });
+      }
+      break;
+    case "dashboard":
+      if (key.name === "i") {
+        ctx.store.dispatch((d) =>
+          setToast(d, "Init wizard: run `agentsync init --remote <url>` from a shell", "info"),
+        );
+      } else if (key.name === "k") {
+        ctx.store.dispatch((d) =>
+          setToast(d, "Key rotate: run `agentsync key rotate` from a shell", "info"),
+        );
+      }
+      break;
+  }
+}
+
+function makeTitleBar(renderer: CliRenderer): TextRenderable {
+  return new TextRenderable(renderer, {
+    height: 1,
+    width: "100%",
+    fg: PALETTE.text,
+    bg: PALETTE.bg,
+    content: "",
+  });
+}
+function renderTitleBar(host: TextRenderable, _state: AppState): void {
+  const now = new Date();
+  const time = now.toTimeString().slice(0, 8);
+  host.content = ` agentsync · v0.1.6 · ${time}`;
+}
+
+function makeTabBar(renderer: CliRenderer): TextRenderable {
+  return new TextRenderable(renderer, {
+    height: 1,
+    width: "100%",
+    fg: PALETTE.text,
+    bg: PALETTE.bg,
+    content: "",
+  });
+}
+function renderTabBar(host: TextRenderable, state: AppState): void {
+  const parts: string[] = [];
+  TAB_IDS.forEach((id, i) => {
+    const num = i + 1;
+    const label = TAB_LABELS[id];
+    const active = id === state.activeTab;
+    const dirty = id === "vault" && state.selection.size > 0;
+    const text = `[${num}] ${label}${dirty ? "*" : ""}`;
+    parts.push(active ? `▌${text}▐` : ` ${text} `);
+  });
+  host.content = ` ${parts.join("  ")}`;
+}
+
+function makeFooter(renderer: CliRenderer): TextRenderable {
+  return new TextRenderable(renderer, {
+    height: 1,
+    width: "100%",
+    fg: PALETTE.textDim,
+    bg: PALETTE.bg,
+    content: "",
+  });
+}
+function renderFooter(host: TextRenderable, state: AppState): void {
+  const dot = state.daemon.online ? "●" : "○";
+  const daemonLabel = state.daemon.online ? "live" : "offline";
+  const running = countRunning(state);
+  const opLabel = running > 0 ? `  ${running} op(s)` : "";
+  const toast = state.toast ? `  ⟶ ${state.toast.text}` : "";
+  host.content = ` p push  l pull  r refresh  ? help  q quit            daemon ${dot} ${daemonLabel}${opLabel}${toast}`;
+}
+
+function renderActionBar(host: TextRenderable, actions: ContextAction[]): void {
+  if (actions.length === 0) {
+    host.content = "";
+    return;
+  }
+  const parts = actions.map((a) => `${a.key} ${a.label}`);
+  host.content = `  ${parts.join("   ")}`;
+}
+
+function renderActiveTab(
+  renderer: CliRenderer,
+  host: BoxRenderable,
+  store: Store,
+  ctx: AppContext,
+): void {
+  void ctx;
+  for (const child of [...host.getChildren()]) {
+    host.remove(child.id);
+  }
+  const state = store.getState();
+  if (state.helpOpen) {
+    renderHelp(renderer, host);
+  } else {
+    switch (state.activeTab) {
+      case "dashboard":
+        renderDashboard(renderer, host, state);
+        break;
+      case "vault":
+        ensureVaultLoaded(store);
+        renderVault(renderer, host, state);
+        break;
+      case "agents":
+        ensureAgentsLoaded(store);
+        renderAgents(renderer, host, state);
+        break;
+      case "migrate":
+        renderMigrate(renderer, host, state);
+        break;
+      case "activity":
+        renderActivity(renderer, host, state);
+        break;
+    }
+  }
+}
+
+function renderHelp(renderer: CliRenderer, host: BoxRenderable): void {
+  const help = [
+    "",
+    "  Global keys",
+    "    1 – 5         Jump to tab",
+    "    Tab / Sh+Tab  Cycle tabs",
+    "    p             Push vault",
+    "    l             Pull vault",
+    "    r             Refresh current tab",
+    "    ?             Toggle this overlay",
+    "    q / Ctrl-C    Quit",
+    "",
+    "  Dashboard",
+    "    i             Init wizard hint",
+    "    k             Key rotate hint",
+    "",
+    "  Vault",
+    "    ↑ / ↓         Move cursor",
+    "    space         Toggle selection (skills only)",
+    "    x             Bulk remove selected skills",
+    "",
+    "  Agents",
+    "    ↑ / ↓         Move cursor",
+    "    d             Diff focused file vs vault (planned)",
+    "",
+    "  Migrate",
+    "    Tab           Cycle From / To / Type / Preview / Apply",
+    "    ← / →         Cycle value of focused field",
+    "    Shift-P       Run preview",
+    "    Shift-A       Apply (after a matching preview)",
+    "",
+    "  Activity",
+    "    c             Clear log",
+    "",
+    "  Press any key to dismiss.",
+  ].join("\n");
+  const box = new BoxRenderable(renderer, {
+    flexGrow: 1,
+    width: "100%",
+    border: true,
+    borderColor: PALETTE.accent,
+    borderStyle: "double",
+    title: " agentsync — keymap ",
+    backgroundColor: PALETTE.panelBg,
+  });
+  box.add(new TextRenderable(renderer, { content: help, fg: PALETTE.text, bg: PALETTE.panelBg }));
+  host.add(box);
+}
+
+function contextActionsForTab(state: AppState): ContextAction[] {
+  switch (state.activeTab) {
+    case "dashboard":
+      return [
+        { key: "i", label: "init" },
+        { key: "k", label: "key rotate" },
+      ];
+    case "vault": {
+      const base = [
+        { key: "↑↓", label: "move" },
+        { key: "space", label: "select" },
+        { key: "/", label: "filter" },
+      ];
+      if (state.selection.size > 0) base.push({ key: "x", label: "remove" });
+      return base;
+    }
+    case "agents":
+      return [
+        { key: "↑↓", label: "move" },
+        { key: "enter", label: "preview" },
+        { key: "d", label: "diff vs vault" },
+      ];
+    case "migrate":
+      return [
+        { key: "tab", label: "next field" },
+        { key: "P", label: "preview" },
+        { key: "A", label: "apply" },
+      ];
+    case "activity":
+      return [{ key: "c", label: "clear" }];
+  }
+}

--- a/src/commands/tui/index.ts
+++ b/src/commands/tui/index.ts
@@ -1,0 +1,18 @@
+import { defineCommand } from "citty";
+import { runApp } from "./app";
+
+/** Launch the interactive TUI. Resolves when the user quits. */
+export async function runTui(): Promise<void> {
+  await runApp();
+}
+
+/** Explicit `agentsync tui` alias — bare `agentsync` is wired up in cli.ts. */
+export const tuiCommand = defineCommand({
+  meta: {
+    name: "tui",
+    description: "Open the interactive terminal UI",
+  },
+  async run() {
+    await runTui();
+  },
+});

--- a/src/commands/tui/lib/ipc-client.ts
+++ b/src/commands/tui/lib/ipc-client.ts
@@ -1,0 +1,59 @@
+import { resolveDaemonSocketPath } from "../../../config/paths";
+import type { DaemonStatus } from "../../../config/schema";
+import { DaemonStatusSchema } from "../../../config/schema";
+import { IpcClient } from "../../../core/ipc";
+
+/** Thin TUI-facing wrapper around the daemon IPC client. */
+export class TuiIpcClient {
+  private readonly socketPath: string;
+
+  constructor() {
+    this.socketPath = resolveDaemonSocketPath();
+  }
+
+  /**
+   * Probe the daemon's status. Returns null when the daemon is not running
+   * (ECONNREFUSED / ENOENT); throws only on unexpected errors that should
+   * surface to the user.
+   */
+  async status(): Promise<DaemonStatus | null> {
+    try {
+      const client = new IpcClient();
+      const response = await client.send("status", {}, this.socketPath);
+      if (!response.ok) return null;
+      const parsed = DaemonStatusSchema.safeParse(response.data);
+      return parsed.success ? parsed.data : null;
+    } catch (err) {
+      if (isDaemonOffline(err)) return null;
+      throw err;
+    }
+  }
+
+  async push(): Promise<{ ok: boolean; error?: string }> {
+    return this.invoke("push");
+  }
+
+  async pull(): Promise<{ ok: boolean; error?: string }> {
+    return this.invoke("pull");
+  }
+
+  private async invoke(cmd: "push" | "pull"): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const client = new IpcClient();
+      const response = await client.send(cmd, {}, this.socketPath);
+      if (response.ok) return { ok: true };
+      return { ok: false, error: response.error ?? "unknown" };
+    } catch (err) {
+      if (isDaemonOffline(err)) return { ok: false, error: "daemon-offline" };
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+function isDaemonOffline(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: string }).code;
+  if (code === "ECONNREFUSED" || code === "ENOENT") return true;
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes("ECONNREFUSED") || message.includes("ENOENT");
+}

--- a/src/commands/tui/state.ts
+++ b/src/commands/tui/state.ts
@@ -1,0 +1,170 @@
+import type { DaemonStatus } from "../../config/schema";
+
+export const TAB_IDS = ["dashboard", "vault", "agents", "migrate", "activity"] as const;
+export type TabId = (typeof TAB_IDS)[number];
+
+export const AGENTS = ["claude", "cursor", "codex", "copilot", "vscode"] as const;
+export type AgentName = (typeof AGENTS)[number];
+
+export const MIGRATE_TYPES = ["global-rules", "mcp", "commands", "skills", "rules"] as const;
+export type ConfigType = (typeof MIGRATE_TYPES)[number];
+
+export type MigrateField = "from" | "to" | "type" | "preview" | "apply";
+
+export interface ActivityEntry {
+  ts: Date;
+  kind: "push" | "pull" | "skill-rm" | "migrate" | "preview" | "error" | "info";
+  status: "ok" | "fail" | "running" | "info";
+  message: string;
+}
+
+export interface DaemonState {
+  online: boolean;
+  status: DaemonStatus | null;
+  lastError: string | null;
+  pidObservedAt: number | null;
+}
+
+export type OpKind =
+  | "push"
+  | "pull"
+  | "migrate"
+  | "migrate-preview"
+  | "skill-rm"
+  | "vault-load"
+  | "agents-load";
+
+export type OpPhase = "running" | "ok" | "error";
+
+export interface OperationStatus {
+  id: string;
+  kind: OpKind;
+  label: string;
+  startedAt: number;
+  finishedAt: number | null;
+  phase: OpPhase;
+  error: string | null;
+  meta: Record<string, unknown>;
+}
+
+export type LoadablePhase = "idle" | "loading" | "ready" | "error";
+
+export interface VaultEntry {
+  agent: string;
+  path: string;
+  absolutePath: string;
+  size: number;
+  isSkill: boolean;
+}
+
+export interface VaultSlice {
+  phase: LoadablePhase;
+  entries: VaultEntry[];
+  cursor: number;
+  error: string | null;
+}
+
+export interface AgentFile {
+  rel: string;
+  size: number;
+  mtime: number;
+}
+
+export interface AgentNode {
+  agent: string;
+  baseDir: string;
+  installed: boolean;
+  files: AgentFile[];
+}
+
+export interface AgentsSlice {
+  phase: LoadablePhase;
+  nodes: AgentNode[];
+  cursor: number;
+}
+
+export interface MigrateSlice {
+  from: AgentName;
+  toSet: Set<AgentName>;
+  type: ConfigType;
+  field: MigrateField;
+  preview: string;
+  previewKey: string | null;
+  appliedSignature: string | null;
+}
+
+export interface ContextAction {
+  key: string;
+  label: string;
+}
+
+export interface AppState {
+  activeTab: TabId;
+  daemon: DaemonState;
+  activity: ActivityEntry[];
+  selection: Set<string>;
+  toast: { text: string; level: "info" | "success" | "error"; expiresAt: number } | null;
+  helpOpen: boolean;
+  vault: VaultSlice;
+  agents: AgentsSlice;
+  migrate: MigrateSlice;
+  inFlight: Record<string, OperationStatus>;
+  opSeq: number;
+}
+
+const MAX_ACTIVITY = 200;
+
+export function createInitialState(): AppState {
+  return {
+    activeTab: "dashboard",
+    daemon: {
+      online: false,
+      status: null,
+      lastError: null,
+      pidObservedAt: null,
+    },
+    activity: [],
+    selection: new Set<string>(),
+    toast: null,
+    helpOpen: false,
+    vault: { phase: "idle", entries: [], cursor: 0, error: null },
+    agents: { phase: "idle", nodes: [], cursor: 0 },
+    migrate: {
+      from: "claude",
+      toSet: new Set<AgentName>(["cursor"]),
+      type: "global-rules",
+      field: "from",
+      preview: "",
+      previewKey: null,
+      appliedSignature: null,
+    },
+    inFlight: {},
+    opSeq: 0,
+  };
+}
+
+export function pushActivity(state: AppState, entry: Omit<ActivityEntry, "ts">): void {
+  state.activity.unshift({ ...entry, ts: new Date() });
+  if (state.activity.length > MAX_ACTIVITY) state.activity.length = MAX_ACTIVITY;
+}
+
+export function setToast(
+  state: AppState,
+  text: string,
+  level: "info" | "success" | "error" = "info",
+  ttlMs = 3000,
+): void {
+  state.toast = { text, level, expiresAt: Date.now() + ttlMs };
+}
+
+export function migrateSignature(m: MigrateSlice): string {
+  return `${m.from}→${[...m.toSet].sort().join("+")}@${m.type}`;
+}
+
+export function countRunning(state: AppState): number {
+  let n = 0;
+  for (const id in state.inFlight) {
+    if (state.inFlight[id].phase === "running") n++;
+  }
+  return n;
+}

--- a/src/commands/tui/state.ts
+++ b/src/commands/tui/state.ts
@@ -81,6 +81,7 @@ export interface AgentsSlice {
   phase: LoadablePhase;
   nodes: AgentNode[];
   cursor: number;
+  error: string | null;
 }
 
 export interface MigrateSlice {
@@ -128,7 +129,7 @@ export function createInitialState(): AppState {
     toast: null,
     helpOpen: false,
     vault: { phase: "idle", entries: [], cursor: 0, error: null },
-    agents: { phase: "idle", nodes: [], cursor: 0 },
+    agents: { phase: "idle", nodes: [], cursor: 0, error: null },
     migrate: {
       from: "claude",
       toSet: new Set<AgentName>(["cursor"]),

--- a/src/commands/tui/store.ts
+++ b/src/commands/tui/store.ts
@@ -79,6 +79,11 @@ export function createStore(initial: AppState): Store {
     opFn: () => Promise<R>,
     opts: RunOpOptions<R> = {},
   ): string {
+    if (closed) {
+      // No-op: never invoke opFn after dispose so side effects can't outlive
+      // teardown. Returns a stable sentinel id callers can ignore safely.
+      return "op-disposed";
+    }
     const id = newOpId();
     const startedAt = Date.now();
     const op: OperationStatus = {

--- a/src/commands/tui/store.ts
+++ b/src/commands/tui/store.ts
@@ -1,0 +1,174 @@
+import {
+  type AppState,
+  type OperationStatus,
+  type OpKind,
+  type OpPhase,
+  pushActivity,
+  setToast,
+} from "./state";
+
+export type Mutator = (draft: AppState) => void;
+export type Subscriber = () => void;
+
+export interface RunOpOptions<R> {
+  meta?: Record<string, unknown>;
+  toastOnStart?: { text: string; level?: "info" | "success" | "error" } | null;
+  onSuccess?: (draft: AppState, result: R) => void;
+  onError?: (draft: AppState, err: Error) => void;
+  /** When set, the terminal phase pushes an ActivityEntry with this kind. */
+  activityKind?: "push" | "pull" | "skill-rm" | "migrate" | "preview" | "info";
+  /** Override the terminal toast text; defaults to label + outcome. */
+  successToast?: string;
+  errorToastPrefix?: string;
+  /** Eviction delay for the inFlight slot once terminal. Default 2000ms. */
+  evictAfterMs?: number;
+}
+
+export interface Store {
+  getState(): Readonly<AppState>;
+  dispatch(mutator: Mutator): void;
+  subscribe(fn: Subscriber): () => void;
+  runOperation<R>(
+    kind: OpKind,
+    label: string,
+    opFn: () => Promise<R>,
+    opts?: RunOpOptions<R>,
+  ): string;
+  /**
+   * Marks the store closed. Pending eviction timers become no-ops, in-flight
+   * `opFn` results are dropped, and `dispatch` becomes a no-op. Idempotent.
+   */
+  dispose(): void;
+}
+
+const DEFAULT_EVICT_MS = 2000;
+
+export function createStore(initial: AppState): Store {
+  const state = initial;
+  const subscribers = new Set<Subscriber>();
+  const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
+  let closed = false;
+
+  function notify(): void {
+    if (closed) return;
+    for (const s of subscribers) s();
+  }
+
+  function dispatch(mutator: Mutator): void {
+    if (closed) return;
+    mutator(state);
+    notify();
+  }
+
+  function newOpId(): string {
+    state.opSeq += 1;
+    return `op-${state.opSeq}`;
+  }
+
+  function setPhase(id: string, phase: OpPhase, error: string | null): void {
+    const op = state.inFlight[id];
+    if (!op) return;
+    op.phase = phase;
+    op.error = error;
+    op.finishedAt = Date.now();
+  }
+
+  function runOperation<R>(
+    kind: OpKind,
+    label: string,
+    opFn: () => Promise<R>,
+    opts: RunOpOptions<R> = {},
+  ): string {
+    const id = newOpId();
+    const startedAt = Date.now();
+    const op: OperationStatus = {
+      id,
+      kind,
+      label,
+      startedAt,
+      finishedAt: null,
+      phase: "running",
+      error: null,
+      meta: opts.meta ?? {},
+    };
+
+    dispatch((draft) => {
+      draft.inFlight[id] = op;
+      if (opts.toastOnStart) {
+        setToast(draft, opts.toastOnStart.text, opts.toastOnStart.level ?? "info");
+      }
+      if (opts.activityKind) {
+        pushActivity(draft, {
+          kind: opts.activityKind,
+          status: "running",
+          message: label,
+        });
+      }
+    });
+
+    void (async () => {
+      try {
+        const result = await opFn();
+        dispatch((draft) => {
+          setPhase(id, "ok", null);
+          opts.onSuccess?.(draft, result);
+          if (opts.activityKind) {
+            pushActivity(draft, {
+              kind: opts.activityKind,
+              status: "ok",
+              message: opts.successToast ?? `${label} ok`,
+            });
+          }
+          if (opts.successToast) setToast(draft, opts.successToast, "success");
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        dispatch((draft) => {
+          setPhase(id, "error", message);
+          opts.onError?.(draft, err instanceof Error ? err : new Error(message));
+          if (opts.activityKind) {
+            pushActivity(draft, {
+              kind: opts.activityKind,
+              status: "fail",
+              message: `${label}: ${message}`,
+            });
+          }
+          const prefix = opts.errorToastPrefix ?? label;
+          setToast(draft, `${prefix} failed: ${message}`, "error");
+        });
+      } finally {
+        if (!closed) {
+          const ms = opts.evictAfterMs ?? DEFAULT_EVICT_MS;
+          const timer = setTimeout(() => {
+            pendingTimers.delete(timer);
+            dispatch((draft) => {
+              delete draft.inFlight[id];
+            });
+          }, ms);
+          pendingTimers.add(timer);
+        }
+      }
+    })();
+
+    return id;
+  }
+
+  function dispose(): void {
+    if (closed) return;
+    closed = true;
+    for (const t of pendingTimers) clearTimeout(t);
+    pendingTimers.clear();
+    subscribers.clear();
+  }
+
+  return {
+    getState: () => state,
+    dispatch,
+    subscribe(fn) {
+      subscribers.add(fn);
+      return () => subscribers.delete(fn);
+    },
+    runOperation,
+    dispose,
+  };
+}

--- a/src/commands/tui/tabs/activity.ts
+++ b/src/commands/tui/tabs/activity.ts
@@ -1,0 +1,49 @@
+import type { CliRenderer } from "@opentui/core";
+import { BoxRenderable, TextRenderable } from "@opentui/core";
+import type { AppState } from "../state";
+
+export function renderActivity(renderer: CliRenderer, host: BoxRenderable, state: AppState): void {
+  const wrapper = new BoxRenderable(renderer, {
+    flexDirection: "column",
+    width: "100%",
+    flexGrow: 1,
+    backgroundColor: "#11151a",
+  });
+  host.add(wrapper);
+
+  const box = new BoxRenderable(renderer, {
+    flexGrow: 1,
+    width: "100%",
+    border: true,
+    borderColor: "#3b4252",
+    borderStyle: "single",
+    title: " Activity (this session) ",
+    backgroundColor: "#11151a",
+  });
+  wrapper.add(box);
+
+  if (state.activity.length === 0) {
+    box.add(
+      new TextRenderable(renderer, {
+        content: "\n  No activity this session. Push, pull, or browse to log entries here.",
+        fg: "#6c7886",
+        bg: "#11151a",
+      }),
+    );
+    return;
+  }
+
+  const rows = state.activity.slice(0, 50).map((a) => {
+    const ts = a.ts.toTimeString().slice(0, 8);
+    const status = a.status.padEnd(7);
+    const kind = a.kind.padEnd(10);
+    return `  ${ts}  ${kind}  ${status}  ${a.message}`;
+  });
+  box.add(
+    new TextRenderable(renderer, {
+      content: rows.join("\n"),
+      fg: "#d8dee9",
+      bg: "#11151a",
+    }),
+  );
+}

--- a/src/commands/tui/tabs/agents.ts
+++ b/src/commands/tui/tabs/agents.ts
@@ -1,0 +1,168 @@
+import { readdir, stat } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import type { CliRenderer, KeyEvent } from "@opentui/core";
+import { BoxRenderable, TextRenderable } from "@opentui/core";
+import { AgentPaths } from "../../../config/paths";
+import type { AgentName, AgentNode, AppState } from "../state";
+import type { Store } from "../store";
+
+/**
+ * What each agent presents to the Agents tab. Most are directory roots that
+ * the walker recurses; vscode is a single owned file because the rest of the
+ * `Code/User/` tree is editor state we have no business surfacing.
+ */
+type AgentSurface = { kind: "dir"; path: string } | { kind: "single-file"; path: string };
+
+function surfaceForAgent(agent: AgentName): AgentSurface {
+  switch (agent) {
+    case "claude":
+      return { kind: "dir", path: dirname(AgentPaths.claude.claudeMd) };
+    case "cursor":
+      return { kind: "dir", path: dirname(AgentPaths.cursor.mcpGlobal) };
+    case "codex":
+      return { kind: "dir", path: AgentPaths.codex.root };
+    case "copilot":
+      return { kind: "dir", path: dirname(AgentPaths.copilot.instructionsFile) };
+    case "vscode":
+      // AgentSync only owns mcp.json under the VS Code user profile. The
+      // surrounding tree is editor state; recursing into it would surface
+      // unrelated files in this tab.
+      return { kind: "single-file", path: AgentPaths.vscode.mcpJson };
+  }
+}
+
+async function walk(base: string): Promise<AgentNode["files"]> {
+  const out: AgentNode["files"] = [];
+  async function rec(dir: string, prefix: string): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (name.startsWith(".") || name === "node_modules") continue;
+      const full = join(dir, name);
+      let info: Awaited<ReturnType<typeof stat>>;
+      try {
+        info = await stat(full);
+      } catch {
+        continue;
+      }
+      const rel = prefix ? `${prefix}/${name}` : name;
+      if (info.isDirectory()) {
+        await rec(full, rel);
+      } else if (info.isFile()) {
+        out.push({ rel, size: info.size, mtime: info.mtimeMs });
+      }
+    }
+  }
+  await rec(base, "");
+  return out;
+}
+
+async function loadAgents(): Promise<AgentNode[]> {
+  const order: AgentName[] = ["claude", "cursor", "codex", "copilot", "vscode"];
+  const nodes: AgentNode[] = [];
+  for (const agent of order) {
+    const surface = surfaceForAgent(agent);
+    if (surface.kind === "single-file") {
+      const info = await stat(surface.path).catch(() => null);
+      const installed = info?.isFile() === true;
+      const files = installed
+        ? [{ rel: basename(surface.path), size: info.size, mtime: info.mtimeMs }]
+        : [];
+      nodes.push({ agent, baseDir: surface.path, installed, files });
+      continue;
+    }
+    let installed = false;
+    try {
+      const info = await stat(surface.path);
+      installed = info.isDirectory();
+    } catch {
+      installed = false;
+    }
+    const files = installed ? await walk(surface.path) : [];
+    nodes.push({ agent, baseDir: surface.path, installed, files });
+  }
+  return nodes;
+}
+
+export function renderAgents(renderer: CliRenderer, host: BoxRenderable, state: AppState): void {
+  const a = state.agents;
+  const wrapper = new BoxRenderable(renderer, {
+    flexDirection: "column",
+    width: "100%",
+    flexGrow: 1,
+    backgroundColor: "#11151a",
+  });
+  host.add(wrapper);
+
+  const box = new BoxRenderable(renderer, {
+    flexGrow: 1,
+    width: "100%",
+    border: true,
+    borderColor: "#3b4252",
+    borderStyle: "single",
+    title: " Local agent content ",
+    backgroundColor: "#11151a",
+  });
+  wrapper.add(box);
+
+  if (a.phase !== "ready" || a.nodes.length === 0) {
+    box.add(
+      new TextRenderable(renderer, {
+        content: "\n  Loading agent installs…",
+        fg: "#6c7886",
+        bg: "#11151a",
+      }),
+    );
+    return;
+  }
+
+  const rows: string[] = [];
+  for (const node of a.nodes) {
+    if (!node.installed) {
+      rows.push(`  ○ ${node.agent.padEnd(8)} (${node.baseDir}) — not installed`);
+      continue;
+    }
+    rows.push(`  ● ${node.agent.padEnd(8)} (${node.baseDir})  ${node.files.length} file(s)`);
+    const shown = node.files.slice(0, 5);
+    for (const f of shown) {
+      const size = f.size < 1024 ? `${f.size}B` : `${(f.size / 1024).toFixed(1)}K`;
+      rows.push(`      ${f.rel.padEnd(50)} ${size}`);
+    }
+    if (node.files.length > shown.length) {
+      rows.push(`      … ${node.files.length - shown.length} more`);
+    }
+  }
+  box.add(
+    new TextRenderable(renderer, {
+      content: rows.join("\n"),
+      fg: "#d8dee9",
+      bg: "#11151a",
+    }),
+  );
+}
+
+export function ensureAgentsLoaded(store: Store): void {
+  const a = store.getState().agents;
+  if (a.phase === "loading" || a.phase === "ready") return;
+  store.dispatch((d) => {
+    d.agents.phase = "loading";
+  });
+  store.runOperation("agents-load", "load agent installs", () => loadAgents(), {
+    onSuccess: (draft, nodes) => {
+      draft.agents.nodes = nodes as AgentNode[];
+      draft.agents.phase = "ready";
+    },
+    onError: (draft) => {
+      draft.agents.nodes = [];
+      draft.agents.phase = "error";
+    },
+  });
+}
+
+export function onAgentsKey(_key: KeyEvent, _store: Store): boolean {
+  return false;
+}

--- a/src/commands/tui/tabs/agents.ts
+++ b/src/commands/tui/tabs/agents.ts
@@ -156,9 +156,10 @@ export function ensureAgentsLoaded(store: Store): void {
       draft.agents.nodes = nodes as AgentNode[];
       draft.agents.phase = "ready";
     },
-    onError: (draft) => {
+    onError: (draft, err) => {
       draft.agents.nodes = [];
       draft.agents.phase = "error";
+      draft.agents.error = err.message;
     },
   });
 }

--- a/src/commands/tui/tabs/dashboard.ts
+++ b/src/commands/tui/tabs/dashboard.ts
@@ -1,0 +1,88 @@
+import type { CliRenderer } from "@opentui/core";
+import { BoxRenderable, TextRenderable } from "@opentui/core";
+import { type AppState, countRunning } from "../state";
+
+function fmtDuration(ms: number): string {
+  if (ms < 1000) return "<1s";
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const remM = m - h * 60;
+  return remM > 0 ? `${h}h ${remM}m` : `${h}h`;
+}
+
+export function renderDashboard(renderer: CliRenderer, host: BoxRenderable, state: AppState): void {
+  const wrapper = new BoxRenderable(renderer, {
+    flexDirection: "column",
+    width: "100%",
+    flexGrow: 1,
+    backgroundColor: "#11151a",
+    border: false,
+  });
+  host.add(wrapper);
+
+  const banner = new TextRenderable(renderer, {
+    height: 3,
+    width: "100%",
+    fg: "#ebcb8b",
+    bg: "#11151a",
+    content: state.daemon.online
+      ? "  Welcome back. Press a tab number to drill in, or p/l to sync."
+      : "  No daemon detected. Run `agentsync daemon start` to enable live sync, or browse offline.",
+  });
+  wrapper.add(banner);
+
+  // Daemon panel
+  const daemonPid = state.daemon.status?.pid ?? "—";
+  const daemonFails = state.daemon.status?.consecutiveFailures ?? 0;
+  const daemonLastErr = state.daemon.status?.lastError ?? "—";
+  const uptime =
+    state.daemon.online && state.daemon.pidObservedAt
+      ? fmtDuration(Date.now() - state.daemon.pidObservedAt)
+      : "—";
+  const running = countRunning(state);
+  const daemonText = [
+    "",
+    `  status   ${state.daemon.online ? "● running" : "○ stopped"}`,
+    `  pid      ${daemonPid}`,
+    `  uptime   ${uptime} (since this TUI started)`,
+    `  fails    ${daemonFails}`,
+    `  lastErr  ${daemonLastErr}`,
+    `  inFlight ${running > 0 ? `${running} op(s) running` : "idle"}`,
+    "",
+  ].join("\n");
+  const daemonBox = new BoxRenderable(renderer, {
+    height: 10,
+    width: "100%",
+    border: true,
+    borderColor: "#3b4252",
+    borderStyle: "single",
+    title: " Daemon ",
+    backgroundColor: "#11151a",
+  });
+  daemonBox.add(
+    new TextRenderable(renderer, {
+      content: daemonText,
+      fg: "#d8dee9",
+      bg: "#11151a",
+    }),
+  );
+  wrapper.add(daemonBox);
+
+  // Hint panel
+  const hint = new TextRenderable(renderer, {
+    height: 4,
+    width: "100%",
+    fg: "#6c7886",
+    bg: "#11151a",
+    content: [
+      "",
+      "  [2] Vault   browse encrypted entries by agent",
+      "  [3] Agents  inspect what each local agent has on disk",
+      "  [4] Migrate translate config from one agent to another",
+    ].join("\n"),
+  });
+  wrapper.add(hint);
+}

--- a/src/commands/tui/tabs/migrate.ts
+++ b/src/commands/tui/tabs/migrate.ts
@@ -1,0 +1,271 @@
+import type { CliRenderer, KeyEvent } from "@opentui/core";
+import { BoxRenderable, TextRenderable } from "@opentui/core";
+import { performMigrate } from "../../../migrate/migrate";
+import {
+  AGENTS,
+  type AgentName,
+  type AppState,
+  type ConfigType,
+  MIGRATE_TYPES,
+  type MigrateField,
+  migrateSignature,
+  setToast,
+} from "../state";
+import type { Store } from "../store";
+
+const FIELDS: MigrateField[] = ["from", "to", "type", "preview", "apply"];
+
+export function renderMigrate(renderer: CliRenderer, host: BoxRenderable, state: AppState): void {
+  const m = state.migrate;
+  const wrapper = new BoxRenderable(renderer, {
+    flexDirection: "column",
+    width: "100%",
+    flexGrow: 1,
+    backgroundColor: "#11151a",
+  });
+  host.add(wrapper);
+
+  const focusMark = (f: MigrateField) => (m.field === f ? "▶" : " ");
+  const radio = (sel: boolean) => (sel ? "(●)" : "( )");
+  const check = (sel: boolean) => (sel ? "[x]" : "[ ]");
+
+  const fromRow = `${focusMark("from")}  From:  ${AGENTS.map((a) => `${radio(a === m.from)} ${a}`).join("  ")}`;
+  const toRow = `${focusMark("to")}  To:    ${AGENTS.map((a) => `${check(m.toSet.has(a))} ${a}`).join("  ")}`;
+  const typeRow = `${focusMark("type")}  Type:  ${MIGRATE_TYPES.map((t) => `${radio(t === m.type)} ${t}`).join("  ")}`;
+
+  const sig = migrateSignature(m);
+  const previewRunning = anyOp(state, "migrate-preview", "running");
+  const applyRunning = anyOp(state, "migrate", "running");
+  const previewIsValid = m.previewKey === sig && !previewRunning;
+
+  const previewLabel = previewRunning
+    ? "[ Preview… ]"
+    : previewIsValid
+      ? "[ Preview ✓ ]"
+      : "[ Preview ]";
+  const applyLabel = applyRunning
+    ? "[ Apply… ]"
+    : previewIsValid
+      ? "[ Apply ]"
+      : "[ Apply (preview first) ]";
+
+  const formText = [
+    "",
+    fromRow,
+    "",
+    toRow,
+    "",
+    typeRow,
+    "",
+    `${focusMark("preview")}  ${previewLabel}        ${focusMark("apply")}  ${applyLabel}`,
+    "",
+    "  Tab / Shift-Tab move between fields. Arrow keys or space change values.",
+    "  Enter activates the Preview / Apply button.",
+  ].join("\n");
+
+  const formBox = new BoxRenderable(renderer, {
+    height: 14,
+    width: "100%",
+    border: true,
+    borderColor: "#3b4252",
+    borderStyle: "single",
+    title: " Migrate ",
+    backgroundColor: "#11151a",
+  });
+  formBox.add(
+    new TextRenderable(renderer, {
+      content: formText,
+      fg: "#d8dee9",
+      bg: "#11151a",
+    }),
+  );
+  wrapper.add(formBox);
+
+  const previewBox = new BoxRenderable(renderer, {
+    flexGrow: 1,
+    width: "100%",
+    border: true,
+    borderColor: "#3b4252",
+    borderStyle: "single",
+    title: " Preview ",
+    backgroundColor: "#11151a",
+  });
+  previewBox.add(
+    new TextRenderable(renderer, {
+      content: m.preview || "  (no preview yet — press P or Tab to the Preview button and Enter)",
+      fg: previewIsValid ? "#a3be8c" : "#6c7886",
+      bg: "#11151a",
+    }),
+  );
+  wrapper.add(previewBox);
+}
+
+export function onMigrateKey(key: KeyEvent, store: Store): boolean {
+  const state = store.getState();
+  const m = state.migrate;
+
+  if (key.name === "tab") {
+    store.dispatch((d) => {
+      const i = FIELDS.indexOf(d.migrate.field);
+      d.migrate.field = FIELDS[(i + (key.shift ? -1 : 1) + FIELDS.length) % FIELDS.length];
+    });
+    return true;
+  }
+
+  if (key.name === "left" || key.name === "right") {
+    return cycleValue(store, key.name === "right");
+  }
+
+  if (key.name === "space" && m.field === "to") {
+    return cycleValue(store, true);
+  }
+
+  if (key.name === "return") {
+    if (m.field === "preview") {
+      runPreview(store);
+      return true;
+    }
+    if (m.field === "apply") {
+      runApply(store);
+      return true;
+    }
+  }
+
+  if (key.shift && key.name === "p") {
+    runPreview(store);
+    return true;
+  }
+  if (key.shift && key.name === "a") {
+    runApply(store);
+    return true;
+  }
+  return false;
+}
+
+function cycleValue(store: Store, forward: boolean): boolean {
+  const m = store.getState().migrate;
+  switch (m.field) {
+    case "from": {
+      store.dispatch((d) => {
+        const i = AGENTS.indexOf(d.migrate.from);
+        d.migrate.from = AGENTS[(i + (forward ? 1 : -1) + AGENTS.length) % AGENTS.length];
+        d.migrate.previewKey = null;
+      });
+      return true;
+    }
+    case "to": {
+      store.dispatch((d) => {
+        const sorted = [...d.migrate.toSet].sort();
+        const last = sorted[sorted.length - 1] as AgentName | undefined;
+        const i = last ? AGENTS.indexOf(last) : -1;
+        const next = AGENTS[(i + (forward ? 1 : -1) + AGENTS.length) % AGENTS.length];
+        if (d.migrate.toSet.has(next)) d.migrate.toSet.delete(next);
+        else d.migrate.toSet.add(next);
+        d.migrate.previewKey = null;
+      });
+      return true;
+    }
+    case "type": {
+      store.dispatch((d) => {
+        const i = MIGRATE_TYPES.indexOf(d.migrate.type);
+        d.migrate.type =
+          MIGRATE_TYPES[(i + (forward ? 1 : -1) + MIGRATE_TYPES.length) % MIGRATE_TYPES.length];
+        d.migrate.previewKey = null;
+      });
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+function migrateArgs(
+  m: AppState["migrate"],
+  dryRun: boolean,
+): { from: AgentName; to: string; type: ConfigType; dryRun: boolean } {
+  return {
+    from: m.from,
+    to: m.toSet.size === AGENTS.length ? "all" : [...m.toSet].sort().join(","),
+    type: m.type,
+    dryRun,
+  };
+}
+
+function runPreview(store: Store): void {
+  const m = store.getState().migrate;
+  if (m.toSet.size === 0) {
+    store.dispatch((d) => setToast(d, "Select at least one target agent", "error"));
+    return;
+  }
+  const sig = migrateSignature(m);
+  store.runOperation(
+    "migrate-preview",
+    `preview ${sig}`,
+    () => performMigrate(migrateArgs(m, true) as never),
+    {
+      meta: { sig },
+      activityKind: "preview",
+      onSuccess: (draft, result) => {
+        const lines: string[] = [];
+        const r = result as {
+          migrated: { targetPath: string }[];
+          skipped: { reason: string }[];
+          errors: string[];
+        };
+        for (const x of r.migrated) lines.push(`  + ${x.targetPath}`);
+        for (const s of r.skipped) lines.push(`  ~ skipped (${s.reason})`);
+        for (const e of r.errors) lines.push(`  ! ${e}`);
+        if (lines.length === 0) lines.push("  Nothing to migrate.");
+        draft.migrate.preview = lines.join("\n");
+        draft.migrate.previewKey = sig;
+        setToast(draft, "Preview ready", "success");
+      },
+      onError: (draft, err) => {
+        draft.migrate.preview = `  Error: ${err.message}`;
+        draft.migrate.previewKey = null;
+      },
+      errorToastPrefix: "Preview",
+    },
+  );
+}
+
+function runApply(store: Store): void {
+  const m = store.getState().migrate;
+  const sig = migrateSignature(m);
+  if (m.previewKey !== sig) {
+    store.dispatch((d) => setToast(d, "Preview the current form before applying", "error"));
+    return;
+  }
+  if (m.appliedSignature === sig) {
+    store.dispatch((d) => setToast(d, "Already applied. Change form to migrate again.", "info"));
+    return;
+  }
+  store.runOperation(
+    "migrate",
+    `apply ${sig}`,
+    () => performMigrate(migrateArgs(m, false) as never),
+    {
+      meta: { sig },
+      activityKind: "migrate",
+      onSuccess: (draft, result) => {
+        const r = result as {
+          migrated: unknown[];
+          skipped: unknown[];
+          errors: string[];
+        };
+        const okMsg = `Applied: ${r.migrated.length} written, ${r.skipped.length} skipped`;
+        setToast(draft, okMsg, r.errors.length === 0 ? "success" : "error");
+        draft.migrate.appliedSignature = sig;
+      },
+      errorToastPrefix: "Apply",
+    },
+  );
+}
+
+function anyOp(state: AppState, kind: string, phase: string): boolean {
+  for (const id in state.inFlight) {
+    const op = state.inFlight[id];
+    if (op.kind === kind && op.phase === phase) return true;
+  }
+  return false;
+}

--- a/src/commands/tui/tabs/migrate.ts
+++ b/src/commands/tui/tabs/migrate.ts
@@ -1,11 +1,12 @@
 import type { CliRenderer, KeyEvent } from "@opentui/core";
 import { BoxRenderable, TextRenderable } from "@opentui/core";
+import type { MigrateOptions } from "../../../config/schema";
 import { performMigrate } from "../../../migrate/migrate";
+import type { MigrateResult } from "../../../migrate/types";
 import {
   AGENTS,
   type AgentName,
   type AppState,
-  type ConfigType,
   MIGRATE_TYPES,
   type MigrateField,
   migrateSignature,
@@ -179,16 +180,32 @@ function cycleValue(store: Store, forward: boolean): boolean {
   }
 }
 
-function migrateArgs(
+/**
+ * `performMigrate` accepts a single agent or "all", not a comma list, so the
+ * multi-select Migrate tab fans out one call per target and merges results.
+ * Returns the aggregated MigrateResult (migrated/skipped/errors concatenated).
+ */
+async function runMigrateForSelection(
   m: AppState["migrate"],
   dryRun: boolean,
-): { from: AgentName; to: string; type: ConfigType; dryRun: boolean } {
-  return {
-    from: m.from,
-    to: m.toSet.size === AGENTS.length ? "all" : [...m.toSet].sort().join(","),
-    type: m.type,
-    dryRun,
-  };
+): Promise<MigrateResult> {
+  const aggregate: MigrateResult = { migrated: [], skipped: [], errors: [], warnings: [] };
+  const targets: ("all" | AgentName)[] =
+    m.toSet.size === AGENTS.length ? ["all"] : [...m.toSet].sort();
+  for (const target of targets) {
+    const options: MigrateOptions = {
+      from: m.from,
+      to: target,
+      type: m.type,
+      dryRun,
+    };
+    const r = await performMigrate(options);
+    aggregate.migrated.push(...r.migrated);
+    aggregate.skipped.push(...r.skipped);
+    aggregate.errors.push(...r.errors);
+    aggregate.warnings.push(...r.warnings);
+  }
+  return aggregate;
 }
 
 function runPreview(store: Store): void {
@@ -198,23 +215,18 @@ function runPreview(store: Store): void {
     return;
   }
   const sig = migrateSignature(m);
-  store.runOperation(
+  store.runOperation<MigrateResult>(
     "migrate-preview",
     `preview ${sig}`,
-    () => performMigrate(migrateArgs(m, true) as never),
+    () => runMigrateForSelection(m, true),
     {
       meta: { sig },
       activityKind: "preview",
       onSuccess: (draft, result) => {
         const lines: string[] = [];
-        const r = result as {
-          migrated: { targetPath: string }[];
-          skipped: { reason: string }[];
-          errors: string[];
-        };
-        for (const x of r.migrated) lines.push(`  + ${x.targetPath}`);
-        for (const s of r.skipped) lines.push(`  ~ skipped (${s.reason})`);
-        for (const e of r.errors) lines.push(`  ! ${e}`);
+        for (const x of result.migrated) lines.push(`  + ${x.targetPath}`);
+        for (const s of result.skipped) lines.push(`  ~ skipped (${s.reason})`);
+        for (const e of result.errors) lines.push(`  ! ${e}`);
         if (lines.length === 0) lines.push("  Nothing to migrate.");
         draft.migrate.preview = lines.join("\n");
         draft.migrate.previewKey = sig;
@@ -240,21 +252,16 @@ function runApply(store: Store): void {
     store.dispatch((d) => setToast(d, "Already applied. Change form to migrate again.", "info"));
     return;
   }
-  store.runOperation(
+  store.runOperation<MigrateResult>(
     "migrate",
     `apply ${sig}`,
-    () => performMigrate(migrateArgs(m, false) as never),
+    () => runMigrateForSelection(m, false),
     {
       meta: { sig },
       activityKind: "migrate",
       onSuccess: (draft, result) => {
-        const r = result as {
-          migrated: unknown[];
-          skipped: unknown[];
-          errors: string[];
-        };
-        const okMsg = `Applied: ${r.migrated.length} written, ${r.skipped.length} skipped`;
-        setToast(draft, okMsg, r.errors.length === 0 ? "success" : "error");
+        const okMsg = `Applied: ${result.migrated.length} written, ${result.skipped.length} skipped`;
+        setToast(draft, okMsg, result.errors.length === 0 ? "success" : "error");
         draft.migrate.appliedSignature = sig;
       },
       errorToastPrefix: "Apply",

--- a/src/commands/tui/tabs/vault.ts
+++ b/src/commands/tui/tabs/vault.ts
@@ -1,0 +1,230 @@
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { CliRenderer, KeyEvent } from "@opentui/core";
+import { BoxRenderable, TextRenderable } from "@opentui/core";
+import { resolveRuntimeContext } from "../../shared";
+import { performSkillRemove } from "../../skill";
+import type { AppState, VaultEntry } from "../state";
+import type { Store } from "../store";
+
+async function loadEntries(): Promise<VaultEntry[]> {
+  // Single source of truth for vault dir + key path resolution. Any future
+  // env-var or config indirection lands in resolveRuntimeContext and this
+  // loader picks it up for free.
+  const { vaultDir } = await resolveRuntimeContext();
+  const out: VaultEntry[] = [];
+
+  async function walk(dir: string, relParts: string[]): Promise<void> {
+    let names: string[];
+    try {
+      names = await readdir(dir);
+    } catch {
+      return;
+    }
+    for (const name of names) {
+      if (name.startsWith(".")) continue;
+      const full = join(dir, name);
+      let info: Awaited<ReturnType<typeof stat>>;
+      try {
+        info = await stat(full);
+      } catch {
+        continue;
+      }
+      if (info.isDirectory()) {
+        await walk(full, [...relParts, name]);
+      } else if (info.isFile() && (name.endsWith(".age") || name.endsWith(".tar.age"))) {
+        const agent = relParts[0] ?? "(root)";
+        const rel = [...relParts, name].join("/");
+        const isSkill = relParts.includes("skills");
+        out.push({ agent, path: rel, absolutePath: full, size: info.size, isSkill });
+      }
+    }
+  }
+
+  await walk(vaultDir, []);
+  return out.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function renderVault(renderer: CliRenderer, host: BoxRenderable, state: AppState): void {
+  const v = state.vault;
+
+  const wrapper = new BoxRenderable(renderer, {
+    flexDirection: "column",
+    width: "100%",
+    flexGrow: 1,
+    backgroundColor: "#11151a",
+  });
+  host.add(wrapper);
+
+  const listBox = new BoxRenderable(renderer, {
+    flexGrow: 1,
+    width: "100%",
+    border: true,
+    borderColor: "#3b4252",
+    borderStyle: "single",
+    title: " Vault entries ",
+    backgroundColor: "#11151a",
+  });
+  wrapper.add(listBox);
+
+  if (v.phase === "error") {
+    listBox.add(
+      new TextRenderable(renderer, {
+        content: `  Cannot list vault: ${v.error}\n  Run \`agentsync init\` first.`,
+        fg: "#bf616a",
+        bg: "#11151a",
+      }),
+    );
+    return;
+  }
+
+  if (v.phase === "loading" || v.phase === "idle") {
+    listBox.add(
+      new TextRenderable(renderer, {
+        content: "\n  Loading vault entries…",
+        fg: "#6c7886",
+        bg: "#11151a",
+      }),
+    );
+    return;
+  }
+
+  if (v.entries.length === 0) {
+    listBox.add(
+      new TextRenderable(renderer, {
+        content:
+          "\n  Vault is empty (or daemon hasn't snapshotted yet).\n  Press p to push your local agent configs.",
+        fg: "#6c7886",
+        bg: "#11151a",
+      }),
+    );
+    return;
+  }
+
+  const rows: string[] = [];
+  let lastAgent = "";
+  for (let i = 0; i < v.entries.length; i++) {
+    const e = v.entries[i];
+    if (e.agent !== lastAgent) {
+      rows.push(`  ${e.agent}/`);
+      lastAgent = e.agent;
+    }
+    const sel = state.selection.has(e.absolutePath) ? "[x]" : e.isSkill ? "[ ]" : "   ";
+    const marker = i === v.cursor ? "▶" : " ";
+    const size = e.size < 1024 ? `${e.size}B` : `${(e.size / 1024).toFixed(1)}K`;
+    rows.push(`  ${marker} ${sel} ${e.path.padEnd(48)} ${size}`);
+  }
+
+  listBox.add(
+    new TextRenderable(renderer, {
+      content: rows.join("\n"),
+      fg: "#d8dee9",
+      bg: "#11151a",
+    }),
+  );
+}
+
+/** Kicks off a vault load via the store. No-op when already loading or ready. */
+export function ensureVaultLoaded(store: Store): void {
+  const v = store.getState().vault;
+  if (v.phase === "loading" || v.phase === "ready") return;
+  store.dispatch((d) => {
+    d.vault.phase = "loading";
+    d.vault.error = null;
+  });
+  store.runOperation("vault-load", "load vault entries", () => loadEntries(), {
+    onSuccess: (draft, entries) => {
+      const list = entries as VaultEntry[];
+      draft.vault.entries = list;
+      draft.vault.cursor = Math.min(draft.vault.cursor, Math.max(0, list.length - 1));
+      draft.vault.phase = "ready";
+      draft.vault.error = null;
+    },
+    onError: (draft, err) => {
+      draft.vault.phase = "error";
+      draft.vault.error = err.message;
+    },
+  });
+}
+
+export function onVaultKey(key: KeyEvent, store: Store): boolean {
+  const state = store.getState();
+  const v = state.vault;
+  if (v.entries.length === 0) return false;
+
+  if (key.name === "up") {
+    store.dispatch((d) => {
+      d.vault.cursor = Math.max(0, d.vault.cursor - 1);
+    });
+    return true;
+  }
+  if (key.name === "down") {
+    store.dispatch((d) => {
+      d.vault.cursor = Math.min(d.vault.entries.length - 1, d.vault.cursor + 1);
+    });
+    return true;
+  }
+  if (key.name === "space") {
+    const cur = v.entries[v.cursor];
+    if (cur?.isSkill) {
+      store.dispatch((d) => {
+        if (d.selection.has(cur.absolutePath)) d.selection.delete(cur.absolutePath);
+        else d.selection.add(cur.absolutePath);
+      });
+      return true;
+    }
+    return false;
+  }
+  if (key.name === "x" && state.selection.size > 0) {
+    runBulkSkillRemove(store);
+    return true;
+  }
+  return false;
+}
+
+function runBulkSkillRemove(store: Store): void {
+  const state = store.getState();
+  // The walker already carries `agent` and the relative vault path on
+  // VaultEntry. Looking the entry up by `absolutePath` keeps removal honest
+  // even if the vault subtree layout changes (e.g. nested plugin skills),
+  // and avoids hand-rolled path slicing that would mis-attribute a deletion.
+  const byAbs = new Map(state.vault.entries.map((e) => [e.absolutePath, e]));
+  const items: { agent: string; name: string }[] = [];
+  for (const abs of state.selection) {
+    const entry = byAbs.get(abs);
+    if (!entry?.isSkill) continue;
+    const fileName = entry.path.split("/").pop() ?? "";
+    const name = fileName.replace(/\.tar\.age$/, "");
+    if (entry.agent && name) items.push({ agent: entry.agent, name });
+  }
+  if (items.length === 0) return;
+
+  store.runOperation(
+    "skill-rm",
+    `remove ${items.length} skill(s)`,
+    async () => {
+      let ok = 0;
+      let fail = 0;
+      for (const item of items) {
+        const r = await performSkillRemove(item);
+        if (r.status === "success") ok++;
+        else fail++;
+      }
+      return { ok, fail };
+    },
+    {
+      activityKind: "skill-rm",
+      onSuccess: (draft, result) => {
+        const { ok, fail } = result as { ok: number; fail: number };
+        draft.selection.clear();
+        draft.vault.phase = "idle";
+        const text = `Removed ${ok} skill(s)${fail > 0 ? `, ${fail} failed` : ""}`;
+        draft.toast = {
+          text,
+          level: fail === 0 ? "success" : "error",
+          expiresAt: Date.now() + 3000,
+        };
+      },
+    },
+  );
+}

--- a/src/daemon/__tests__/installer-linux.test.ts
+++ b/src/daemon/__tests__/installer-linux.test.ts
@@ -67,7 +67,15 @@ mock.module("node:child_process", () => ({
   execFile: execFileMock,
 }));
 
+// Spread the real fs/promises so unrelated exports (stat, readdir, etc.)
+// remain available to modules loaded in other test files that share Bun's
+// module cache during a multi-file run. Without this, the mock returns a
+// 4-key object and any subsequent `import { stat } from "node:fs/promises"`
+// (e.g. from src/commands/destroy.test.ts) errors with
+// `Export named 'stat' not found`.
+const actualFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
 mock.module("node:fs/promises", () => ({
+  ...actualFsPromises,
   mkdir: async () => {},
   writeFile: async (path: string, content: string | Uint8Array) => {
     fsWrites.set(path, typeof content === "string" ? content : (content as Buffer).toString());
@@ -96,6 +104,13 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+  // Re-mock back to the real implementations BEFORE mock.restore() so any
+  // test file loaded later in the same Bun run sees an unmocked fs/promises.
+  // mock.restore() alone leaves the cached fs/promises pointing at our
+  // override, which breaks unrelated tests that call readFile/stat
+  // (e.g. destroy.test.ts going through loadConfig).
+  mock.module("node:fs/promises", () => actualFsPromises);
+  mock.module("node:child_process", () => actualChildProcess);
   mock.restore();
 });
 

--- a/src/test-helpers/fixtures.ts
+++ b/src/test-helpers/fixtures.ts
@@ -86,7 +86,13 @@ export async function createAgeIdentity(): Promise<{
  */
 export async function createBareRepo(dir: string): Promise<string> {
   const repoPath = join(dir, "remote.git");
-  const result = Bun.spawnSync(["git", "init", "--bare", repoPath]);
+  // Pin the initial branch so the bare repo's HEAD symref matches whatever
+  // the seed pushes regardless of the host git's init.defaultBranch
+  // (varies between Ubuntu CI and macOS local). Without this, `git rev-parse
+  // HEAD` on the bare repo can return the literal string "HEAD" instead of
+  // a resolved sha, surfacing as confusing "Expected: not HEAD" test
+  // failures only on CI.
+  const result = Bun.spawnSync(["git", "init", "--bare", "--initial-branch=main", repoPath]);
   if (result.exitCode !== 0) {
     throw new Error(`git init --bare failed: ${new TextDecoder().decode(result.stderr)}`);
   }


### PR DESCRIPTION
## Summary

This branch lands three concurrent efforts that were sitting uncommitted on `main` and reshapes two architectural surfaces along the way:

1. **TUI subtree** (`src/commands/tui/`) — interactive dashboard with vault/agents/migrate/activity tabs over the daemon IPC.
2. **`destroy` command** — multi-confirmation vault teardown with three scopes (local, remote, all).
3. **Architecture-lens refactor** of two pre-existing seams:
   - **Unified Store + `runOperation`** (TUI): replaces per-tab module-level `tabState` with one `AppState` slice graph and an `inFlight` op registry. Cross-tab visibility is instant, no longer poll-bound.
   - **`defineFileArtifact` + `runApplyPlan`** (agents): collapses ~400 LOC of duplicated walk → decrypt → filename-dispatch across the five agent adapters into a declarative plan plus one shared dispatcher.

Plus the docs/CLI/build work that accumulated alongside (CLAUDE.md, README, docs/, package.json/bun.lock, init.ts/key.ts refactors).

## Changes

### Apply-vault refactor (agents)

- `src/agents/_apply.ts` (new, 156 LOC) — `FileArtifact` / `DirArtifact` / `EscapeHatch` directives + `runApplyPlan` dispatcher.
- `src/agents/{claude,cursor,codex,copilot,vscode}/index.ts` — `applyXxxVault` rewritten as `ApplyPlan` data. Five copies of `readAgeFiles` deleted.
- `src/agents/__tests__/_apply.test.ts` — 13 tests covering walker, dispatch ordering, dry-run, suffix-stripping, `match`/`filter`/`enabled` predicates, and escape-hatch contract.

### TUI Unified Store

- `src/commands/tui/state.ts` — added `OperationStatus`, `LoadablePhase`, per-tab slices (`vault`, `agents`, `migrate`), `inFlight` map.
- `src/commands/tui/store.ts` (new) — `createStore` with `dispatch` / `subscribe` / `runOperation` / `dispose`.
- `src/commands/tui/app.ts` — store-driven render loop, `invokeDaemonOp` going through `runOperation`, `contextActions` derived in render (not stored).
- `src/commands/tui/tabs/{migrate,vault,agents,dashboard}.ts` — all module-level `tabState` deleted; pure render-from-state + key handlers operating on the store.
- `src/commands/tui/__tests__/store.test.ts` + `cross-tab.test.ts` — 16 tests for atomicity, dispose semantics, cross-tab visibility.

### `destroy` command

- `src/commands/destroy.ts` + tests + `src/cli.ts` wire-up. Three scopes, three confirmation gates, agent-files-never-touched invariant enforced both by construction (no `AgentPaths` import in destroy.ts) and by three sha256+mtime tests.

### Docs / housekeeping

- `README.md`, `CLAUDE.md`, `docs/{architecture,commands,migrate,operations,contributing}.md` updated for new commands and conventions.
- `package.json` / `bun.lock` / `scripts/build*.ts` adjustments.
- `src/commands/{init,key}.ts` reshape (existing churn, picked up here).

### Architecture

```mermaid
flowchart TD
  subgraph BEFORE
    direction TB
    bClaude[applyClaudeVault<br/>~120 LOC]:::dup
    bCodex[applyCodexVault<br/>~75 LOC]:::dup
    bCursor[applyCursorVault<br/>~75 LOC]:::dup
    bCopilot[applyCopilotVault<br/>~95 LOC]:::dup
    bVscode[applyVsCodeVault<br/>~25 LOC]:::dup
    bClaude --> bWalk[hand-rolled<br/>readdir + decrypt<br/>+ if-chain]:::warn
    bCodex --> bWalk
    bCursor --> bWalk
    bCopilot --> bWalk
    bVscode --> bWalk
    bWalk --> bSpec[specialist handlers<br/>package-private]:::ok
  end
  classDef dup fill:#5a1f1f,stroke:#ffb4b4,color:#ffffff
  classDef warn fill:#7a4a1f,stroke:#ffd9a8,color:#ffffff
  classDef ok fill:#1f5a2f,stroke:#b4ffc4,color:#ffffff
```

```mermaid
flowchart TD
  subgraph AFTER
    direction TB
    aClaude[claude plan<br/>declarative]:::lean
    aCodex[codex plan<br/>declarative]:::lean
    aCursor[cursor plan<br/>declarative]:::lean
    aCopilot[copilot plan<br/>declarative]:::lean
    aVscode[vscode plan<br/>1 directive]:::lean
    aClaude --> aRuntime
    aCodex --> aRuntime
    aCursor --> aRuntime
    aCopilot --> aRuntime
    aVscode --> aRuntime
    aRuntime[runApplyPlan<br/>walk + decrypt + dryrun<br/>+ path-safety]:::core
    aRuntime --> aSpec[specialist handlers<br/>exported, reusable]:::ok
  end
  classDef lean fill:#1f3a5a,stroke:#b4d4ff,color:#ffffff
  classDef core fill:#3a1f5a,stroke:#d4b4ff,color:#ffffff
  classDef ok fill:#1f5a2f,stroke:#b4ffc4,color:#ffffff
```

```mermaid
flowchart LR
  subgraph TUIbefore
    direction TB
    bMigrate[migrate.ts<br/>tabState locals]:::scatter
    bVault[vault.ts<br/>tabState locals]:::scatter
    bAgents[agents.ts<br/>tabState locals]:::scatter
    bApp[AppState<br/>polled only]:::poll
    bMigrate -.-> bApp
    bVault -.-> bApp
    bAgents -.-> bApp
    bApp -.->|1.5s poll| bDaemon[daemon IPC]:::ipc
  end
  classDef scatter fill:#5a1f1f,stroke:#ffb4b4,color:#ffffff
  classDef poll fill:#7a4a1f,stroke:#ffd9a8,color:#ffffff
  classDef ipc fill:#1f3a5a,stroke:#b4d4ff,color:#ffffff
```

```mermaid
flowchart LR
  subgraph TUIafter
    direction TB
    aMigrate[migrate.ts<br/>pure render]:::pure
    aVault[vault.ts<br/>pure render]:::pure
    aAgents[agents.ts<br/>pure render]:::pure
    aStore[AppState slices<br/>plus inFlight ops]:::store
    aRunOp[runOperation<br/>dispatcher]:::core
    aMigrate --> aStore
    aVault --> aStore
    aAgents --> aStore
    aStore --> aSubs[subscribers<br/>render on dispatch]:::pure
    aMigrate -->|async work| aRunOp
    aVault -->|async work| aRunOp
    aRunOp --> aStore
    aRunOp -->|when daemon-bound| aDaemon[daemon IPC]:::ipc
  end
  classDef pure fill:#1f5a2f,stroke:#b4ffc4,color:#ffffff
  classDef store fill:#3a1f5a,stroke:#d4b4ff,color:#ffffff
  classDef core fill:#1f3a5a,stroke:#b4d4ff,color:#ffffff
  classDef ipc fill:#37474f,stroke:#cfd8dc,color:#ffffff
```

## Test Evidence

- `bun run check` (typecheck + biome ci + bun test + docs ownership) — all green.
- **660 tests pass, 0 fail** (was 631 on `main`; +29 covering the new modules):
  - 16 store tests (`runOperation` atomicity, hooks, eviction, dispose semantics).
  - 13 `_apply.ts` tests (walker, dispatch, dry-run, match/filter/enabled, escape hatch, `warnOnUnknownTopLevel`).
- `src/agents/_apply.ts`: 97% line / 100% function coverage.
- Two iterations of senior review ran via subagents. Iter 1 surfaced 20 findings → 6 applied (blocker context-actions slice; major dispose; major hardcoded paths violating CLAUDE.md; major path-slicing in vault-bulk-rm; architecture vault-dir routing; dead suffix check). Iter 2 surfaced 6 → 4 applied (vscode walk overshoot — corrected by special-casing the single-file surface; dispose test coverage; tighter `AgentName` typing; clarified destroy walker comment to match actual behaviour).

## Risks / Follow-ups

- **Pre-existing TUI UX issue** with multi-select on the Migrate `to` field is unchanged here — the `←/→` directional toggle is the same as before the refactor. Tracked for a separate UX pass.
- **`exitOnCtrlC: true`** in the OpenTUI renderer can short-circuit `store.dispose()` on Ctrl+C. Practical effect is nil (process exits anyway). Optional follow-up: flip to `false` and route Ctrl+C through `quitResolver`.
- **Aggregated apply errors** were *not* adopted in this refactor (rejected design 1B from the architecture lens). Apply still fails fast on the first bad artifact. A future PR can introduce error aggregation as a deliberate behaviour change with its own design discussion.
- **Apply-plan `enabled() + dryRun`** behaviour is "silent skip" — matches pre-refactor behaviour for `claude marketplace.json` but isn't pinned by a dedicated test. Add one when next touching the marketplace gate.

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Interactive TUI: Running `agentsync` with no arguments now launches an interactive terminal interface for vault browsing, agent management, push/pull operations, and migrations.
  * Destroy command: Added `agentsync destroy` for wiping vault contents with multi-stage safety confirmations, supporting local-only, remote-only, or full wipe modes.
  * Non-interactive fallback: Scripts and automation default to `status` output when stdout isn't a TTY.

* **Documentation**
  * Updated quickstart to emphasize TUI as the default entry point.
  * Added comprehensive command documentation and troubleshooting guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->