### PR TITLE
fix: JSONC pull crash and Sync tab UX

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@opentui/core": "^0.2.10",
         "age-encryption": "^0.3.0",
         "citty": "^0.2.2",
+        "jsonc-parser": "^3.3.1",
         "picocolors": "^1.1.1",
         "simple-git": "^3.27.0",
         "tar": "^7.4.0",
@@ -110,6 +111,8 @@
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "lefthook": ["lefthook@2.1.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.6", "lefthook-darwin-x64": "2.1.6", "lefthook-freebsd-arm64": "2.1.6", "lefthook-freebsd-x64": "2.1.6", "lefthook-linux-arm64": "2.1.6", "lefthook-linux-x64": "2.1.6", "lefthook-openbsd-arm64": "2.1.6", "lefthook-openbsd-x64": "2.1.6", "lefthook-windows-arm64": "2.1.6", "lefthook-windows-x64": "2.1.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q=="],
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@opentui/core": "^0.2.10",
     "age-encryption": "^0.3.0",
     "citty": "^0.2.2",
+    "jsonc-parser": "^3.3.1",
     "picocolors": "^1.1.1",
     "simple-git": "^3.27.0",
     "tar": "^7.4.0",

--- a/src/agents/__tests__/_utils.test.ts
+++ b/src/agents/__tests__/_utils.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
-import { atomicWrite, collect, readIfExists } from "../_utils";
+import { atomicWrite, collect, readIfExists, setJsoncTopLevelKey } from "../_utils";
 
 // _utils helpers
 
@@ -88,5 +88,59 @@ describe("agents/_utils", () => {
     const artifact = collect(result, "/src/settings.json", "claude/settings.json.age");
     expect(artifact.warnings).toHaveLength(1);
     expect(artifact.warnings[0]).toContain("Detected");
+  });
+
+  // setJsoncTopLevelKey
+
+  test("setJsoncTopLevelKey writes a fresh object for empty input", () => {
+    const out = setJsoncTopLevelKey("", "rules", "be concise");
+    expect(JSON.parse(out)).toEqual({ rules: "be concise" });
+  });
+
+  test("setJsoncTopLevelKey edits one key in a strict-JSON document", () => {
+    const raw = `{\n  "editor.fontSize": 14,\n  "rules": "old"\n}\n`;
+    const parsed = JSON.parse(setJsoncTopLevelKey(raw, "rules", "new")) as Record<string, unknown>;
+    expect(parsed.rules).toBe("new");
+    expect(parsed["editor.fontSize"]).toBe(14);
+  });
+
+  test("setJsoncTopLevelKey tolerates a trailing comma instead of aborting", () => {
+    // A trailing comma is the JSONC feature that made strict JSON.parse throw
+    // "Property name must be a string literal" and abort the whole pull. The
+    // jsonc-parser edit API must set the key and leave the comma in place.
+    const raw = `{\n  "[typescript]": {\n    "editor.defaultFormatter": "esbenp.prettier-vscode",\n  },\n}\n`;
+    const out = setJsoncTopLevelKey(raw, "rules", "be concise");
+    expect(out).toContain('"rules": "be concise"');
+    expect(out).toContain('"esbenp.prettier-vscode"');
+  });
+
+  test("setJsoncTopLevelKey preserves comments in the document", () => {
+    const raw = `{\n  // user preference\n  "editor.wordWrap": "on"\n}\n`;
+    const out = setJsoncTopLevelKey(raw, "rules", "x");
+    expect(out).toContain("// user preference");
+    expect(out).toContain('"rules": "x"');
+  });
+
+  test("setJsoncTopLevelKey sets an object value (hooks/mcpServers path)", () => {
+    const raw = `{\n  "model": "opus"\n}\n`;
+    const parsed = JSON.parse(setJsoncTopLevelKey(raw, "hooks", { PreToolUse: [] })) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed.hooks).toEqual({ PreToolUse: [] });
+    expect(parsed.model).toBe("opus");
+  });
+
+  test("setJsoncTopLevelKey writes a fresh object for whitespace-only input", () => {
+    expect(JSON.parse(setJsoncTopLevelKey("  \n\t ", "rules", "x"))).toEqual({ rules: "x" });
+  });
+
+  test("setJsoncTopLevelKey replaces a non-object root instead of throwing", () => {
+    expect(JSON.parse(setJsoncTopLevelKey("[1, 2, 3]", "rules", "x"))).toEqual({ rules: "x" });
+  });
+
+  test("setJsoncTopLevelKey replaces a malformed document instead of corrupting it", () => {
+    const out = setJsoncTopLevelKey("{not valid json", "rules", "x");
+    expect(JSON.parse(out)).toEqual({ rules: "x" });
   });
 });

