### PR TITLE
fix(config): treat blank APPDATA and CODEX_HOME env vars as unset

### DIFF
--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -5,24 +5,13 @@ import { log } from "@clack/prompts";
 import { loadConfig, resolveConfigPath } from "../config/loader";
 import { resolveAgentSyncHome } from "../config/paths";
 import type { AgentSyncConfig } from "../config/schema";
+import { nonBlank } from "../lib/env";
 
 /** Runtime paths and machine identity resolved from the local environment. */
 export interface RuntimeContext {
   vaultDir: string;
   privateKeyPath: string;
   machineName: string;
-}
-
-/**
- * Trim a candidate string and treat blank values as absent. An exported but
- * empty env var is "" (a defined string), so `??` alone would short-circuit
- * the fallback chain on it; this collapses "" and whitespace-only to undefined
- * so resolution falls through to the next source. A non-blank value is
- * returned trimmed.
- */
-function nonBlank(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
 }
 
 /** Resolve the working directories and machine label that all commands share. */

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { nonBlank } from "../lib/env";
 
 const HOME = homedir();
 const PLATFORM = process.platform;
@@ -45,7 +46,7 @@ export const AgentPaths = {
     marketplaceJson: join(HOME, ".claude", ".claude-plugin", "marketplace.json"),
   },
   codex: (() => {
-    const CODEX_HOME = process.env.CODEX_HOME ?? join(HOME, ".codex");
+    const CODEX_HOME = nonBlank(process.env.CODEX_HOME) ?? join(HOME, ".codex");
     return {
       root: CODEX_HOME,
       agentsMd: join(CODEX_HOME, "AGENTS.md"),
@@ -140,12 +141,12 @@ export function resolveClaudePluginPaths(pluginRoot: string): {
  * directory, a different path.
  */
 export function resolveAgentSyncHome(): string {
-  const override = process.env.AGENTSYNC_DIR?.trim();
+  const override = nonBlank(process.env.AGENTSYNC_DIR);
   if (override) {
     return override;
   }
   if (process.platform === "win32") {
-    return join(process.env.APPDATA ?? HOME, "agentsync");
+    return join(nonBlank(process.env.APPDATA) ?? HOME, "agentsync");
   }
   return join(HOME, ".config", "agentsync");
 }

--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { nonBlank } from "../env";
+
+describe("nonBlank", () => {
+  test("returns undefined for undefined", () => {
+    expect(nonBlank(undefined)).toBeUndefined();
+  });
+
+  test("returns undefined for an empty string", () => {
+    expect(nonBlank("")).toBeUndefined();
+  });
+
+  test("returns undefined for a whitespace-only string", () => {
+    expect(nonBlank("   ")).toBeUndefined();
+    expect(nonBlank("\t")).toBeUndefined();
+    expect(nonBlank("\n")).toBeUndefined();
+  });
+
+  test("returns a non-blank value unchanged", () => {
+    expect(nonBlank("value")).toBe("value");
+  });
+
+  test("trims surrounding whitespace from a non-blank value", () => {
+    expect(nonBlank("  value  ")).toBe("value");
+  });
+
+  test("preserves internal whitespace", () => {
+    expect(nonBlank("  a b  ")).toBe("a b");
+  });
+
+  test("treats '0' as a real value, not a blank", () => {
+    // The check is blank-vs-non-blank, not falsy-vs-truthy: "0" is a valid
+    // non-empty string and must survive.
+    expect(nonBlank("0")).toBe("0");
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,11 @@
+/**
+ * Trim a candidate string and treat blank values as absent. An exported but
+ * empty env var is "" (a defined string), so `??` alone would short-circuit
+ * the fallback chain on it; this collapses "" and whitespace-only to undefined
+ * so resolution falls through to the next source. A non-blank value is
+ * returned trimmed.
+ */
+export function nonBlank(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}


### PR DESCRIPTION
## Summary

`resolveAgentSyncHome()`'s Windows branch read `process.env.APPDATA ?? HOME`, and the `AgentPaths.codex` IIFE read `process.env.CODEX_HOME ?? join(HOME, ".codex")`. `??` only falls through on `null`/`undefined`, so an exported-but-empty `APPDATA=` or `CODEX_HOME=` is the empty string `""` and short-circuits the fallback, rooting the resolved path at `""` (the process CWD). This is the same bare-`??` bug class as #107 (machineName) and #110 (vault/key paths).

Closes #115.

## Changes

- `src/lib/env.ts` (new) — exports `nonBlank()`, the single definition of the "blank env var means unset" rule. A dependency-free leaf module, so both `config/` and `commands/` can import it without a circular reference.
- `src/lib/__tests__/env.test.ts` (new) — 7 unit tests: `undefined`, empty, whitespace-only (`\t`, `\n`), plain value, trimmed value, preserved internal whitespace, and `"0"` (guards against confusing blank-vs-unset with falsy-vs-truthy).
- `src/commands/shared.ts` — dropped the private `nonBlank()`, now imports it from `../lib/env`. Behavior unchanged. This also removes a latent upward dependency: had `config/paths.ts` ever needed the helper from its old home, it would have had to import *up* into `commands/`.
- `src/config/paths.ts` — imports `nonBlank()` and applies it at three env reads: `APPDATA` (Windows branch), `CODEX_HOME` (codex IIFE), and the `AGENTSYNC_DIR` read (replacing the inline `?.trim()` added in #113).

## Behavior note

`nonBlank()` also **trims** a non-blank value before returning it. The previous bare `??` at the `APPDATA` and `CODEX_HOME` sites passed the env value through verbatim, so this is a small additional behavior change at those two sites: a path env var with stray leading/trailing whitespace (e.g. `CODEX_HOME=" /opt/codex "`) is now normalized. This is intended — a filesystem path env var with surrounding whitespace is a misconfiguration — and matches what `AGENTSYNC_DIR` already did.

## Test Evidence

- Full suite — 826 pass, 0 fail (+7 from the new `env.test.ts`).
- `src/lib/env.ts` and `src/commands/shared.ts` — 100% line / 100% function coverage.
- `bun run typecheck`, `bun run lint`, `check:docs`, `check:spec-refs` — all pass.

## Risks / Follow-ups

- The `APPDATA` branch executes only on Windows (the CI runner is Linux) and `CODEX_HOME` is captured in a module-load-time IIFE that Bun's module cache makes impractical to re-exercise per test, so neither call site has a dedicated integration test. Their correctness rests on `nonBlank()`'s direct unit tests plus the type-checked wiring. Making `AgentPaths.codex` testable would require refactoring it from a frozen object into a call-time function, rippling across every consumer — deliberately out of scope.

## Checklist

- [x] New code has tests where appropriate
- [x] Documentation updated if behavior changed (no user-facing doc change; the whitespace-normalization note is in this description)
