### PR TITLE
fix(tui): fetch vault from remote before computing Sync diff

### DIFF
--- a/src/commands/__tests__/destroy.test.ts
+++ b/src/commands/__tests__/destroy.test.ts
@@ -276,7 +276,7 @@ describe("performDestroy", () => {
       performDestroy({ scope: "remote", yes: true }),
     );
     expect(second.status).toBe("not-an-agentsync-vault");
-  });
+  }, 20000);
 
   describe("confirmation gates", () => {
     test("gate 1 'n' aborts at gate 1 without touching the vault", async () => {

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -1084,7 +1084,7 @@ describe("integration", () => {
     ).toBe(true);
     expect(fakeLogs.success.some((message) => message.includes("Pull completed"))).toBe(false);
     expect(fakeApplyCalls).toHaveLength(0);
-  });
+  }, 20000);
 
   test("performPush inherits the shared divergence policy before writing vault artifacts", async () => {
     const { machineB } = await createDivergentMachinePair(join(tmpDir, "push-divergence"));
@@ -1108,7 +1108,7 @@ describe("integration", () => {
       ),
     ).toBe(true);
     expect(existsSync(join(machineB.vaultDir, "claude", "blocked.age"))).toBe(false);
-  });
+  }, 20000);
 });
 
 // ─── agent-skills-sync integration guarantees ─────────────────────────