--- a/src/agents/_utils.ts
+++ b/src/agents/_utils.ts
@@ -8,6 +8,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { readFile, stat, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import { applyEdits, modify, type ParseError, parse } from "jsonc-parser";
 import type { RedactionResult } from "../core/sanitizer";
 
 /**
@@ -68,6 +69,37 @@ export async function readIfExists(path: string): Promise<string | null> {
 export async function atomicWrite(path: string, content: string | Buffer): Promise<void> {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, content);
+}
+
+/**
+ * Set a single top-level key in a JSONC document, leaving the rest of the file
+ * verbatim — comments, trailing commas, and formatting all survive.
+ *
+ * Agent config files (Cursor/VS Code settings.json, ~/.claude/settings.json,
+ * ~/.claude.json) are JSONC, not strict JSON. A plain `JSON.parse` on the apply
+ * path aborts the whole pull on a trailing comma, and a `JSON.parse` →
+ * `JSON.stringify` round-trip silently discards the user's comments. The
+ * `jsonc-parser` edit API tolerates JSONC and rewrites only the owned key, so a
+ * pull never reformats config AgentSync does not control.
+ *
+ * When `raw` has no editable JSONC object — it is empty, whitespace-only,
+ * malformed, or a non-object root (array/primitive) — there is nothing to edit
+ * in place: `modify` would either throw or splice a fresh object before the
+ * residual content. A clean single-key object is written instead. A freshly
+ * written file ends in a newline; an edited file keeps the user's own EOF.
+ */
+export function setJsoncTopLevelKey(raw: string, key: string, value: unknown): string {
+  const errors: ParseError[] = [];
+  const parsed = parse(raw, errors, { allowTrailingComma: true });
+  const rootIsObject =
+    errors.length === 0 && parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
+  if (!rootIsObject) {
+    return `${JSON.stringify({ [key]: value }, null, 2)}\n`;
+  }
+  const edits = modify(raw, [key], value, {
+    formattingOptions: { insertSpaces: true, tabSize: 2 },
+  });
+  return applyEdits(raw, edits);
 }
 
 /**

--- a/src/agents/claude/index.ts
+++ b/src/agents/claude/index.ts
@@ -13,6 +13,7 @@ import {
   readIfExists,
   type SnapshotArtifact,
   type SnapshotResult,
+  setJsoncTopLevelKey,
 } from "../_utils";
 import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "../skills-walker";
 import { applyClaudePluginsDir } from "./plugin-apply";
@@ -340,23 +341,32 @@ export async function applyClaudeMd(content: string): Promise<void> {
 export async function applyClaudeHooks(hooksJsonContent: string): Promise<void> {
   const home = homedir();
   const existingRaw = await readIfExists(AgentPaths.claude.settingsJson);
-  const existing = existingRaw ? (JSON.parse(existingRaw) as Record<string, unknown>) : {};
+  // Vault content was re-serialized as clean JSON on snapshot, so parsing it
+  // strict is safe. The local settings.json is JSONC — edit the `hooks` key in
+  // place so a trailing comma elsewhere does not abort the pull.
   const incoming = JSON.parse(hooksJsonContent) as Record<string, unknown>;
   // Denormalize only the incoming subset — local-only keys must not be touched
   // because they were never normalized on snapshot and any `$` in their values
   // is literal.
-  existing.hooks = denormalizeFromVault(incoming.hooks ?? {}, home);
-  await atomicWrite(AgentPaths.claude.settingsJson, `${JSON.stringify(existing, null, 2)}\n`);
+  const hooks = denormalizeFromVault(incoming.hooks ?? {}, home);
+  await atomicWrite(
+    AgentPaths.claude.settingsJson,
+    setJsoncTopLevelKey(existingRaw ?? "", "hooks", hooks),
+  );
 }
 
 /** Merge synced Claude MCP servers back into the local Claude config file. */
 export async function applyClaudeMcp(claudeJsonContent: string): Promise<void> {
   const home = homedir();
   const existingRaw = await readIfExists(AgentPaths.claude.mcpJson);
-  const existing = existingRaw ? (JSON.parse(existingRaw) as Record<string, unknown>) : {};
   const incoming = JSON.parse(claudeJsonContent) as Record<string, unknown>;
-  existing.mcpServers = denormalizeFromVault(incoming.mcpServers ?? {}, home);
-  await atomicWrite(AgentPaths.claude.mcpJson, `${JSON.stringify(existing, null, 2)}\n`);
+  // ~/.claude.json is large and JSONC-tolerant. Edit `mcpServers` in place so
+  // the rest of Claude's config (and any trailing comma) is left untouched.
+  const mcpServers = denormalizeFromVault(incoming.mcpServers ?? {}, home);
+  await atomicWrite(
+    AgentPaths.claude.mcpJson,
+    setJsoncTopLevelKey(existingRaw ?? "", "mcpServers", mcpServers),
+  );
 }
 
 /** Restore one Claude command markdown file from the vault. */

--- a/src/agents/cursor/index.ts
+++ b/src/agents/cursor/index.ts
@@ -1,6 +1,7 @@
 import { mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
+import { parse as parseJsonc } from "jsonc-parser";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
 import { denormalizeStringFromVault, normalizeStringForVault } from "../../core/path-portability";
@@ -12,6 +13,7 @@ import {
   readIfExists,
   type SnapshotArtifact,
   type SnapshotResult,
+  setJsoncTopLevelKey,
 } from "../_utils";
 import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "../skills-walker";
 
@@ -26,9 +28,13 @@ async function readCursorRules(): Promise<string | null> {
   const raw = await readIfExists(AgentPaths.cursor.settingsJson);
   if (raw === null) return null;
 
+  // Cursor's settings.json is JSONC. Parse it tolerantly so a comment or a
+  // trailing comma does not silently drop the user's `rules` from the vault.
   try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const rules = parsed.rules;
+    const parsed = parseJsonc(raw, undefined, { allowTrailingComma: true }) as
+      | Record<string, unknown>
+      | undefined;
+    const rules = parsed?.rules;
     if (typeof rules !== "string") return null;
     return rules;
   } catch {
@@ -102,9 +108,11 @@ export async function snapshotCursor(_config?: AgentSyncConfig): Promise<Snapsho
  */
 export async function applyCursorRules(rulesContent: string): Promise<void> {
   const raw = await readIfExists(AgentPaths.cursor.settingsJson);
-  const settings: Record<string, unknown> = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
-  settings.rules = denormalizeStringFromVault(rulesContent, homedir());
-  await atomicWrite(AgentPaths.cursor.settingsJson, `${JSON.stringify(settings, null, 2)}\n`);
+  const rules = denormalizeStringFromVault(rulesContent, homedir());
+  // Cursor's settings.json is JSONC. Edit the `rules` key in place so a
+  // trailing comma elsewhere does not abort the pull and the user's other
+  // settings and comments survive untouched.
+  await atomicWrite(AgentPaths.cursor.settingsJson, setJsoncTopLevelKey(raw ?? "", "rules", rules));
 }
 
 /**

--- a/src/agents/cursor/index.ts
+++ b/src/agents/cursor/index.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
-import { parse as parseJsonc } from "jsonc-parser";
+import { type ParseError, parse as parseJsonc } from "jsonc-parser";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
 import { denormalizeStringFromVault, normalizeStringForVault } from "../../core/path-portability";
@@ -30,10 +30,15 @@ async function readCursorRules(): Promise<string | null> {
 
   // Cursor's settings.json is JSONC. Parse it tolerantly so a comment or a
   // trailing comma does not silently drop the user's `rules` from the vault.
+  // jsonc-parser returns a best-effort partial object for malformed input
+  // instead of throwing, so reject on collected errors — otherwise a truncated
+  // `rules` value from a corrupt file could be synced.
   try {
-    const parsed = parseJsonc(raw, undefined, { allowTrailingComma: true }) as
+    const errors: ParseError[] = [];
+    const parsed = parseJsonc(raw, errors, { allowTrailingComma: true }) as
       | Record<string, unknown>
       | undefined;
+    if (errors.length > 0) return null;
     const rules = parsed?.rules;
     if (typeof rules !== "string") return null;
     return rules;

--- a/src/commands/tui/app.ts
+++ b/src/commands/tui/app.ts
@@ -261,7 +261,6 @@ function handleKey(key: KeyEvent, ctx: AppContext, quit: () => void): void {
     if (idx >= 0 && idx < TAB_IDS.length) {
       ctx.store.dispatch((d) => {
         d.activeTab = TAB_IDS[idx];
-        d.selection.clear();
       });
       return;
     }

--- a/src/commands/tui/tabs/sync.ts
+++ b/src/commands/tui/tabs/sync.ts
@@ -56,7 +56,7 @@ function copyToClipboard(text: string): void {
 
 const STATUS_VERB: Record<SyncRow["status"], string> = {
   synced: "synced",
-  "local-changed": "modified",
+  "local-changed": "changed",
   "local-only": "new",
   "vault-only": "missing",
   unknown: "unknown",
@@ -79,8 +79,8 @@ const SECTIONS: Section[] = [
   },
   {
     key: "local-changed",
-    title: "To push: local edits",
-    hint: "press p",
+    title: "Changed — local and vault differ",
+    hint: "press p to push or l to pull",
   },
   {
     key: "local-only",
@@ -1324,7 +1324,7 @@ function renderUnifiedRows(
 
 const SKILL_FILE_STATUS_VERB: Record<SkillFile["status"], string> = {
   synced: "synced",
-  "local-changed": "modified",
+  "local-changed": "changed",
   "local-only": "new",
   "vault-only": "missing",
 };
@@ -1622,8 +1622,9 @@ export function renderSync(renderer: CliRenderer, host: BoxRenderable, state: Ap
   // arrays.
   const cursorPath = navIndex[s.cursor]?.vaultPath;
 
-  // Verb column width — fits "modified:" (9 chars) plus the trailing colon
-  // we render inline. Picked so every section's rows line up consistently.
+  // Verb column width — fits the longest status verb plus the trailing colon
+  // we render inline ("missing:" / "unknown:", 8 chars). Picked so every
+  // section's rows line up consistently.
   const verbW = 10;
   const lines: string[] = [];
   let cursorLineIdx = -1;


### PR DESCRIPTION
## Summary

`agentsync pull` aborts with `JSON Parse error: Property name must be a string literal` whenever a machine's Cursor or Claude config is JSONC — i.e. contains `//` comments or a trailing comma. Cursor (and VS Code) `settings.json` is JSONC *by design*, so a single trailing comma anywhere in the file killed the entire pull. The apply path read the user's existing config with strict `JSON.parse`; the snapshot side did the same and would also silently drop the user's `rules` from the vault.

This PR makes agent-config reads JSONC-tolerant, and additionally fixes two Sync-tab UX issues surfaced alongside the crash report: inconsistent status wording and row selection being lost on number-key tab switches.

## Changes

### `agents` — JSONC-tolerant config apply (the crash)

- New `setJsoncTopLevelKey` in `src/agents/_utils.ts` — sets one top-level key via `jsonc-parser`'s `modify`/`applyEdits`, tolerating comments and trailing commas. Edits in place so the user's comments and formatting survive; the old `JSON.parse` → `JSON.stringify` round-trip silently reformatted the whole file and stripped comments on every pull. Falls back to a fresh single-key object when the document is empty, whitespace-only, malformed, or a non-object root.
- `applyCursorRules`, `applyClaudeHooks`, `applyClaudeMcp` now use it — strict `JSON.parse` on the user's existing config removed.
- `readCursorRules` parses `settings.json` with the tolerant parser — a trailing comma no longer silently drops `rules` from the vault on `push`.
- Added `jsonc-parser@^3.3.1` (Microsoft's, zero-dependency).
- 8 unit tests for `setJsoncTopLevelKey`.

### `tui` — Sync tab clarity

- Unified status vocabulary to `changed` across `STATUS_VERB` and `SKILL_FILE_STATUS_VERB` (was `modified` in rows, `edits` in the header, `changed` in the summary — three words for one state).
- Section header reworded `To push: local edits` → `Changed — local and vault differ`, since the classifier only detects *difference*, not direction.
- Removed a stray `selection.clear()` so row selection survives number-key tab switches, matching `Tab`-cycle behaviour.

### Architecture

Before — strict parse on the apply path:

```mermaid
flowchart LR
  pullA["agentsync pull"] --> applyA["applyCursorRules"]
  applyA --> parseA["JSON.parse settings.json"]
  parseA --> crashA["trailing comma throws<br/>whole pull aborts"]:::bad
  classDef bad fill:#bf616a,color:#ffffff
```

After — tolerant in-place edit:

```mermaid
flowchart LR
  pullB["agentsync pull"] --> applyB["applyCursorRules"]
  applyB --> editB["setJsoncTopLevelKey<br/>jsonc-parser modify"]
  editB --> okB["settings.json updated<br/>comments preserved"]:::good
  classDef good fill:#a3be8c,color:#2c3e50
```

## Test Evidence

- `bunx tsc --noEmit` — clean.
- `bunx biome ci .` — no errors (14 pre-existing warnings unchanged).
- 808 unit tests pass, 0 fail, including 8 new `setJsoncTopLevelKey` cases: empty, whitespace-only, strict JSON, trailing comma, comments, object value, array root, malformed root.
- The new trailing-comma test reproduces the exact crash input from the bug report and proves the pull no longer aborts.
- `bun test` exits non-zero from a pre-existing per-file coverage gate on the barely-tested TUI files — confirmed identical on the `main` baseline via `git stash`. CI's unit-test step already tolerates this exit when there are no `(fail)` markers.

## Risks / Follow-ups

Claude's *snapshot* path (`sanitizeClaudeHooks` / `sanitizeClaudeMcp` in `src/agents/claude/sanitize.ts`) still uses strict `JSON.parse`, so `push` could abort if `~/.claude/settings.json` or `~/.claude.json` is hand-edited into JSONC. That file is untouched by this PR; mirroring the tolerant parse there is a recommended follow-up. The pull-side crash and the full Cursor read+write paths are fixed.

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed tab navigation shortcuts clearing current selection state
- Configuration files now preserve formatting and comments during synchronization

**Style**
- Updated sync status terminology for clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->