### PR TITLE
fix(release): scope SHA256SUMS upload to repo in checkout-less job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -202,4 +202,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: gh release upload "$TAG_NAME" checksums/SHA256SUMS --clobber
+        run: gh release upload "$TAG_NAME" checksums/SHA256SUMS --clobber --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

The `aggregate-checksums` job in the release pipeline failed during the v0.1.8 release with `fatal: not a git repository`. The job has no `actions/checkout` step (it only handles release assets, not source), so `gh release upload` could not resolve the target repository — `gh` falls back to inspecting a local `.git` directory when no `--repo` flag is given, and none exists in that job.

The download step in the same job already passes `--repo "$GITHUB_REPOSITORY"`. This change makes the upload step consistent, removing its dependency on a git checkout.

## Changes

- `.github/workflows/release-please.yml`: add `--repo "$GITHUB_REPOSITORY"` to the `gh release upload` call in the "Upload SHA256SUMS to release" step of the `aggregate-checksums` job.

### Architecture

```mermaid
flowchart LR
  subgraph repoflow["aggregate-checksums job — no actions/checkout"]
    direction TB
    Before["Before<br/>gh release upload TAG SHA256SUMS --clobber"]:::bad
    BeforeFail["gh falls back to local .git remote<br/>fatal: not a git repository"]:::bad
    After["After<br/>gh release upload TAG SHA256SUMS --clobber --repo GITHUB_REPOSITORY"]:::good
    AfterOk["gh resolves repo from flag<br/>upload succeeds"]:::good
    Before --> BeforeFail
    After --> AfterOk
  end
  classDef bad fill:#c0392b,color:#ffffff
  classDef good fill:#1e8449,color:#ffffff
```

## Test Evidence

Cannot be exercised locally — the job only runs on a release tag in CI. Verified by inspection: the change mirrors the working `gh release download --repo "$GITHUB_REPOSITORY"` call in the same job. `$GITHUB_REPOSITORY` is a GitHub-provided built-in, always populated in the Actions runtime.

## Risks / Follow-ups

- Pre-existing: the v0.1.8 release has no `SHA256SUMS` asset because this step failed. After merge, re-run the failed job (`gh run rerun 25959932469 --failed`) or upload the manifest manually.

## Checklist

- [ ] New code has tests where appropriate — N/A, CI-only workflow change
- [x] Documentation updated if behavior changed — no behavior change