### PR TITLE
fix(commands): treat blank env vars as unset in vault and key paths

### DIFF
--- a/src/commands/__tests__/shared.test.ts
+++ b/src/commands/__tests__/shared.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { resolveAgentSyncHome } from "../../config/paths";
 import { createTmpDir } from "../../test-helpers/fixtures";
 
 // resolveRuntimeContext + loadPrivateKey
@@ -129,6 +130,39 @@ describe("resolveRuntimeContext", () => {
 
     const ctx = await resolveRuntimeContext();
     expect(ctx.machineName).toBe("ci-runner");
+  });
+
+  test("treats an empty AGENTSYNC_VAULT_DIR as unset and falls back to the default path", async () => {
+    const { resolveRuntimeContext } = await import("../shared");
+
+    // An exported-but-empty env var is "", not undefined; `??` alone would
+    // short-circuit on it and yield an empty vault dir (the process CWD).
+    process.env.AGENTSYNC_VAULT_DIR = "";
+    process.env.AGENTSYNC_KEY_PATH = join(tmpDir, "key.txt");
+
+    const ctx = await resolveRuntimeContext();
+    expect(ctx.vaultDir).toBe(join(resolveAgentSyncHome(), "vault"));
+  });
+
+  test("treats an empty AGENTSYNC_KEY_PATH as unset and falls back to the default path", async () => {
+    const { resolveRuntimeContext } = await import("../shared");
+
+    process.env.AGENTSYNC_VAULT_DIR = join(tmpDir, "vault");
+    process.env.AGENTSYNC_KEY_PATH = "";
+
+    const ctx = await resolveRuntimeContext();
+    expect(ctx.privateKeyPath).toBe(join(resolveAgentSyncHome(), "key.txt"));
+  });
+
+  test("treats whitespace-only path env vars as unset and falls back to defaults", async () => {
+    const { resolveRuntimeContext } = await import("../shared");
+
+    process.env.AGENTSYNC_VAULT_DIR = "   ";
+    process.env.AGENTSYNC_KEY_PATH = "\t";
+
+    const ctx = await resolveRuntimeContext();
+    expect(ctx.vaultDir).toBe(join(resolveAgentSyncHome(), "vault"));
+    expect(ctx.privateKeyPath).toBe(join(resolveAgentSyncHome(), "key.txt"));
   });
 });
 

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -31,8 +31,8 @@ export async function resolveRuntimeContext(): Promise<RuntimeContext> {
   await mkdir(baseDir, { recursive: true });
 
   return {
-    vaultDir: process.env.AGENTSYNC_VAULT_DIR ?? join(baseDir, "vault"),
-    privateKeyPath: process.env.AGENTSYNC_KEY_PATH ?? join(baseDir, "key.txt"),
+    vaultDir: nonBlank(process.env.AGENTSYNC_VAULT_DIR) ?? join(baseDir, "vault"),
+    privateKeyPath: nonBlank(process.env.AGENTSYNC_KEY_PATH) ?? join(baseDir, "key.txt"),
     // AGENTSYNC_MACHINE env var > HOSTNAME env var > os.hostname() > static fallback
     machineName:
       nonBlank(process.env.AGENTSYNC_MACHINE) ??


### PR DESCRIPTION
## Summary

`resolveRuntimeContext()` resolved `vaultDir` and `privateKeyPath` with a bare nullish-coalescing chain: `process.env.AGENTSYNC_VAULT_DIR ?? join(baseDir, "vault")`. `??` only falls through on `null`/`undefined`, so an exported-but-empty env var (`AGENTSYNC_VAULT_DIR=` or `AGENTSYNC_KEY_PATH=`) is the empty string `""` — a defined value — and short-circuits the chain. The vault dir or key path then resolves to `""`, which downstream path joins treat as the process CWD instead of the intended `~/.config/agentsync` defaults.

This is the same bug class as #107 (machineName), in the same function. Empty exported env vars are plausible when a wrapper script does `export AGENTSYNC_VAULT_DIR=$SOMETHING_UNSET`.

Closes #110.

## Changes

- `src/commands/shared.ts` — applied the existing `nonBlank()` helper (added for the `machineName` chain in #111) to the `vaultDir` and `privateKeyPath` reads. `nonBlank()` trims a candidate and maps `null`/`undefined`/whitespace-only to `undefined`, so `??` falls through on blank values. No new helper — the fix reuses the one already in the same file.
- `src/commands/__tests__/shared.test.ts` — added 3 regression tests: empty-string `AGENTSYNC_VAULT_DIR`, empty-string `AGENTSYNC_KEY_PATH`, and whitespace-only path vars, each asserting fall-through to the `resolveAgentSyncHome()`-based default path.

### Architecture

```mermaid
flowchart LR
  subgraph resolution["vault and key path resolution"]
    direction TB
    EnvV["AGENTSYNC_VAULT_DIR env var"] --> CoalV{"?? null or undefined only"}
    CoalV -->|"empty string passes through"| BadOut["vaultDir = empty string maps to CWD"]:::bad
    CoalV -->|null or undefined| DefV["join baseDir vault"]
    EnvN["AGENTSYNC_VAULT_DIR env var after fix"] --> Blank{"nonBlank: blank maps to undefined"}
    Blank -->|"empty or whitespace falls through"| DefV2["join baseDir vault"]:::good
  end
  classDef bad fill:#c0392b,color:#ffffff
  classDef good fill:#1e8449,color:#ffffff
```

Before: a blank `AGENTSYNC_VAULT_DIR`/`AGENTSYNC_KEY_PATH` short-circuits to an empty path. After: `nonBlank()` collapses blank values to `undefined`, so resolution always reaches the intended default.

## Test Evidence

- `bun test src/commands/__tests__/shared.test.ts` — 14 pass, 0 fail.
- `src/commands/shared.ts` — 100% line / 100% function coverage.
- `bun run typecheck`, `bun run lint`, `check:docs`, `check:spec-refs` — all pass.

## Risks / Follow-ups

- The new tests touch the real `resolveAgentSyncHome()` base directory (`~/.config/agentsync`) because that path is not redirectable — a pre-existing harness limitation shared by every test in the file, not introduced here. Tracked as #113 (make `resolveAgentSyncHome()` honor an `AGENTSYNC_HOME` override for hermetic tests).

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed (no user-facing doc change; same internal pattern as #107)
