### PR TITLE
docs: fix path drift and CLI help accuracy from audit findings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,7 +121,7 @@ Reconciliation is fast-forward only and is the **same rule** used by `init`, `pu
 
 - If the local branch is identical to the remote branch, the operation continues.
 - If the local branch is behind the remote, the operation fast-forwards the local before continuing.
-- If the local branch is ahead of the remote, the operation pushes after the local step completes.
+- If the local branch is ahead of the remote, `push` fast-forwards the remote; `pull` continues without writing (pull never pushes).
 - If the local branch has diverged from the remote, the operation stops with a printed recovery path. AgentSync never merges or rebases automatically.
 
 The reasoning: a configuration vault is a flat record of intent. Three-way merge on encrypted blobs would either produce nonsense or require trust in a merge driver that has no way to inspect the plaintext. Failing closed forces the human to decide which branch is canonical.
@@ -236,11 +236,11 @@ Private keys stay on disk in the local runtime directory (`~/.config/agentsync/k
 
 ## Path resolution
 
-Every agent path is resolved through a single resolver that maps `<agent>.<dir>` to an absolute path on the current OS. Tests and platform overrides drive the resolver through environment variables rather than rewriting paths inline. The consequence: AgentSync runs identically inside the Docker E2E harness, on a developer laptop, and in CI, with no platform-specific branches in the call sites.
+Every agent path is resolved through a single resolver that maps `<agent>.<dir>` to an absolute path on the current OS. Tests and platform overrides drive the resolver through environment variables rather than rewriting paths inline. The consequence: AgentSync runs identically inside the Docker E2E harness, on a developer laptop, and in CI, without command-implementation sites needing to branch on platform — platform-specific decisions live in `src/config/paths.ts` and `src/daemon/installer-*.ts` and nowhere else.
 
 ## Vault format versioning
 
-The vault has a format version recorded in `agentsync.toml`. Backwards-incompatible changes (a renamed namespace, a new sanitiser rule that would reject already-published content, a new encryption-recipient encoding) require a migration step. Each migration is recorded under `src/migrate/` and is documented in [Migrate](migrate.md). AgentSync refuses to push to a vault whose format version is newer than the CLI understands.
+The vault carries a `version` field in `agentsync.toml` (default `"1"`) that future backwards-incompatible changes (a renamed namespace, a new sanitiser rule that would reject already-published content, a new encryption-recipient encoding) will use to gate migrations. Each migration lives under `src/migrate/` and is documented in [Migrate](migrate.md). The current schema treats the field as informational; a forward-incompatibility refusal will land alongside the first breaking change.
 
 ## Source map
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -154,7 +154,7 @@ agentsync push --dry-run
 
 **Caveats**:
 
