### PR TITLE
fix(daemon): use os.tmpdir() for Windows task XML path

### DIFF
--- a/src/daemon/__tests__/installer-windows.test.ts
+++ b/src/daemon/__tests__/installer-windows.test.ts
@@ -8,7 +8,9 @@
  * (`__setInstallerWindowsImplForTests`). Bypasses Bun's mock.module()
  * entirely so daemon.test.ts's installer overrides cannot bleed in.
  */
+
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
 
 const fsWrites = new Map<string, string>();
 const fsRms = new Set<string>();
@@ -150,6 +152,40 @@ describe("installWindows", () => {
 
     const xmlEntry = [...fsRms].find((p) => p.endsWith(".xml"));
     expect(xmlEntry).toBeDefined();
+  });
+
+  // Regression guard: the install path must always resolve under os.tmpdir().
+  // Hand-rolling `process.env.TEMP ?? "C:\\Temp"` previously produced a path
+  // whose parent does not exist on stock Windows, aborting installWindows()
+  // with ENOENT before schtasks /Create ever ran.
+  test("writes XML under os.tmpdir() with the agentsync-task.xml filename", async () => {
+    await m.installWindows(["C:\\agentsync.exe"]);
+
+    const xmlPath = [...fsWrites.keys()].find((p) => p.endsWith("agentsync-task.xml"));
+    expect(xmlPath).toBeDefined();
+    if (!xmlPath) return;
+    expect(xmlPath.startsWith(tmpdir())).toBe(true);
+  });
+
+  // Regression guard: an exported-but-empty TEMP env var must not collapse
+  // the write path to drive root. `??` would short-circuit only on undefined,
+  // letting "" through; os.tmpdir() treats blanks as unset and falls through
+  // its own resolution chain.
+  test("resolves under os.tmpdir() even when TEMP is set to empty string", async () => {
+    const saved = process.env.TEMP;
+    process.env.TEMP = "";
+    try {
+      await m.installWindows(["C:\\agentsync.exe"]);
+
+      const xmlPath = [...fsWrites.keys()].find((p) => p.endsWith("agentsync-task.xml"));
+      expect(xmlPath).toBeDefined();
+      if (!xmlPath) return;
+      expect(xmlPath.startsWith(tmpdir())).toBe(true);
+      // Defence-in-depth: must not be the drive-root regression
+      expect(xmlPath).not.toBe("\\agentsync-task.xml");
+    } finally {
+      process.env.TEMP = saved;
+    }
   });
 });
 

--- a/src/daemon/installer-windows.ts
+++ b/src/daemon/installer-windows.ts
@@ -8,6 +8,8 @@
  */
 import { execFile } from "node:child_process";
 import type * as fsPromises from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import { log } from "@clack/prompts";
 