--- a/src/commands/tui/app.ts
+++ b/src/commands/tui/app.ts
@@ -103,6 +103,7 @@ export async function runApp(): Promise<void> {
   root.add(actionBar);
   root.add(footer);
 
+  let alive = true;
   const ctx: AppContext = {
     renderer,
     store,
@@ -117,7 +118,20 @@ export async function runApp(): Promise<void> {
     },
   };
 
-  store.subscribe(() => ctx.rerender());
+  // Coalesce renders onto a microtask. renderActiveTab calls ensureSyncLoaded,
+  // which dispatches; a synchronous subscriber would re-enter rendering mid
+  // render and stack a second panel into the same host. Deferring means a
+  // dispatch-during-render schedules the next render instead of nesting.
+  let renderScheduled = false;
+  const scheduleRender = (): void => {
+    if (renderScheduled) return;
+    renderScheduled = true;
+    queueMicrotask(() => {
+      renderScheduled = false;
+      if (alive) ctx.rerender();
+    });
+  };
+  store.subscribe(scheduleRender);
   ctx.rerender();
 
   const pollOnce = async () => {
@@ -168,6 +182,7 @@ export async function runApp(): Promise<void> {
   try {
     await quitPromise;
   } finally {
+    alive = false;
     teardown(renderer);
     store.dispose();
     process.removeListener("SIGINT", onSignal);

--- a/src/commands/tui/app.ts
+++ b/src/commands/tui/app.ts
@@ -7,6 +7,7 @@ import {
   type ContextAction,
   countRunning,
   createInitialState,
+  setKeyHint,
   setToast,
   TAB_IDS,
   type TabId,
@@ -113,7 +114,7 @@ export async function runApp(): Promise<void> {
       renderTitleBar(titleBar, state);
       renderTabBar(tabBar, state);
       renderActiveTab(renderer, contentHost, store, ctx);
-      renderActionBar(actionBar, contextActionsForTab(state));
+      renderActionBar(actionBar, contextActionsForTab(state), activeKeyHint(state));
       renderFooter(footer, state);
     },
   };
@@ -156,9 +157,13 @@ export async function runApp(): Promise<void> {
 
   toastTimer = setInterval(() => {
     const s = store.getState();
-    if (s.toast && s.toast.expiresAt < Date.now()) {
+    const now = Date.now();
+    const toastExpired = s.toast !== null && s.toast.expiresAt < now;
+    const hintExpired = s.keyHint !== null && s.keyHint.expiresAt < now;
+    if (toastExpired || hintExpired) {
       store.dispatch((d) => {
-        d.toast = null;
+        if (toastExpired) d.toast = null;
+        if (hintExpired) d.keyHint = null;
       });
     }
   }, 500);
@@ -221,6 +226,17 @@ function handleKey(key: KeyEvent, ctx: AppContext, quit: () => void): void {
       });
     }
     return;
+  }
+
+  // Show the action before running it: flash the pressed key in the bars and
+  // surface its label, so a keypress is visibly acknowledged even when the
+  // handler that follows does slow work.
+  const action = actionLabelFor(key, ctx.store.getState());
+  if (action) {
+    ctx.store.dispatch((d) => {
+      setKeyHint(d, action.key);
+      setToast(d, action.label, "info", 1500);
+    });
   }
 
   if (key.name >= "1" && key.name <= "4") {
@@ -354,15 +370,78 @@ function renderFooter(host: TextRenderable, state: AppState): void {
   const running = countRunning(state);
   const opLabel = running > 0 ? `  ${running} op(s)` : "";
   const toast = state.toast ? `  ⟶ ${state.toast.text}` : "";
-  host.content = ` p push  l pull  r refresh  ? help  q quit            daemon ${dot} ${daemonLabel}${opLabel}${toast}`;
+  // The just-pressed global key renders as [k] instead of  k . Both markers
+  // are 3 wide so the bar does not shift when a key flashes.
+  const hintKey = activeKeyHint(state);
+  const globalKeys: [string, string][] = [
+    ["p", "push"],
+    ["l", "pull"],
+    ["r", "refresh"],
+    ["?", "help"],
+    ["q", "quit"],
+  ];
+  const actions = globalKeys
+    .map(([k, label]) => `${hintKey === k ? `[${k}]` : ` ${k} `}${label}`)
+    .join(" ");
+  host.content = `${actions}            daemon ${dot} ${daemonLabel}${opLabel}${toast}`;
 }
 
-function renderActionBar(host: TextRenderable, actions: ContextAction[]): void {
+/** The action-bar key being flashed right now, or null once the flash TTL
+ *  has elapsed. Expiry is checked at render time so a stale hint never shows. */
+function activeKeyHint(state: AppState): string | null {
+  if (state.keyHint && state.keyHint.expiresAt > Date.now()) {
+    return state.keyHint.key;
+  }
+  return null;
+}
+
+/**
+ * Map a keypress to the action it triggers, for the pre-action flash + toast.
+ * Pure navigation (arrows, space, enter, esc) returns null so the bars do not
+ * flash on every cursor move. Returns the bar key it maps to and a label.
+ */
+function actionLabelFor(key: KeyEvent, state: AppState): { key: string; label: string } | null {
+  if (state.helpOpen) return null;
+  const name = key.name;
+  if (name >= "1" && name <= "4") {
+    const idx = Number(name) - 1;
+    if (idx < TAB_IDS.length) return { key: name, label: TAB_LABELS[TAB_IDS[idx]] };
+  }
+  if (name === "tab") return { key: "tab", label: key.shift ? "prev tab" : "next tab" };
+  if (name === "p" && !key.shift) return { key: "p", label: "push" };
+  if (name === "l" && !key.shift) return { key: "l", label: "pull" };
+  if (name === "r" && !key.shift) return { key: "r", label: "refresh" };
+  if (name === "?" || (key.shift && name === "/")) return { key: "?", label: "help" };
+  switch (state.activeTab) {
+    case "dashboard":
+      if (name === "i") return { key: "i", label: "init" };
+      if (name === "k") return { key: "k", label: "key rotate" };
+      break;
+    case "sync":
+      if (name === "x" && state.selection.size > 0) return { key: "x", label: "remove" };
+      if (name === "k") return { key: "k", label: "load key" };
+      break;
+    case "migrate":
+      if (key.shift && name === "p") return { key: "P", label: "preview" };
+      if (key.shift && name === "a") return { key: "A", label: "apply" };
+      break;
+    case "activity":
+      if (name === "c") return { key: "c", label: "clear" };
+      break;
+  }
+  return null;
+}
+
+function renderActionBar(
+  host: TextRenderable,
+  actions: ContextAction[],
+  hintKey: string | null,
+): void {
   if (actions.length === 0) {
     host.content = "";
     return;
   }
-  const parts = actions.map((a) => `${a.key} ${a.label}`);
+  const parts = actions.map((a) => `${hintKey === a.key ? `[${a.key}]` : a.key} ${a.label}`);
   host.content = `  ${parts.join("   ")}`;
 }
 

--- a/src/commands/tui/app.ts
+++ b/src/commands/tui/app.ts
@@ -418,6 +418,17 @@ function actionLabelFor(key: KeyEvent, state: AppState): { key: string; label: s
       if (name === "k") return { key: "k", label: "key rotate" };
       break;
     case "sync":
+      // A Sync sub-mode (diff, skill drill-in, confirm-remove, key prompt)
+      // owns the keymap and swallows k/x, so do not flash an action the
+      // sub-mode will never run.
+      if (
+        state.sync.diff ||
+        state.sync.skillDrillIn ||
+        state.sync.confirmRemove ||
+        state.sync.keyPrompt === "pending"
+      ) {
+        break;
+      }
       if (name === "x" && state.selection.size > 0) return { key: "x", label: "remove" };
       if (name === "k") return { key: "k", label: "load key" };
       break;

--- a/src/commands/tui/state.ts
+++ b/src/commands/tui/state.ts
@@ -189,6 +189,8 @@ export interface AppState {
   activity: ActivityEntry[];
   selection: Set<string>;
   toast: { text: string; level: "info" | "success" | "error"; expiresAt: number } | null;
+  /** Most recently pressed action key, flashed briefly in the action bars. */
+  keyHint: { key: string; expiresAt: number } | null;
   helpOpen: boolean;
   sync: SyncSlice;
   migrate: MigrateSlice;
@@ -210,6 +212,7 @@ export function createInitialState(): AppState {
     activity: [],
     selection: new Set<string>(),
     toast: null,
+    keyHint: null,
     helpOpen: false,
     sync: {
       phase: "idle",
@@ -255,6 +258,12 @@ export function setToast(
   ttlMs = 3000,
 ): void {
   state.toast = { text, level, expiresAt: Date.now() + ttlMs };
+}
+
+/** Record an action keypress so the bars can flash the pressed key. The TTL
+ *  is short so it reads as "just pressed", not a sticky indicator. */
+export function setKeyHint(state: AppState, key: string, ttlMs = 450): void {
+  state.keyHint = { key, expiresAt: Date.now() + ttlMs };
 }
 
 export function migrateSignature(m: MigrateSlice): string {

--- a/src/commands/tui/tabs/sync.ts
+++ b/src/commands/tui/tabs/sync.ts
@@ -5,6 +5,7 @@ import type { CliRenderer, KeyEvent } from "@opentui/core";
 import { BoxRenderable, TextRenderable } from "@opentui/core";
 import { Agents } from "../../../agents/registry";
 import { decryptString } from "../../../core/encryptor";
+import { GitClient, type GitReconciliationResult } from "../../../core/git";
 import { listArchiveEntries } from "../../../core/tar";
 import { pairDiffRows, type SideBySideRow } from "../../../lib/diff";
 import { performPull } from "../../pull";
@@ -12,7 +13,7 @@ import { performPush } from "../../push";
 import { loadPrivateKey, loadVaultConfigOrExit, resolveRuntimeContext } from "../../shared";
 import { computeSyncStatus, type SyncRow } from "../../status";
 import type { AppState, DiffModalState, SkillDrillInState, SkillFile } from "../state";
-import { setToast } from "../state";
+import { pushActivity, setToast } from "../state";
 import type { Store } from "../store";
 import { runBulkSkillRemove } from "./_skill-remove";
 
@@ -144,10 +145,37 @@ function navigableRows(state: AppState): SyncRow[] {
   return out;
 }
 
-async function loadRows(privateKey: string | null): Promise<SyncRow[]> {
+/** Outcome of the pre-diff vault fetch. A failure is non-fatal: the panel
+ *  still renders against the stale clone so it stays usable offline. */
+type VaultFetchOutcome =
+  | { ok: true; status: GitReconciliationResult["status"] }
+  | { ok: false; message: string };
+
+async function loadRows(
+  privateKey: string | null,
+): Promise<{ rows: SyncRow[]; fetch: VaultFetchOutcome }> {
   const runtime = await resolveRuntimeContext();
   const config = await loadVaultConfigOrExit(runtime.vaultDir);
-  return computeSyncStatus(runtime, config, privateKey);
+
+  // Fast-forward the vault clone before diffing. Without this the panel
+  // compares against the last-pulled snapshot, so skills pushed from another
+  // machine never surface as vault-only. A fetch failure (offline, auth,
+  // diverged history) is non-fatal: fall through to the stale clone so the
+  // panel still renders, and report the failure as an activity entry.
+  let fetch: VaultFetchOutcome;
+  try {
+    const result = await new GitClient(runtime.vaultDir).reconcileWithRemote({
+      remote: "origin",
+      branch: config.remote.branch,
+      allowMissingRemote: true,
+    });
+    fetch = { ok: true, status: result.status };
+  } catch (err) {
+    fetch = { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+
+  const rows = await computeSyncStatus(runtime, config, privateKey);
+  return { rows, fetch };
 }
 
 export function ensureSyncLoaded(store: Store): void {
@@ -163,17 +191,36 @@ export function ensureSyncLoaded(store: Store): void {
   });
 
   const key = store.getState().sync.keyCache;
-  store.runOperation("sync-load", "load sync rows", () => loadRows(key), {
-    onSuccess: (draft, rows) => {
-      const list = rows as SyncRow[];
-      draft.sync.rows = list;
+  store.runOperation("sync-load", "fetch vault + load sync rows", () => loadRows(key), {
+    onSuccess: (draft, payload) => {
+      const { rows, fetch } = payload;
+      draft.sync.rows = rows;
       draft.sync.cursor = 0;
       draft.sync.phase = "ready";
       draft.sync.error = null;
+      if (fetch.ok) {
+        // "fast-forwarded" and "bootstrapped-existing" both mean the clone
+        // advanced to origin; only "noop" is genuinely unchanged.
+        const verb =
+          fetch.status === "remote-missing"
+            ? "remote vault branch missing — comparing local only"
+            : fetch.status === "noop"
+              ? "vault already up to date with origin"
+              : "vault advanced to origin";
+        pushActivity(draft, { kind: "info", status: "info", message: `Sync: ${verb}` });
+      } else {
+        pushActivity(draft, {
+          kind: "error",
+          status: "fail",
+          message: `Sync: vault fetch failed, showing last-known state — ${fetch.message}`,
+        });
+        setToast(draft, "Vault fetch failed — showing last-known state", "error");
+      }
     },
     onError: (draft, err) => {
       draft.sync.phase = "error";
       draft.sync.error = err.message;
+      pushActivity(draft, { kind: "error", status: "fail", message: `Sync: ${err.message}` });
     },
   });
 }

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -2,8 +2,6 @@ import { mkdir, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import simpleGit, { type SimpleGit } from "simple-git";
 
-const decoder = new TextDecoder();
-
 /** Stable error categories returned by the vault reconciliation flow. */
 export type GitReconciliationCode = "DIVERGED_HISTORY" | "REMOTE_BRANCH_MISSING";
 
@@ -58,17 +56,26 @@ export class GitClient {
     this.git = simpleGit(repoDir);
   }
 
-  private runGit(args: string[]): { exitCode: number; stdout: string; stderr: string } {
-    const result = Bun.spawnSync(["git", "-C", this.repoDir, ...args]);
-    return {
-      exitCode: result.exitCode,
-      stdout: decoder.decode(result.stdout).trim(),
-      stderr: decoder.decode(result.stderr).trim(),
-    };
+  // Async subprocess (Bun.spawn, not spawnSync): a synchronous git call blocks
+  // the event loop, which freezes the TUI render/input loop during the network
+  // round-trips in fetch/ls-remote. Awaiting an async subprocess yields instead.
+  private async runGit(
+    args: string[],
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn(["git", "-C", this.repoDir, ...args], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { exitCode, stdout: stdout.trim(), stderr: stderr.trim() };
   }
 
-  private assertGit(args: string[], action: string): string {
-    const result = this.runGit(args);
+  private async assertGit(args: string[], action: string): Promise<string> {
+    const result = await this.runGit(args);
     if (result.exitCode !== 0) {
       throw new Error(`${action} failed: ${result.stderr || result.stdout || "no output"}`);
     }
@@ -76,12 +83,12 @@ export class GitClient {
   }
 
   private async revParse(ref: string): Promise<string | null> {
-    const result = this.runGit(["rev-parse", "--verify", ref]);
+    const result = await this.runGit(["rev-parse", "--verify", ref]);
     return result.exitCode === 0 ? result.stdout : null;
   }
 
-  private isAncestor(ancestor: string, descendant: string): boolean {
-    const result = this.runGit(["merge-base", "--is-ancestor", ancestor, descendant]);
+  private async isAncestor(ancestor: string, descendant: string): Promise<boolean> {
+    const result = await this.runGit(["merge-base", "--is-ancestor", ancestor, descendant]);
     if (result.exitCode === 0) {
       return true;
     }
@@ -103,33 +110,33 @@ export class GitClient {
     }
 
     if ((await this.revParse("HEAD")) !== null) {
-      this.assertGit(["checkout", "-b", branch], `git checkout -b ${branch}`);
+      await this.assertGit(["checkout", "-b", branch], `git checkout -b ${branch}`);
     }
   }
 
-  private trySetUpstream(branch: string, remoteRef: string): void {
-    const result = this.runGit(["branch", "--set-upstream-to", remoteRef, branch]);
+  private async trySetUpstream(branch: string, remoteRef: string): Promise<void> {
+    const result = await this.runGit(["branch", "--set-upstream-to", remoteRef, branch]);
     if (result.exitCode !== 0 && !result.stderr.includes("set up to track")) {
       throw new Error(result.stderr || result.stdout || "git branch --set-upstream-to failed");
     }
   }
 
-  private ensureLocalConfig(key: string, value: string): void {
-    const existing = this.runGit(["config", "--local", "--get", key]);
+  private async ensureLocalConfig(key: string, value: string): Promise<void> {
+    const existing = await this.runGit(["config", "--local", "--get", key]);
     if (existing.exitCode === 0 && existing.stdout.length > 0) {
       return;
     }
 
-    const result = this.runGit(["config", "--local", key, value]);
+    const result = await this.runGit(["config", "--local", key, value]);
     if (result.exitCode !== 0) {
       throw new Error(result.stderr || result.stdout || `git config --local ${key} failed`);
     }
   }
 
-  private ensureCommitConfig(): void {
-    this.ensureLocalConfig("user.name", "Agent Sync");
-    this.ensureLocalConfig("user.email", "agentsync@local.invalid");
-    this.ensureLocalConfig("commit.gpgsign", "false");
+  private async ensureCommitConfig(): Promise<void> {
+    await this.ensureLocalConfig("user.name", "Agent Sync");
+    await this.ensureLocalConfig("user.email", "agentsync@local.invalid");
+    await this.ensureLocalConfig("commit.gpgsign", "false");
   }
 
   /**
@@ -167,7 +174,7 @@ export class GitClient {
 
   /** Ensure the expected remote exists without failing when it was already configured. */
   async ensureRemote(name: string, url: string): Promise<void> {
-    const result = this.runGit(["remote", "get-url", name]);
+    const result = await this.runGit(["remote", "get-url", name]);
     if (result.exitCode === 0) {
       if (result.stdout !== url) {
         throw new Error(
@@ -182,7 +189,7 @@ export class GitClient {
 
   /** Set the unborn HEAD branch explicitly before the first commit. */
   async setHeadBranch(branch: string): Promise<void> {
-    this.assertGit(
+    await this.assertGit(
       ["symbolic-ref", "HEAD", `refs/heads/${branch}`],
       `git symbolic-ref HEAD ${branch}`,
     );
@@ -191,7 +198,7 @@ export class GitClient {
   /** Inspect whether a remote branch currently exists and, if it does, capture its head SHA. */
   async inspectRemoteBranch(remote = "origin", branch = "main"): Promise<RemoteBranchState> {
     const refName = `refs/heads/${branch}`;
-    const result = this.runGit(["ls-remote", "--heads", remote, refName]);
+    const result = await this.runGit(["ls-remote", "--heads", remote, refName]);
     if (result.exitCode !== 0) {
       throw new Error(result.stderr || result.stdout || `git ls-remote failed for ${remote}`);
     }
@@ -239,7 +246,7 @@ export class GitClient {
       );
     }
 
-    this.assertGit(["fetch", "--prune", remote, branch], `git fetch ${remote} ${branch}`);
+    await this.assertGit(["fetch", "--prune", remote, branch], `git fetch ${remote} ${branch}`);
     const remoteRef = `refs/remotes/${remote}/${branch}`;
     const remoteHead = await this.revParse(remoteRef);
 
@@ -249,11 +256,11 @@ export class GitClient {
 
     const localHead = await this.revParse("HEAD");
     if (localHead === null) {
-      this.assertGit(
+      await this.assertGit(
         ["checkout", "-B", branch, remoteRef],
         `git checkout -B ${branch} ${remoteRef}`,
       );
-      this.trySetUpstream(branch, remoteRef);
+      await this.trySetUpstream(branch, remoteRef);
       return {
         status: "bootstrapped-existing",
         remote,
@@ -271,7 +278,7 @@ export class GitClient {
     }
 
     if (branchHead === remoteHead) {
-      this.trySetUpstream(branch, remoteRef);
+      await this.trySetUpstream(branch, remoteRef);
       return {
         status: "noop",
         remote,
@@ -281,9 +288,9 @@ export class GitClient {
       };
     }
 
-    if (this.isAncestor(branchHead, remoteHead)) {
-      this.assertGit(["merge", "--ff-only", remoteRef], `git merge --ff-only ${remoteRef}`);
-      this.trySetUpstream(branch, remoteRef);
+    if (await this.isAncestor(branchHead, remoteHead)) {
+      await this.assertGit(["merge", "--ff-only", remoteRef], `git merge --ff-only ${remoteRef}`);
+      await this.trySetUpstream(branch, remoteRef);
       return {
         status: "fast-forwarded",
         remote,
@@ -293,8 +300,8 @@ export class GitClient {
       };
     }
 
-    if (this.isAncestor(remoteHead, branchHead)) {
-      this.trySetUpstream(branch, remoteRef);
+    if (await this.isAncestor(remoteHead, branchHead)) {
+      await this.trySetUpstream(branch, remoteRef);
       return {
         status: "noop",
         remote,
@@ -305,8 +312,8 @@ export class GitClient {
     }
 
     if (options.force) {
-      this.assertGit(["reset", "--hard", remoteRef], `git reset --hard ${remoteRef}`);
-      this.trySetUpstream(branch, remoteRef);
+      await this.assertGit(["reset", "--hard", remoteRef], `git reset --hard ${remoteRef}`);
+      await this.trySetUpstream(branch, remoteRef);
       return {
         status: "fast-forwarded",
         remote,
@@ -343,7 +350,7 @@ export class GitClient {
       return false;
     }
 
-    this.ensureCommitConfig();
+    await this.ensureCommitConfig();
     await this.git.commit(message);
     return true;
   }


### PR DESCRIPTION
## Summary

The TUI **Sync** tab diffed local agent configs against the *on-disk vault
clone* and never fetched the remote. When skills were pushed from another
machine, the clone stayed behind `origin` until the user ran `pull`, so:

- vault skills also present locally were misreported as `local-only` ("new")
  because `stat` of the not-yet-fetched `.tar.age` bundle failed;
- vault-only skills never surfaced at all — `collectAgeFiles` walks only the
  stale clone, so "To pull: vault-only" showed `0` not because there was
  nothing to pull, but because the panel never looked at the remote.

This makes the Sync tab fast-forward the vault clone before diffing, and
records the fetch outcome in the Activity tab. A fetch failure is non-fatal:
the panel falls through to the stale clone so it stays usable offline.

Three follow-up fixes were folded in after the auto-fetch exposed latent bugs:

- **Event-loop freeze.** `GitClient.runGit` used `Bun.spawnSync`, so the
  network round-trips in `reconcileWithRemote` blocked the TUI render and
  input loop. The subprocess runner is now async (`Bun.spawn`).
- **Stacked Sync panel.** A synchronous store subscriber re-entered
  rendering when `ensureSyncLoaded` dispatched mid-render, appending a
  second panel. Renders are now coalesced onto a microtask.
- **Keypress feedback.** Action keys now flash before running: the pressed
  key shows as `[k]` in the footer/action bar and its label surfaces as a
  toast, so a keypress is visibly acknowledged even before slow work.

## Changes

- `src/commands/tui/tabs/sync.ts`
  - `loadRows` fast-forwards the vault clone via `GitClient.reconcileWithRemote`
    before `computeSyncStatus`, returning `{ rows, fetch }`.
  - Fetch failures (offline, auth, diverged history) are non-fatal —
    `computeSyncStatus` still runs against the stale clone.
  - `ensureSyncLoaded` writes an Activity entry per load (vault advanced /
    up to date / remote branch missing / fetch failed; failure also toasts).
- `src/core/git.ts`
  - `runGit` converted from `Bun.spawnSync` to async `Bun.spawn`; the
    private helpers that call it (`assertGit`, `isAncestor`, `trySetUpstream`,
    `ensureLocalConfig`, `ensureCommitConfig`) are now async. Every public
    method was already `async`, so the external API is unchanged.
- `src/commands/tui/app.ts`
  - Renders are coalesced onto a microtask, so a dispatch during render
    schedules the next render instead of re-entering the current one.
  - On an action keypress, `actionLabelFor` maps the key to a label;
    `handleKey` flashes the key (`setKeyHint`) and toasts the label before
    the handler runs. Footer and action bar render the flashed key as `[k]`.
- `src/commands/tui/state.ts`
  - Adds `keyHint` state and the `setKeyHint` helper for the keypress flash.
- `src/commands/__tests__/{integration,destroy}.test.ts`
  - Three real-git integration tests get a 20s timeout; the async
    subprocess path leaves them near the 5s default under full-suite load.

### Architecture

Before:

```mermaid
flowchart LR
  Open["Open Sync tab"] --> Load["loadRows"]
  Load --> Compute["computeSyncStatus<br/>diffs against stale clone"]
  Compute --> Render["Render rows<br/>vault-only always 0"]
  class Open,Load,Render plain
  class Compute bad
  classDef plain fill:#ecf0f1,color:#2c3e50
  classDef bad fill:#bf616a,color:#ffffff
```

After:

```mermaid
flowchart LR
  Open["Open Sync tab"] --> Load["loadRows"]
  Load --> Fetch["reconcileWithRemote<br/>async fast-forward"]
  Fetch --> Compute["computeSyncStatus<br/>diffs against fresh clone"]
  Compute --> Activity["Activity entry<br/>+ render accurate rows"]
  Fetch -. fetch fails .-> Compute
  class Open,Load,Activity plain
  class Fetch,Compute good
  classDef plain fill:#ecf0f1,color:#2c3e50
  classDef good fill:#2c3e50,color:#ffffff
```

## Test Evidence

- `tsc --noEmit` — passes.
- `biome ci` — clean (9 pre-existing warnings, no errors).
- `bun test` — 777 pass across 52 files (1 environment-only failure:
  `npm pack` dry-run, blocked by a local Volta pin issue unrelated to this
  change; passes in CI).

## Risks / Follow-ups

- The Sync tab now performs a network `git fetch` on each tab load (once
  per visit, guarded by the `loading`/`ready` phase check). The async
  subprocess means it no longer blocks render or input.
- The CLI `agentsync status` still does the old offline-only diff — same
  bug class, intentionally out of scope here.
- No fixture-backed test for the fetch path; the non-fatal fallback and
  `runOperation` plumbing are covered by existing tests.

## Checklist

- [ ] New code has tests where appropriate
- [x] Documentation updated if behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual key press feedback in action bars with brief on-screen highlights
  * Enhanced sync status with informational messages about vault branch state (missing, up-to-date, or advanced)

* **Bug Fixes**
  * Improved error handling during sync operations—displays last-known state when vault fetch fails

* **Tests**
  * Updated test timeouts for improved reliability in integration scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->