### PR TITLE
docs(operations): document HOSTNAME env-var fallback in machine-name resolution

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -96,8 +96,11 @@ Defaults are chosen so you can install and forget. Tune them only if you observe
 |---|---|---|
 | `AGENTSYNC_VAULT_DIR` | Vault clone directory | `~/.config/agentsync/vault` (Unix), `%APPDATA%/agentsync/vault` (Windows) |
 | `AGENTSYNC_KEY_PATH` | Private key file | `~/.config/agentsync/key.txt` (Unix), `%APPDATA%/agentsync/key.txt` (Windows) |
-| `AGENTSYNC_MACHINE` | Machine identifier in recipient names | derived from `os.hostname()` |
+| `AGENTSYNC_MACHINE` | Machine identifier in recipient names | `HOSTNAME` if set, else the `os.hostname()` call, else the literal `local-machine` |
+| `HOSTNAME` | Machine identifier when `AGENTSYNC_MACHINE` is unset (fallback only, not a recommended knob) | the `os.hostname()` call, else the literal `local-machine` |
 | `CODEX_HOME` | Codex root directory | `~/.codex` |
+
+`HOSTNAME` is consulted only as a fallback for the machine identifier. It is a bash-shell convenience variable, not a portable environment variable: it is generally absent under `sh`/`dash`/`zsh`, absent on macOS and Windows, and defaults to the container ID inside Docker. Two machines with the same `os.hostname()` but different exported `HOSTNAME` therefore resolve to different recipient names, and conversely, when neither variable is set, two machines whose `os.hostname()` returns the same value resolve to the same name. Set `AGENTSYNC_MACHINE` explicitly to make the identifier deterministic. See [Recipient naming](#recipient-naming) for why this value matters.
 
 ### Logs
 
@@ -131,7 +134,7 @@ Rotation requires the existing private key to still be readable, because every v
 
 ### Recipient naming
 
-Recipient names are stable config keys. Use machine names that describe the device clearly (`work-mbp`, `home-desktop`). Names are visible to anyone who can read the vault repository — they are not secret, but they should not encode anything you do not want associated with a public Git remote.
+Recipient names are stable config keys. Use machine names that describe the device clearly (`work-mbp`, `home-desktop`). Names are visible to anyone who can read the vault repository — they are not secret, but they should not encode anything you do not want associated with a public Git remote. When `AGENTSYNC_MACHINE` is unset the name is derived automatically; see the [Configuration](#configuration) section for the full `HOSTNAME` → `os.hostname()` → `local-machine` resolution chain.
 
 ## Verifying release binaries
 


### PR DESCRIPTION
## Summary

Fixes the machine-name documentation drift reported in #103. The
"Environment-variable escape hatches" table in `docs/operations.md`
documented only `AGENTSYNC_MACHINE` for machine identity, with a
`Default` cell that read "derived from `os.hostname()`".

The actual resolution in `src/commands/shared.ts:26` is a four-step
chain:

```ts
machineName:
  process.env.AGENTSYNC_MACHINE ?? process.env.HOSTNAME ?? hostname() ?? "local-machine",
```

Two gaps closed:

1. **`HOSTNAME` was an undocumented override.** When `AGENTSYNC_MACHINE`
   is unset, AgentSync consults the `HOSTNAME` env var *before* the
   `os.hostname()` call. `HOSTNAME` appeared nowhere in `docs/`,
   `README.md`, or `CLAUDE.md`.
2. **The `Default` cell was wrong.** It omitted both the `HOSTNAME` step
   and the `local-machine` static fallback.

This matters because the resolved `machineName` becomes a recipient key
name written into `agentsync.toml` inside the vault Git repo — the same
page warns recipient names are "visible to anyone who can read the vault
repository". An operator could not deliberately choose a name without
knowing every input that feeds it.

## Changes

`docs/operations.md` only — a doc-only fix. `operations.md` owns the
env-var table per the doc-ownership table in `contributing.md`, so the
change is single-file and does not trip the docs-mirror CI check.

- Add a `HOSTNAME` row to the escape-hatch table, marked fallback-only
  and not a recommended knob.
- Correct the `AGENTSYNC_MACHINE` `Default` cell to describe the full
  `HOSTNAME` → `os.hostname()` → `local-machine` chain.
- Add a paragraph on `HOSTNAME`'s bash-shell-specific, non-portable
  nature (absent under `sh`/`dash`/`zsh`, on macOS and Windows; the
  container ID under Docker) and the same-`os.hostname()` collision case.
- Cross-link the "Recipient naming" and "Configuration" sections so a
  reader choosing a recipient name sees the full set of inputs.

## Testing

- `bun run scripts/check-docs-mirror.ts` — passes
- `bun run check:spec-refs` — passes
- `mkdocs build --strict` — no link/anchor warnings; both new anchors
  (`#configuration`, `#recipient-naming`) resolve to real headings

## Notes

- A senior-review pass flagged that `??` only falls through on
  `undefined`/`null`, so an exported-but-empty `AGENTSYNC_MACHINE=` or
  `HOSTNAME=` yields an empty `machineName`. That is a pre-existing code
  behavior outside this docs-only diff; filed as #107 to track the code
  hardening separately.

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation to clarify machine-name resolution behavior, including default values and fallback rules for the `AGENTSYNC_MACHINE` environment variable.
  * Enhanced the "Recipient naming" section to document the complete resolution chain for machine identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->