-- Push is **additive by default**: deleting a skill locally does not remove it from the vault. Use [`skill remove`](#skill) for explicit removal.
+- Push is **additive**: deleting a skill locally does not remove it from the vault. Use [`skill remove`](#skill) for explicit removal.
 - The sanitiser is a hard gate. Literal secrets or never-sync paths abort the entire push before bytes leave the machine. See [Push aborts because secrets were detected](operations.md#push-aborts-because-secrets-were-detected).
 - Reconciliation is fast-forward only. Divergence aborts the push with recovery guidance.
 - `--dry-run` exercises the snapshot, sanitiser, and encryption pipeline so previews reflect what would actually be written.
@@ -177,7 +177,7 @@ agentsync pull --dry-run
 |---|---|---|
 | `--agent` | all enabled | Restrict to one agent. |
 | `--dry-run` | `false` | Show what would be applied without writing locally. |
-| `--force` | `false` | Skip interactive conflict prompts. |
+| `--force` | `false` | Apply the remote state without prompting on conflicts. Used by the daemon and other non-interactive callers. |
 
 **Outcome**: supported local agent files are updated from the vault, including per-agent skills under `claude/skills/`, `codex/skills/`, `cursor/skills/`, and `copilot/skills/`. Claude Code plugins under `claude/plugins/<name>/` round-trip back to `~/.claude/plugins/<name>/`. `marketplace.json` is only applied when `claudePlugins.syncMarketplace = true` is set locally.
 
@@ -375,7 +375,7 @@ agentsync destroy --scope=all           # both
 
 | Scope | After destroy |
 |---|---|
-| `local` | `~/.agentsync/vault/` is gone. `~/.agentsync/key.txt`, the daemon, the remote, and every `~/.<agent>/` directory are unchanged. Re-init from the same remote restores the clone. |
+| `local` | `~/.config/agentsync/vault/` (or `%APPDATA%/agentsync/vault/` on Windows) is gone. `~/.config/agentsync/key.txt`, the daemon, the remote, and every `~/.<agent>/` directory are unchanged. Re-init from the same remote restores the clone. |
 | `remote` | Remote branch has a new commit, `destroy: clear vault content`, that removes every previously-tracked file. Local vault dir keeps its `.git/` history. Other machines that still have the data can `git revert <sha>` to recover. |
 | `all` | Both of the above. Remote is wiped first so a failed push does not leave you with a wiped local that cannot reach the remote. |
 
@@ -389,7 +389,7 @@ agentsync destroy --scope=all           # both
   quiet in the meantime.
 - `key.txt` is preserved across every scope. Re-init from the same remote
   reuses the existing identity so you stay a recipient. Delete the key
-  manually (`rm ~/.agentsync/key.txt`) if you really need a key wipe.
+  manually (`rm ~/.config/agentsync/key.txt` on Unix, or remove `%APPDATA%/agentsync/key.txt` on Windows) if you really need a key wipe.
 - Refuses to run in a non-TTY context without `--yes`, to protect against
   accidental destroys from piped scripts.
 
@@ -400,4 +400,4 @@ agentsync destroy --scope=all           # both
 | 0 | Success. |
 | 1 | Failure. Re-run only after addressing the printed cause. Some failures are not recoverable (a lost private key cannot be re-derived; a divergent vault must be reset or recloned). |
 
-Every command prints a one-line summary on success and an actionable error on failure. If neither is printed, the command was killed externally (a SIGKILL on an unsigned macOS binary is the most common case; see the GitHub Releases for the signed binary).
+Every command prints a one-line summary on success and an actionable error on failure. If neither is printed, the command was killed externally — a Gatekeeper SIGKILL on the unsigned macOS release binary is the most common case. To avoid it, install via `bun install -g @chrisleekr/agentsync`, or verify the binary first with `gh attestation verify`. See [Operations → Verifying release binaries](operations.md#verifying-release-binaries).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,7 +28,7 @@ bun install
 bun run check
 ```
 
-`bun run check` runs the typecheck, Biome lint, the test suite, and the docs-mirror check. A clean run is the precondition for opening a pull request.
+`bun run check` runs typecheck, Biome lint, the docs-mirror check, the spec-tracker ID leak guard, and the test suite (in that order). A clean run is the precondition for opening a pull request.
 
 While developing, run the CLI directly from source rather than the global install so your changes take effect immediately:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,10 +54,15 @@ Five steps from zero to a working sync.
     agentsync push
     ```
 
-4. **Join from another machine.** On a second machine, run `init` against the same remote, copy or regenerate the age private key, then `pull`.
+4. **Join from another machine.** On the second machine, `init` generates a fresh age keypair; on a machine that already has the vault, register the new public key as a recipient (`agentsync key add <name> <pubkey>` and push), then `pull` here.
 
     ```bash
+    # on the new machine
     agentsync init --remote git@github.com:<you>/agentsync-vault.git --branch main
+    # then on a machine that already has the vault, add the new recipient and push:
+    #   agentsync key add <name> <pubkey-printed-by-init>
+    #   agentsync push
+    # back on the new machine
     agentsync pull
     ```
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -108,11 +108,11 @@ flowchart TD
 - **MCP per-server merge**: Only colliding server names are overwritten; target-only servers are preserved. The merge key is target-specific: VS Code uses top-level `servers` + `inputs`, Claude/Cursor/Copilot CLI use `mcpServers`, Codex uses `[mcp.servers.*]` TOML tables.
 - **Secret detection**: If API keys or tokens are found in MCP content (including HTTP-transport `headers.Authorization`), migration aborts with a clear error. Remove literal secrets and retry.
 - **Graceful skipping**: Missing source files and unsupported pairs produce skip messages, not errors.
-- **`--name` is strict**: When `--name` is set and zero source artefacts match that name, migration hard-errors and exits non-zero rather than silently skipping. Catches typos. Behaviour change in this version — earlier releases silently skipped.
+- **`--name` is strict**: When `--name` is set and zero source artefacts match that name, migration hard-errors and exits non-zero rather than silently skipping. Catches typos.
 
 ## Skills migration
 
-`agentsync migrate --type skills --from <agent> --to <agent|all>` cross-translates the Anthropic SKILL.md spec between Claude, Cursor, and Codex (all three implement the same progressive-disclosure spec verbatim). Copilot CLI is supported as a best-effort target — files land in `~/.copilot/skills/<name>/` but Copilot has no documented SKILL.md loader as of 2026-05, so a warning is emitted. VS Code is skipped (no SKILL.md surface).
+`agentsync migrate --type skills --from <agent> --to <agent|all>` cross-translates the Anthropic SKILL.md spec between Claude, Cursor, and Codex (all three implement the same progressive-disclosure spec verbatim). Copilot CLI is supported as a best-effort target — files land in `~/.copilot/skills/<name>/` but Copilot does not yet implement a documented SKILL.md loader, so a warning is emitted. VS Code is skipped (no SKILL.md surface).
 
 Each skill directory's supporting files (`reference.md`, `scripts/*`, assets) ride along as sidecars — they're written under the destination skill dir verbatim. Binary assets are base64-roundtripped. Skill names are validated against the same traversal/hidden-name guard the snapshot path uses.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -47,9 +47,11 @@ The platform backend is selected at runtime:
 |---|---|---|
 | macOS | launchd LaunchAgent | `~/Library/LaunchAgents/com.agentsync.daemon.plist` |
 | Linux | systemd user unit | `~/.config/systemd/user/agentsync.service` |
-| Windows | Task Scheduler | per-user scheduled task `AgentSyncDaemon` |
+| Windows | Task Scheduler | per-user scheduled task `AgentSync` |
 
 After `daemon install`, the OS supervisor restarts the daemon on user login and after a crash. `daemon start` brings it up immediately without waiting for the next login.
+
+> **Install globally first.** `daemon install` refuses to register an executable that lives in a temporary directory (the case when running via `bunx`) because the OS supervisor would lose the binary on the next reboot. Run `bun install -g @chrisleekr/agentsync` (or another stable install path) before `daemon install`.
 
 ### Lifecycle
 
@@ -74,17 +76,36 @@ debounceMs = 300        # quiet window after a file change before push fires; 50
 autoPush = true         # disable to make the daemon read-only
 autoPull = true         # disable to opt out of periodic pull
 pullIntervalMs = 300000 # how often periodic pull runs, in milliseconds; minimum 1000
+
+[agents]
+cursor = true           # enable cursor adapter
+claude = true           # enable claude adapter
+codex = true            # enable codex adapter
+copilot = true          # enable copilot adapter
+vscode = false          # opt-in; vscode's surface is MCP-only
+
+[claudePlugins]
+syncMarketplace = false # opt-in: include ~/.claude/marketplace.json in push/pull
 ```
 
 Defaults are chosen so you can install and forget. Tune them only if you observe excessive push churn or want to widen the pull cadence. Values outside the supported range are rejected at config load.
+
+**Environment-variable escape hatches.** For tests, CI, and air-gapped setups, the following variables override the resolved defaults:
+
+| Variable | Overrides | Default |
+|---|---|---|
+| `AGENTSYNC_VAULT_DIR` | Vault clone directory | `~/.config/agentsync/vault` (Unix), `%APPDATA%/agentsync/vault` (Windows) |
+| `AGENTSYNC_KEY_PATH` | Private key file | `~/.config/agentsync/key.txt` (Unix), `%APPDATA%/agentsync/key.txt` (Windows) |
+| `AGENTSYNC_MACHINE` | Machine identifier in recipient names | derived from `os.hostname()` |
+| `CODEX_HOME` | Codex root directory | `~/.codex` |
 
 ### Logs
 
 Inspect platform logs when `daemon status` reports unhealthy:
 
-- macOS: `~/Library/Logs/agentsync.out.log` and `agentsync.err.log`, plus the LaunchAgent's `Console.app` entries.
+- macOS: `~/Library/Logs/AgentSync/agentsync.out.log` and `~/Library/Logs/AgentSync/agentsync.err.log`, plus the LaunchAgent's `Console.app` entries.
 - Linux: `journalctl --user -u agentsync.service`.
-- Windows: Task Scheduler history for `AgentSyncDaemon`, plus the daemon's stdout file under the user's local app data.
+- Windows: Task Scheduler history for `AgentSync`, plus the daemon's stdout file under the user's local app data.
 
 ## Key management
 
@@ -223,8 +244,9 @@ When you want to throw away vault state and start over, reach for
 Decide the scope first:
 
 - **Local clone is corrupted, remote is fine** → `agentsync destroy`
-  (default `--scope=local`). Removes `~/.agentsync/vault/`, keeps
-  `key.txt`. Then re-init from the same remote.
+  (default `--scope=local`). Removes `~/.config/agentsync/vault/`
+  (`%APPDATA%/agentsync/vault/` on Windows), keeps `key.txt`. Then
+  re-init from the same remote.
 - **You want every machine to start fresh, including the remote** →
   `agentsync destroy --scope=remote`. Adds a commit to the remote that
   removes every tracked file (not a force-push — history is preserved
@@ -236,7 +258,7 @@ Decide the scope first:
 Before running, back the vault up if you might still want it:
 
 ```bash
-cp -r ~/.agentsync/vault ~/.agentsync/vault.bak.$(date +%s)
+cp -r ~/.config/agentsync/vault ~/.config/agentsync/vault.bak.$(date +%s)
 ```
 
 Three confirmation gates must pass: preview prompt → typed phrase

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -97,7 +97,10 @@ export const pullCommand = defineCommand({
     description: "Pull and apply vault configs locally",
   },
   args: {
-    agent: { type: "string", description: "Specific agent to sync (cursor|claude|codex|copilot)" },
+    agent: {
+      type: "string",
+      description: "Specific agent to sync (cursor|claude|codex|copilot|vscode)",
+    },
     dryRun: { type: "boolean", description: "Show actions without applying", default: false },
     force: {
       type: "boolean",

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -313,7 +313,7 @@ export const pushCommand = defineCommand({
   args: {
     agent: {
       type: "string",
-      description: "Specific agent to sync (cursor|claude|codex|copilot)",
+      description: "Specific agent to sync (cursor|claude|codex|copilot|vscode)",
     },
     message: { type: "string", description: "Custom commit message" },
     dryRun: {


### PR DESCRIPTION
## Summary

Claim-by-claim audit of every page in `docs/` against source surfaced nine DRIFT items, plus stale dates, missing reference rows, and reader-friction sentences. This PR fixes all verified findings in one surgical pass.

## Top fixes (DRIFT — incorrect facts users will trip on)

- **Vault / key paths**: `~/.agentsync/vault/` and `~/.agentsync/key.txt` corrected to `~/.config/agentsync/vault/` and `~/.config/agentsync/key.txt` on Unix (`%APPDATA%/agentsync/...` on Windows). Source resolution lives in `src/config/paths.ts:128-134` (`resolveAgentSyncHome`) and `src/commands/shared.ts:22-23`. Was wrong in `commands.md` (destroy outcome, key wipe note) and `operations.md` (Reset a vault, vault backup snippet). `operations.md` was internally contradictory — "Recover a missing private key" already used the correct path; "Reset a vault" did not.
- **Windows scheduled task name**: `AgentSyncDaemon` → `AgentSync`. Source constant `TASK_NAME = "AgentSync"` in `src/daemon/installer-windows.ts:65`. Affected two places in `operations.md` (Install per OS table; Logs section). A user running `schtasks /Query /TN AgentSyncDaemon` to diagnose would get task-not-found.
- **macOS log path**: `~/Library/Logs/agentsync.{out,err}.log` → `~/Library/Logs/AgentSync/agentsync.{out,err}.log`. Source writes to the `AgentSync` subdirectory (`src/daemon/installer-macos.ts:173,107-108`). One directory off — `tail` on the documented path saw nothing.
- **`--agent` flag enum**: `push --help` and `pull --help` description strings now list `(cursor|claude|codex|copilot|vscode)`. `vscode` is fully registered in `src/agents/registry.ts:62-65` and `AgentName` includes it, but the citty `description` strings on `src/commands/push.ts` and `pull.ts` omitted it. Lint auto-formatted the `pull.ts` arg block when the line crossed the length threshold.
- **Vault format version refusal**: `architecture.md` claimed `"AgentSync refuses to push to a vault whose format version is newer than the CLI understands."` Source has `version: z.string().default("1")` in `src/config/schema.ts` but no comparison logic anywhere. Softened to describe the field as informational with the refusal landing alongside the first breaking change.
- **Reconciliation rule asymmetry**: rule had a universal "the operation pushes after the local step completes" but `pull` never pushes. Split into `push`/`pull` semantics.
- **`bun run check` description**: `contributing.md` listed four steps; actual `package.json` runs five (`typecheck && lint && check:docs && check:spec-refs && test`). Added the missing `check:spec-refs` step.
- **Signed-macOS-binary claim**: removed from `commands.md` Exit codes paragraph. No signed binary ships; `operations.md` Windows SmartScreen section already explains the Sigstore-based trust path.

## STALE — dated literals that would silently rot

- `migrate.md`: dropped `as of 2026-05` qualifier on the Copilot SKILL.md loader note. Also removed `Behaviour change in this version — earlier releases silently skipped.` sentence from the `--name` strictness note.

## MISSING — facts in source not represented in docs

- `operations.md` Configuration table now documents the previously-undocumented config blocks and env vars:
  - `[agents]` block with the five enabled flags (default `vscode = false`)
  - `[claudePlugins]` with `syncMarketplace` (opt-in)
  - Env-var escape hatches `AGENTSYNC_VAULT_DIR`, `AGENTSYNC_KEY_PATH`, `AGENTSYNC_MACHINE`, `CODEX_HOME` (all consumed in `src/commands/shared.ts:22-26` and `src/config/paths.ts:1390`)
- `operations.md` daemon install section now warns about the `bunx` temp-dir refusal footgun (`src/commands/daemon.ts:712-744` rejects executables in a temp dir).

## FRICTION — sentences that confused readers

- `index.md` Quickstart step 4 ("Join from another machine") now documents the real `init` → `key add` → `push` → `pull` flow rather than the ambiguous "copy or regenerate the age private key".
- `commands.md` push caveat: "additive by default" → "additive" (no toggle exists).
- `commands.md` `pull --force` description tightened to match source semantics.
- `architecture.md` "no platform-specific branches in the call sites" narrowed to "command-implementation sites" — `src/config/paths.ts` and `src/daemon/installer-*.ts` are explicitly platform-branched.

## What was checked but kept unchanged

- `migrate.md` Config Type Support Matrix paths (Codex `$CODEX_HOME`, `~/.agents/skills` preferred / `~/.codex/skills` legacy, Copilot MCP path) all match `src/config/paths.ts`.
- `architecture.md` daemon model invariants (one daemon per user, one sync at a time, one retry, 10s shutdown) match `src/daemon/index.ts`.
- `operations.md` Configuration defaults (`debounceMs`, `pullIntervalMs`, etc.) match the Zod schema in `src/config/schema.ts`.
- Doc-ownership table in `contributing.md` — six rows, every existing `.md` covered, no orphans (the mirror script enforces this).
- Stable anchors preserved across every change.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (Biome auto-formatted the wider `pull.ts` arg block)
- [x] `bun run check:docs` — clean (mirror table still valid)
- [x] `bun run check:spec-refs` — clean (no spec-tracker IDs introduced)
- [x] `bun test` — 776 pass, 0 fail
- [ ] `bun run docs:build` (mkdocs `--strict`) — to be verified by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)