@@ -156,7 +158,9 @@ export async function installWindows(args: string[]): Promise<void> {
   const override = getOverride("installWindows");
   if (override) return override(args);
   const xml = buildXml(args);
-  const tmpXml = `${process.env.TEMP ?? "C:\\Temp"}\\agentsync-task.xml`;
+  // Use os.tmpdir() so the resolved directory always exists: on Windows it
+  // checks TEMP → TMP → %SystemRoot%\Temp and treats blank values as unset.
+  const tmpXml = join(tmpdir(), "agentsync-task.xml");
 
   const { writeFile, rm } = await fsImpl();
   await writeFile(tmpXml, xml, "utf16le");


### PR DESCRIPTION
## Summary

Fix the Windows daemon installer so `agentsync daemon install` does not
abort with `ENOENT` on a stock Windows install. The previous code hand-
rolled the temp path as `` `${process.env.TEMP ?? "C:\\Temp"}\\agentsync-task.xml` ``,
which has two cross-platform defects: (1) the fallback `C:\Temp` does not
exist on stock Windows, so `writeFile` throws and the installer aborts
before `schtasks /Create` runs; (2) `??` does not treat an exported-but-
empty `TEMP=` as unset, so the path collapses to `\agentsync-task.xml`
at drive root. Replace with `join(tmpdir(), "agentsync-task.xml")`, which
checks `TEMP` → `TMP` → `%SystemRoot%\Temp` and treats blanks as unset —
matching the existing pattern in `src/commands/daemon.ts` and
`src/core/version-check.ts`.

## Changes

- `src/daemon/installer-windows.ts`: import `tmpdir` from `node:os` and
  `join` from `node:path`; rebuild `tmpXml` in `installWindows()` via
  `join(tmpdir(), "agentsync-task.xml")`. No behaviour change when
  `TEMP` is set and non-empty.
- `src/daemon/__tests__/installer-windows.test.ts`: add two regression
  tests against the existing `fsStub` injection: one asserts the write
  path lives under `os.tmpdir()` and ends with `agentsync-task.xml`;
  the other sets `TEMP=""` and asserts the path does not collapse to
  drive root. The blank-`TEMP` test saves and restores `process.env.TEMP`
  in a `try/finally`.

## Diagram

```mermaid
graph TD
    A["agentsync daemon install (Windows)"] --> B["installWindows(args)"]
    B --> C{"Resolve tmpXml"}
    C -->|before| D1["process.env.TEMP ?? C:\\Temp + \\agentsync-task.xml"]
    D1 --> E1{"TEMP state"}
    E1 -->|set, non-empty| F1["writes to real temp"]
    E1 -->|undefined| G1["C:\\Temp\\agentsync-task.xml"]
    G1 --> H1["writeFile ENOENT on stock Windows — install aborts"]:::bad
    E1 -->|empty string| I1["\\agentsync-task.xml at drive root"]:::bad
    C -->|after| D2["join(tmpdir(), agentsync-task.xml)"]
    D2 --> F2["tmpdir() checks TEMP then TMP then SystemRoot Temp; blanks treated as unset"]:::good
    F2 --> J["writeFile succeeds → schtasks /Create runs"]:::good
    classDef bad fill:#c0392b,color:#ffffff,stroke:#7b241c
    classDef good fill:#1e8449,color:#ffffff,stroke:#196f3d
```

## Files changed (path · one-line rationale)

- `src/daemon/installer-windows.ts` · swap hand-rolled temp path for `join(tmpdir(), "agentsync-task.xml")`; add `node:os` and `node:path` imports.
- `src/daemon/__tests__/installer-windows.test.ts` · add two regression tests pinning the `tmpdir()` invariant (default + blank-`TEMP`).

## Commits (sha · subject)

- `a718251` · fix(daemon): use os.tmpdir() for Windows task XML path

## Tests run (command · result)

- `bun test src/daemon/__tests__/installer-windows.test.ts` · pass — 18 pass, 0 fail (16 pre-existing + 2 new regression guards).
- `bun run typecheck` · pass (`tsc --noEmit`).
- `bun run lint` · pass (Biome, 14 pre-existing warnings, 0 errors — none introduced by this PR).
- `bun run check:spec-refs` · pass — `spec-tracker leakage check passed (139 files)`.
- `bun test` (full suite) · 1 pre-existing failure in `src/commands/__tests__/daemon.test.ts > install subcommand calls installer.install with args array`. Reproduced on `main` from the same sandbox before any changes: the workspace lives under `/tmp`, which trips `isEphemeralPath()` in `src/commands/daemon.ts:33-36`. Not caused by this PR — no daemon-command code is touched.

## Verification

- `rg "process\.env\.TEMP" src` returns no results — the installer was the lone direct reader, now removed.
- `src/daemon/installer-windows.ts` imports `tmpdir` from `node:os` and `join` from `node:path`; `tmpXml` is built via `join(tmpdir(), "agentsync-task.xml")`.
- New test `writes XML under os.tmpdir() with the agentsync-task.xml filename` asserts the resolved path satisfies `xmlPath.startsWith(tmpdir())` and ends with `agentsync-task.xml`.
- New test `resolves under os.tmpdir() even when TEMP is set to empty string` sets `process.env.TEMP = ""`, invokes `installWindows`, asserts the path is still under `tmpdir()` and is not the drive-root `\agentsync-task.xml`, then restores the env in `finally`.

Closes #125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows installer reliability by fixing temporary task file path resolution to ensure correct system temporary directory usage regardless of environment configuration.

* **Tests**
  * Added regression tests to verify scheduled task file placement in the system temporary directory and confirm proper handling of misconfigured environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->