### PR TITLE
fix(sanitizer): detect AGE-SECRET-KEY-1 vault identity in secret scanner

### DIFF
--- a/src/core/__tests__/sanitizer.test.ts
+++ b/src/core/__tests__/sanitizer.test.ts
@@ -162,6 +162,7 @@ describe("sanitizer", () => {
     ["slack-token-app", `xoxa-${"abc123".repeat(2)}`],
     ["slack-token-refresh", `xoxr-${"abc123".repeat(2)}`],
     ["slack-token-session", `xoxs-${"abc123".repeat(2)}`],
+    ["age-secret-key", `AGE-SECRET-KEY-1${"A".repeat(58)}`],
   ])("scanForSecrets detects %s embedded in prose", (expectedName, sampleSecret) => {
     const body = `Note from setup: my key is ${sampleSecret}. Do not share.`;
     const warnings = scanForSecrets(body, "/tmp/leaky.md");
@@ -190,6 +191,18 @@ describe("sanitizer", () => {
     const warnings = scanForSecrets(mcpJson, "/home/user/.claude.json");
     expect(warnings.length).toBeGreaterThan(0);
     expect(warnings.some((w) => w.includes("anthropic-api-key"))).toBe(true);
+  });
+
+  test("redactSecretLiterals rewrites an age secret key pasted as a whole JSON value", () => {
+    // An MCP env block like { AGENTSYNC_KEY: "AGE-SECRET-KEY-1..." } must be
+    // redacted, not just aborted, so the rest of the structured config survives.
+    const ageKey = `AGE-SECRET-KEY-1${"A".repeat(58)}`;
+    const input = { env: { AGENTSYNC_KEY: ageKey } };
+    const result = redactSecretLiterals(input);
+    const value = result.value as { env: { AGENTSYNC_KEY: string } };
+    expect(value.env.AGENTSYNC_KEY).not.toBe(ageKey);
+    expect(value.env.AGENTSYNC_KEY.startsWith("$AGENTSYNC_REDACTED")).toBeTrue();
+    expect(result.warnings.length).toBeGreaterThan(0);
   });
 
   test("scanForSecrets does NOT false-positive on long alphanumeric runs in prose", () => {

--- a/src/core/sanitizer.ts
+++ b/src/core/sanitizer.ts
@@ -66,6 +66,13 @@ const WHOLE_VALUE_SECRET_PATTERNS = [
   /^sk-[a-zA-Z0-9]{20,}$/,
   /^ghp_[a-zA-Z0-9]{36}$/,
   /^xoxb-[0-9]+-[a-zA-Z0-9]+$/,
+  // AgentSync's own vault identity. Bech32 HRP "AGE-SECRET-KEY-", separator
+  // "1", uppercased, so the body is a strict subset of [A-Z0-9]. A native
+  // X25519 key is a fixed 32 bytes, which bech32-encodes to exactly 58 chars,
+  // so we bound to the exact length like the other fixed-size patterns. The
+  // hyphens in the prefix mean the base64 catch-all below can never match it,
+  // so this anchored entry is required to redact a key pasted as a JSON value.
+  /^AGE-SECRET-KEY-1[A-Z0-9]{58}$/,
   /^[A-Za-z0-9+/]{40,}={0,2}$/,
 ];
 
@@ -87,6 +94,11 @@ export const EMBEDDED_SECRET_PATTERNS: ReadonlyArray<{ name: string; pattern: Re
   { name: "aws-access-key", pattern: /AKIA[0-9A-Z]{16}/ },
   { name: "google-api-key", pattern: /AIza[0-9A-Za-z_-]{35}/ },
   { name: "slack-token", pattern: /xox[abprs]-[A-Za-z0-9-]{10,}/ },
+  // The vault's own age identity decrypts every artifact AgentSync has ever
+  // stored, retroactively and irreversibly once committed to git history. A
+  // native X25519 key bech32-encodes to a fixed 58-char body; the 16-char
+  // prefix makes false positives on prose effectively impossible.
+  { name: "age-secret-key", pattern: /AGE-SECRET-KEY-1[A-Z0-9]{58}/ },
 ];
 
 export interface RedactionResult<T> {


### PR DESCRIPTION
## Summary

Closes #136.

The sanitizer's two secret-pattern arrays covered eight third-party credential formats but had **no entry for the vault's own age identity** — the single most catastrophic secret in AgentSync's threat model, since it decrypts every artifact ever stored.

A user pasting `AGE-SECRET-KEY-1...` into a synced file (a `CLAUDE.md` backup reminder, an `mcp.json` `env` block, a skill README key-rotation example) would pass both defense-in-depth chokepoints (`scanForSecrets` → abort, `redactSecretLiterals` → redact) because no pattern matched. The master key would then be encrypted to the recipient list and committed to **immutable** git history — recoverable forever by any current or future recipient.

## Changes

- `src/core/sanitizer.ts`
  - `EMBEDDED_SECRET_PATTERNS` (unanchored, drives `scanForSecrets`): `AGE-SECRET-KEY-1[A-Z0-9]{58}` → aborts a push when the key appears inside prose.
  - `WHOLE_VALUE_SECRET_PATTERNS` (anchored, drives `redactSecretLiterals`): `^AGE-SECRET-KEY-1[A-Z0-9]{58}$` → rewrites a key pasted as a whole JSON string value.
- `src/core/__tests__/sanitizer.test.ts`
  - +1 parameterised row covering the embedded/scan path.
  - +1 dedicated test covering the whole-value JSON redaction path.

## Why a dedicated pattern (not the base64 catch-all)

The existing catch-all is `^[A-Za-z0-9+/]{40,}={0,2}$` — its charset has no hyphens, so the `AGE-SECRET-KEY-` prefix can never match it. A dedicated entry is required, not redundant.

## Why `{58}` exactly

A native age X25519 identity is a fixed 32-byte key; bech32 encodes it to a deterministic 58-char `[A-Z0-9]` body (52 data + 6 checksum). This matches the file's documented exact-length convention for fixed-size keys (`ghp_...{36}`, `AKIA...{16}`). The 16-char prefix drives false positives on prose to ~zero.

## Testing

- `bun test` — full suite passes (830 pass, 0 fail); `sanitizer.ts` at 100% line/func coverage.
- typecheck, biome lint, spec-ref check all clean.
- Verified independently (senior review): a real generated identity has a 58-char body across 200 generations; the public `age1...` recipient does **not** false-match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)