### PR TITLE
fix(migrate): preserve JSONC state in MCP merge instead of silent overwrite

### DIFF
--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -396,6 +396,86 @@ describe("performMigrate", () => {
     expect(written).toContain("slack");
   });
 
+  test("MCP merge preserves JSONC comments and unrelated state in ~/.claude.json", async () => {
+    // Source brings one server in.
+    writeFixture(
+      testCursor.mcpGlobal,
+      JSON.stringify({ mcpServers: { slack: { command: "slack-mcp", args: [], env: {} } } }),
+    );
+    // Target ~/.claude.json carries a comment, a trailing comma, and
+    // system-managed state Claude Code owns. A strict JSON.parse throws on the
+    // comment; the old bare catch then overwrote the whole file with just
+    // mcpServers, destroying trackedFileBackups/projects silently.
+    writeFixture(
+      testClaude.mcpJson,
+      `{
+  // user comment that strict JSON.parse rejects
+  "trackedFileBackups": { "a.txt": "deadbeef" },
+  "projects": { "/home/u/proj": { "lastUsed": 1 } },
+  "mcpServers": { "gh": { "command": "gh-mcp", "args": [], "env": {} } },
+}`,
+    );
+
+    const result = await performMigrate({
+      from: "cursor",
+      to: "claude",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = (await readIfExists(testClaude.mcpJson)) as string;
+    // Unrelated state and the user's comment must survive the in-place edit.
+    expect(written).toContain("trackedFileBackups");
+    expect(written).toContain("projects");
+    expect(written).toContain("user comment");
+    // Servers merged: source slack added, existing gh kept.
+    const { parse: parseJsonc } = await import("jsonc-parser");
+    const parsed = parseJsonc(written, [], { allowTrailingComma: true }) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(parsed.mcpServers.gh).toBeDefined();
+    expect(parsed.mcpServers.slack).toBeDefined();
+  });
+
+  test("MCP merge preserves JSONC comments and existing inputs in VS Code mcp.json", async () => {
+    writeFixture(
+      testClaude.mcpJson,
+      JSON.stringify({ mcpServers: { slack: { command: "slack-mcp", args: [], env: {} } } }),
+    );
+    // VS Code mcp.json is settings-style JSONC: comment + an existing input.
+    writeFixture(
+      testVscode.mcpJson,
+      `{
+  // vscode user comment
+  "servers": { "gh": { "command": "gh-mcp" } },
+  "inputs": [{ "id": "token", "type": "promptString" }],
+}`,
+    );
+
+    const result = await performMigrate({
+      from: "claude",
+      to: "vscode",
+      type: "mcp",
+      dryRun: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const { readIfExists } = await import("../../agents/_utils");
+    const written = (await readIfExists(testVscode.mcpJson)) as string;
+    expect(written).toContain("vscode user comment");
+    const { parse: parseJsonc } = await import("jsonc-parser");
+    const parsed = parseJsonc(written, [], { allowTrailingComma: true }) as {
+      servers: Record<string, unknown>;
+      inputs: Array<{ id?: string }>;
+    };
+    expect(parsed.servers.gh).toBeDefined();
+    expect(parsed.servers.slack).toBeDefined();
+    // The existing input must not be dropped.
+    expect(parsed.inputs.some((i) => i.id === "token")).toBeTrue();
+  });
+
   test("reports skip for missing source files", async () => {
     const result = await performMigrate({
       from: "claude",

--- a/src/migrate/migrate.ts
+++ b/src/migrate/migrate.ts
@@ -9,7 +9,8 @@
 import { mkdir, readdir, readFile, stat } from "node:fs/promises";
 import { basename, join, relative } from "node:path";
 import * as TOML from "@iarna/toml";
-import { atomicWrite, readIfExists } from "../agents/_utils";
+import { type ParseError, parse as parseJsonc } from "jsonc-parser";
+import { atomicWrite, readIfExists, setJsoncTopLevelKey } from "../agents/_utils";
 import { applyClaudeMd } from "../agents/claude";
 import { applyCodexAgentsMd } from "../agents/codex";
 import { applyCopilotInstructions } from "../agents/copilot";
@@ -259,6 +260,46 @@ export async function readSourceArtefacts(
 }
 
 /**
+ * Parse a JSONC document into a plain object for reading existing values.
+ *
+ * Returns {} for a non-object root or any genuine parse error (trailing commas
+ * and comments are tolerated, not errors). This mirrors setJsoncTopLevelKey's
+ * own object/error gate, so a corrupt target is treated the same on the read
+ * side (merge from nothing) as on the write side (write a clean object).
+ */
+function parseJsoncObject(raw: string): Record<string, unknown> {
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(raw, errors, { allowTrailingComma: true });
+  if (errors.length > 0 || parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {};
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Merge two MCP `inputs` arrays with the source list winning on collision.
+ * Dedupe by `id` when present, otherwise by structural equality. Incoming is
+ * iterated first so its entry is recorded under the dedupe key before existing.
+ */
+function mergeMcpInputs(incoming: unknown[], existing: unknown[]): unknown[] {
+  const seen = new Set<string>();
+  const merged: unknown[] = [];
+  for (const list of [incoming, existing]) {
+    for (const entry of list) {
+      const id =
+        entry && typeof entry === "object"
+          ? ((entry as { id?: unknown }).id as string | undefined)
+          : undefined;
+      const dedupeKey = typeof id === "string" ? id : JSON.stringify(entry);
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      merged.push(entry);
+    }
+  }
+  return merged;
+}
+
+/**
  * Write a migrated artefact to the target agent using existing apply functions.
  * @param to - Target agent.
  * @param type - Configuration type.
@@ -341,62 +382,61 @@ export async function applyMigrated(
       // either write to a section the target ignores or duplicate state.
       const existing = await readIfExists(targetPath);
       if (existing) {
-        try {
-          if (to === "codex") {
-            const existingParsed = TOML.parse(existing);
-            const incomingParsed = TOML.parse(content);
-            const existingMcp = (existingParsed.mcp ?? {}) as TOML.JsonMap;
-            const incomingMcp = (incomingParsed.mcp ?? {}) as TOML.JsonMap;
-            const existingServers = (existingMcp.servers ?? {}) as TOML.JsonMap;
-            const incomingServers = (incomingMcp.servers ?? {}) as TOML.JsonMap;
-            existingMcp.servers = { ...existingServers, ...incomingServers };
-            existingParsed.mcp = existingMcp;
-            content = TOML.stringify(existingParsed);
-          } else if (to === "vscode") {
-            const existingParsed = JSON.parse(existing) as Record<string, unknown>;
-            const incomingParsed = JSON.parse(content) as Record<string, unknown>;
-            const existingServers = (existingParsed.servers ?? {}) as Record<string, unknown>;
-            const incomingServers = (incomingParsed.servers ?? {}) as Record<string, unknown>;
-            existingParsed.servers = { ...existingServers, ...incomingServers };
-            const existingInputs = Array.isArray(existingParsed.inputs)
-              ? existingParsed.inputs
-              : [];
-            const incomingInputs = Array.isArray(incomingParsed.inputs)
-              ? incomingParsed.inputs
-              : [];
-            if (incomingInputs.length > 0) {
-              // Source wins on collision (mirrors the spread-based servers
-              // merge above and the documented "source value wins" rule in
-              // docs/migrate.md). Iterate incoming first so its entry is
-              // recorded under the dedupe key before the existing one.
-              const seen = new Set<string>();
-              const merged: unknown[] = [];
-              for (const list of [incomingInputs, existingInputs]) {
-                for (const entry of list) {
-                  const id =
-                    entry && typeof entry === "object"
-                      ? ((entry as { id?: unknown }).id as string | undefined)
-                      : undefined;
-                  const dedupeKey = typeof id === "string" ? id : JSON.stringify(entry);
-                  if (seen.has(dedupeKey)) continue;
-                  seen.add(dedupeKey);
-                  merged.push(entry);
-                }
-              }
-              existingParsed.inputs = merged;
-            }
-            content = `${JSON.stringify(existingParsed, null, 2)}\n`;
-          } else {
-            // Claude and Cursor: mcpServers merge
-            const existingParsed = JSON.parse(existing) as Record<string, unknown>;
-            const incomingParsed = JSON.parse(content) as Record<string, unknown>;
-            const existingServers = (existingParsed.mcpServers ?? {}) as Record<string, unknown>;
-            const incomingServers = (incomingParsed.mcpServers ?? {}) as Record<string, unknown>;
-            existingParsed.mcpServers = { ...existingServers, ...incomingServers };
-            content = `${JSON.stringify(existingParsed, null, 2)}\n`;
+        if (to === "codex") {
+          // Codex config.toml is strict TOML, not JSONC. A malformed existing
+          // file throws here and is recorded as a write error upstream, never
+          // silently overwritten.
+          const existingParsed = TOML.parse(existing);
+          const incomingParsed = TOML.parse(content);
+          const existingMcp = (existingParsed.mcp ?? {}) as TOML.JsonMap;
+          const incomingMcp = (incomingParsed.mcp ?? {}) as TOML.JsonMap;
+          const existingServers = (existingMcp.servers ?? {}) as TOML.JsonMap;
+          const incomingServers = (incomingMcp.servers ?? {}) as TOML.JsonMap;
+          existingMcp.servers = { ...existingServers, ...incomingServers };
+          existingParsed.mcp = existingMcp;
+          content = TOML.stringify(existingParsed);
+        } else if (to === "vscode") {
+          // VS Code mcp.json is JSONC (comments, trailing commas) and sits
+          // beside user state. Edit servers/inputs in place so unrelated keys
+          // and comments survive; a strict JSON.parse used to throw on any
+          // JSONC feature, after which the bare catch overwrote the whole file.
+          const incomingParsed = JSON.parse(content) as Record<string, unknown>;
+          const incomingServers = (incomingParsed.servers ?? {}) as Record<string, unknown>;
+          const existingObj = parseJsoncObject(existing);
+          const existingServers = (existingObj.servers ?? {}) as Record<string, unknown>;
+          let merged = setJsoncTopLevelKey(existing, "servers", {
+            ...existingServers,
+            ...incomingServers,
+          });
+          const incomingInputs = Array.isArray(incomingParsed.inputs) ? incomingParsed.inputs : [];
+          if (incomingInputs.length > 0) {
+            const existingInputs = Array.isArray(existingObj.inputs) ? existingObj.inputs : [];
+            merged = setJsoncTopLevelKey(
+              merged,
+              "inputs",
+              mergeMcpInputs(incomingInputs, existingInputs),
+            );
           }
-        } catch {
-          /* existing file corrupt — overwrite entirely */
+          content = merged;
+        } else {
+          // Claude, Cursor, and Copilot: mcpServers merge. ~/.claude.json is
+          // large and JSONC-tolerant, and Claude Code continuously writes
+          // trackedFileBackups, projects, and other state to it. A strict
+          // JSON.parse threw on any JSONC feature and the bare catch then
+          // overwrote the whole file with just mcpServers, destroying that
+          // state. Edit mcpServers in place, matching applyClaudeMcp on the
+          // pull side. A genuinely corrupt target (real JSON error, not a JSONC
+          // feature) reads as {} and is rewritten as a clean mcpServers object —
+          // the same fail-open the pull path takes, since no safe in-place edit
+          // of unparseable content exists.
+          const incomingParsed = JSON.parse(content) as Record<string, unknown>;
+          const incomingServers = (incomingParsed.mcpServers ?? {}) as Record<string, unknown>;
+          const existingObj = parseJsoncObject(existing);
+          const existingServers = (existingObj.mcpServers ?? {}) as Record<string, unknown>;
+          content = setJsoncTopLevelKey(existing, "mcpServers", {
+            ...existingServers,
+            ...incomingServers,
+          });
         }
       }
       await atomicWrite(targetPath, content);


### PR DESCRIPTION
## Summary

Closes #135.

`applyMigrated`'s MCP merge parsed existing target files with **strict `JSON.parse`** inside a `try` whose bare `catch {}` fell through to overwrite the **entire** file with just the translator's output.

The worst target is `~/.claude.json` (JSONC, system-managed): a single comment or trailing comma made `JSON.parse` throw, and the catch then wrote only `mcpServers`, **silently destroying** `trackedFileBackups`, `projects`, and every other key Claude Code manages. The trigger is passive — Claude itself or a JSONC-aware editor can introduce a comment. The success path also flattened comments/formatting via a `JSON.stringify` round-trip. VS Code's `mcp.json` (also JSONC) shared the defect; only the strict-TOML Codex path was safe.

This is the exact failure `setJsoncTopLevelKey` already prevents on the **pull** side (`applyClaudeMcp`) — the migrate path was the lone offender, an asymmetry where pull preserves user state and migrate destroys it.

## Fix (`src/migrate/migrate.ts`)

- Two new helpers: `parseJsoncObject` (lenient JSONC parse → object, or `{}` on genuine error/non-object — gated identically to `setJsoncTopLevelKey`) and `mergeMcpInputs` (extracted the inputs dedup, source-wins-on-`id`).
- **Claude / Cursor / Copilot** and **VS Code** branches now edit keys in place via `setJsoncTopLevelKey` (same helper as the pull side), so comments and unrelated keys survive. VS Code chains `servers` then `inputs`.
- **Removed the blanket silent-overwrite `catch`.** A genuine parse failure now surfaces upstream in `result.errors` (`applyMigrated` is wrapped at the call site) instead of clobbering data. Codex stays strict TOML and fails loud on a malformed existing file.
- A genuinely corrupt (non-JSONC) target is rewritten clean — matching the pull path, since no safe in-place edit of unparseable content exists. This keeps the documented single-code-path/pull-parity invariant.

## Tests (`src/migrate/__tests__/migrate.test.ts`)

- A `cursor → claude` MCP merge into a `~/.claude.json` containing a comment, a trailing comma, `trackedFileBackups`, and `projects`: asserts all unrelated state **and the comment** survive, and servers merge. (Fails on the old code — the comment would throw and wipe the file.)
- A `claude → vscode` merge into a JSONC `mcp.json` with an existing input: asserts the comment survives, servers merge, and the existing input is retained.

## Verification

Full suite **834 pass / 0 fail**; typecheck, biome, spec-refs clean. Senior-review gate passed (2 iterations; copilot comment scope + corrupt-target documentation addressed). e2e `10-migrate.sh` exercises the migrate CLI end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)