### PR TITLE
feat(packaging): cross-compile a Windows binary and document PowerShell verification

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -80,6 +80,9 @@ jobs:
           - os: macos-latest
             target: agentsync-macos-x64
             bun_target: bun-darwin-x64
+          - os: ubuntu-latest
+            target: agentsync-windows-x64.exe
+            bun_target: bun-windows-x64
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -133,6 +133,16 @@ shasum -a 256 -c agentsync-linux-x64.sha256
 
 A line ending in `OK` means the bytes you downloaded match the bytes the release job hashed. Anything else aborts the install. The `.sha256` file lists the binary by its release filename, so keep the downloaded filename unchanged (or update the first column of the `.sha256` to whatever you renamed it to) before running `-c`.
 
+Windows ships neither `shasum` nor `sha256sum` by default. Use PowerShell's `Get-FileHash` and compare against the first column of the downloaded `.sha256` file:
+
+```powershell
+$expected = (Get-Content agentsync-windows-x64.exe.sha256).Split(' ')[0]
+$actual   = (Get-FileHash agentsync-windows-x64.exe -Algorithm SHA256).Hash.ToLower()
+if ($expected -eq $actual) { "OK" } else { throw "checksum mismatch" }
+```
+
+In a CI script that needs a non-zero exit on mismatch, replace `throw` with `Write-Error 'checksum mismatch'; exit 1` so the host shell sees the failure regardless of `$ErrorActionPreference`.
+
 ### Verify build provenance
 
 The attestation proves the binary was produced by this repository's `release-please` workflow at the tagged commit. Verify it with the GitHub CLI:


### PR DESCRIPTION
## Summary

The `build-and-upload` matrix in `.github/workflows/release-please.yml` shipped binaries for macOS and Linux only. Windows was a fully supported runtime everywhere else in the repo — `installer-windows.ts`, the `win32` branches in `config/paths.ts`, the daemon dispatch in `commands/daemon.ts`, and the docs — but the release page attached no Windows binary, so Windows users had to install Bun and invoke through `bunx --package` to use the Task Scheduler installer.

This PR adds one matrix entry:

```yaml
- os: ubuntu-latest
  target: agentsync-windows-x64.exe
  bun_target: bun-windows-x64
```

`ubuntu-latest` is the right runner — Bun cross-compiles to `bun-windows-x64` the same way the matrix already cross-compiles `bun-linux-arm64` (from ubuntu) and `bun-darwin-x64` (from macos). No `windows-latest` runner, no extra minutes, no new CI surface.

The per-binary `.sha256` step, Sigstore `actions/attest-build-provenance@v3` step, and `gh release upload` step all key on `matrix.target`, so the new Windows entry inherits both verification layers (shipped in #88) automatically.

`docs/operations.md` gets a PowerShell `Get-FileHash` recipe (Windows ships neither `shasum` nor `sha256sum` natively) plus a one-sentence note for CI authors that `throw` does not reliably propagate exit code from `pwsh -Command` — `Write-Error … ; exit 1` is the portable form.

## Out of scope (filed as follow-ups)

- **#90 — Windows code-signing**: unsigned `.exe` triggers SmartScreen on first download. Requires org-level cert procurement; deferred.
- **#91 — Aggregate `SHA256SUMS` manifest for Scoop/Chocolatey**: per-binary `.sha256` is strictly more granular and already covers the primary verification question. Deferred until a downstream packager actually needs it.

Closes #69.

## Test plan

- [ ] Next release tag produces a fifth `build-and-upload` job that emits `dist/agentsync-windows-x64.exe`, its `.sha256` sibling, and a Sigstore attestation.
- [ ] Verify on a Windows host: `Get-FileHash agentsync-windows-x64.exe -Algorithm SHA256` matches the first column of the `.sha256` file, and `gh attestation verify agentsync-windows-x64.exe --repo chrisleekr/agentsync` succeeds.
- [ ] Confirm `agentsync daemon install` works against the downloaded `.exe` (the existing `installer-windows.ts` path expects exactly an on-disk binary).
- [ ] Drift CI (`bun run check:docs`) stays green — no doc file added/removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)