### PR TITLE
docs(operations): document Windows SmartScreen warning, close #90 in favour of Sigstore trust path

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -170,6 +170,14 @@ A passing verification reports the workflow path, commit SHA, and Sigstore trans
 
 Both checks are independent. The checksum protects against transport corruption and mirror tampering; the attestation protects against a substituted binary that happens to carry a forged checksum. Run both on first install of every release, and repeat the pair for each platform binary you download — every job in the release matrix mints its own attestation.
 
+### Windows SmartScreen on first run
+
+The first time you launch `agentsync-windows-x64.exe`, Windows will display *"Windows protected your PC"* with the body text *"Microsoft Defender SmartScreen prevented an unrecognized app from starting. Running this app might put your PC at risk."* It refuses to run until you click **More info** → **Run anyway**. This happens because the binary is not signed with an [Authenticode](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/authenticode) code-signing certificate. Since the CA/B Forum 2023 ruling, every code-signing cert (OV or EV) requires HSM-backed key storage, so the practical floor is a few hundred dollars per year plus ongoing key-management overhead.
+
+This project relies on the [Sigstore-backed build provenance attestation](#verify-build-provenance) as its trust path instead. If `gh attestation verify agentsync-windows-x64.exe --repo chrisleekr/agentsync` passes against the binary you downloaded, the bytes were produced by this repository's `release-please` workflow at the tagged commit — the SmartScreen warning is a UX consequence of the missing Authenticode cert, not a signal that the binary is unsafe. Click through it once per binary update.
+
+SmartScreen reputation is per-binary-hash and accrues with downloads; every new release starts from zero, so the warning recurs on each update.
+
 ## Recovery runbooks
 
 ### Recover from divergence


### PR DESCRIPTION
## Summary

Closes #90 by **documentation rather than implementation**. The original tracker proposed Authenticode code-signing for the Windows binary (#92), but the cost shape doesn't fit this project:

- CA/B Forum 2023 ruling makes HSM-backed key storage mandatory for every code-signing cert (OV and EV alike).
- Practical floor: a few hundred dollars per year + ongoing key-management overhead.
- Sigstore-backed build provenance attestation (shipped in #88) already provides equivalent trust at zero cost via `gh attestation verify --repo chrisleekr/agentsync`.

The right trade-off is to document the SmartScreen UX consequence and route Windows users to the existing attestation flow rather than pay for a parallel trust path.

## What ships

`docs/operations.md` gets a new `### Windows SmartScreen on first run` H3 inside the existing "Verifying release binaries" section. Three short paragraphs:

1. The exact dialog text users see (header + body verbatim per current Microsoft Defender SmartScreen behaviour), and the `More info → Run anyway` click-through path.
2. The missing-Authenticode-cert cause, the CA/B 2023 HSM rule explaining why this isn't a trivial fix, and a back-reference to the Sigstore verification recipe as the project's trust root.
3. Per-binary-hash reputation behaviour so users understand the warning recurs on each release (reputation accrues with downloads; never disappears for unsigned binaries).

Single-file, 8-line diff. No code touched.

Closes #90.

## Test plan

- [ ] `bun run check:docs` stays green (no doc file added/removed).
- [ ] `bun run check:spec-refs` stays green (no spec-tracker leakage).
- [ ] The cross-link `[Sigstore-backed build provenance attestation](#verify-build-provenance)` resolves to the existing H3 in the same page.
- [ ] Dialog text matches current Windows 11 SmartScreen output (verified against Microsoft Learn docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)