### PR TITLE
fix(config): make writeConfig crash-safe with atomic temp-and-rename

### DIFF
--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { createTmpDir } from "../../test-helpers/fixtures";
@@ -86,6 +86,30 @@ describe("loader", () => {
     expect(reloaded.recipients).toEqual(original.recipients);
     expect(reloaded.agents).toEqual(original.agents);
     expect(reloaded.sync.debounceMs).toBe(original.sync.debounceMs);
+  });
+
+  test("writeConfig leaves no temp sibling after a successful write", async () => {
+    await writeFile(configPath, MINIMAL_TOML, "utf8");
+    const config = await loadConfig(configPath);
+    await writeConfig(configPath, config);
+    // The temp file must have been renamed over the destination, not left behind.
+    const leftovers = (await readdir(tmpDir)).filter((f) => f.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
+    expect((await loadConfig(configPath)).version).toBe("1");
+  });
+
+  test("writeConfig preserves the destination and removes the temp when rename fails", async () => {
+    // A directory at the destination path makes rename(file -> dir) fail,
+    // standing in for any mid-write rename failure. The original must survive
+    // and no partial temp may be left in the vault tree.
+    const dirDest = join(tmpDir, "as-dir");
+    await mkdir(dirDest, { recursive: true });
+    await writeFile(configPath, MINIMAL_TOML, "utf8");
+    const config = await loadConfig(configPath);
+    await expect(writeConfig(dirDest, config)).rejects.toThrow();
+    const leftovers = (await readdir(tmpDir)).filter((f) => f.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
+    expect((await stat(dirDest)).isDirectory()).toBeTrue();
   });
 
   test("writeConfig creates parent directories if needed", async () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { parse, stringify } from "@iarna/toml";
 import { type AgentSyncConfig, AgentSyncConfigSchema } from "./schema";
@@ -13,11 +14,61 @@ export async function loadConfig(configPath: string): Promise<AgentSyncConfig> {
   return AgentSyncConfigSchema.parse(structuredClone(parsed));
 }
 
-/** Persist a validated config object back to the canonical agentsync TOML location. */
+/**
+ * Persist a validated config object to the canonical agentsync TOML location.
+ *
+ * agentsync.toml gates every command through loadConfig, and a plain writeFile
+ * opens with O_TRUNC: a crash, SIGKILL, OOM-kill, or power loss mid-write leaves
+ * the file empty or partial, after which loadConfig throws and the vault bricks.
+ *
+ * Write to a unique sibling temp file, fsync it, then rename it over the
+ * destination. rename(2) is atomic on a single filesystem (the temp sits in the
+ * same dir), so a crash always leaves either the old file or the new file fully
+ * intact, never a truncated middle — that atomicity is the core guarantee. The
+ * temp fsync also forces the bytes to disk before the file is visible under the
+ * canonical name, so a reader never sees a rename pointing at unwritten data;
+ * this is why the read-after-write in our own tests is safe here even though the
+ * deliberately-non-atomic atomicWrite in agents/_utils.ts dropped rename to dodge
+ * a Bun-on-tmpfs visibility race. Config needs real durability that atomicWrite
+ * forgoes, so we keep the rename and pay for the fsync.
+ *
+ * The temp name is randomized so two concurrent writers (e.g. overlapping key
+ * commands) never share a scratch file and clobber each other's bytes.
+ */
 export async function writeConfig(configPath: string, config: AgentSyncConfig): Promise<void> {
-  await mkdir(dirname(configPath), { recursive: true });
+  const dir = dirname(configPath);
+  await mkdir(dir, { recursive: true });
   const serialized = stringify(config as unknown as Parameters<typeof stringify>[0]);
-  await writeFile(configPath, serialized, "utf8");
+  const tmpPath = `${configPath}.${randomUUID()}.tmp`;
+  const handle = await open(tmpPath, "w");
+  try {
+    await handle.writeFile(serialized, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await rename(tmpPath, configPath);
+  } catch (err) {
+    // Rename failed, so the destination is untouched. Drop the temp file so a
+    // failed write never leaks a partial agentsync.toml temp into the vault tree.
+    await unlink(tmpPath).catch(() => {});
+    throw err;
+  }
+  // Best-effort: persist the directory entry the rename created so the switch to
+  // the new file survives power loss, not just the file's contents. Some
+  // platforms (Windows) reject fsync on a directory fd, so a failure here is
+  // non-fatal — the rename has already happened.
+  try {
+    const dirHandle = await open(dir, "r");
+    try {
+      await dirHandle.sync();
+    } finally {
+      await dirHandle.close();
+    }
+  } catch {
+    // Directory fsync unsupported on this platform; the atomicity guarantee holds.
+  }
 }
 
 /** Build the canonical config path inside a vault directory. */


### PR DESCRIPTION
## Summary

Closes #138.

`writeConfig` wrote `agentsync.toml` with a plain `O_TRUNC` `writeFile`. A crash, SIGKILL, OOM-kill, or power loss between the truncate and the final byte left the file empty or partial — after which `loadConfig` throws and **every** command that funnels through `loadVaultConfigOrExit` exits. There is no in-tree fallback; `agentsync.toml` is the single source of truth for recipients, remote, branch, and agent toggles.

The worst case is `key rotate`: the new private key is already on disk and vault files are re-encrypted to the new recipient, but a truncated config blocks every recovery path (`git checkout HEAD -- agentsync.toml` restores the *old* recipient, and re-publishing the new key hits the `name-conflict` branch).

## Fix

`src/config/loader.ts` — `writeConfig` now does a durable atomic write:

1. Serialize to a **unique** sibling temp file (`agentsync.toml.<uuid>.tmp`).
2. `fsync` the temp file (bytes durable before it's visible under the canonical name — also sidesteps the Bun-on-tmpfs read-after-write race).
3. `rename` the temp over the destination — atomic on a single filesystem, so a crash leaves either the old or the new file fully intact, never a truncated middle.
4. Best-effort `fsync` of the parent directory so the *switch* survives power loss (non-fatal where unsupported, e.g. Windows).
5. On rename failure: `unlink` the temp and rethrow, leaving the destination untouched.

The temp name is randomized so two concurrent writers (overlapping `key` commands) never share a scratch file.

### Why not reuse `agents/_utils.ts` `atomicWrite`

That helper is *intentionally* non-atomic — it dropped rename to dodge a documented Bun-on-tmpfs visibility race for tiny adapter files. Config needs real durability that helper forgoes, so it is not reused (and not refactored — out of scope, used by all adapters).

## Tests

`src/config/__tests__/loader.test.ts`:
- No `.tmp` sibling remains after a successful write (atomic swap consumed the temp).
- Rename failure (directory at destination) preserves the original and removes the temp — exercises the cleanup/rethrow path.
- Existing round-trip and parent-dir-creation tests still pass.

`loader.ts` at 100% line coverage. Full suite green (one unrelated watcher debounce test is a known timing flake that passes in isolation). typecheck + biome + spec-refs clean. Senior-review gate passed (2 iterations; parent-dir fsync, temp uniqueness, and JSDoc accuracy all addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)