### PR TITLE
fix(config): resolve Windows APPDATA agent paths through nonBlank guard

### DIFF
--- a/src/config/__tests__/paths.test.ts
+++ b/src/config/__tests__/paths.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import {
   AgentPaths,
   resolveAgentSyncHome,
   resolveClaudePluginPaths,
   resolveDaemonSocketPath,
+  resolveWindowsAppData,
 } from "../paths";
 
 // AgentPaths shape validation (non-mutable, import-time baked paths)
@@ -165,5 +166,39 @@ describe("resolveAgentSyncHome AGENTSYNC_DIR override", () => {
   test("treats a whitespace-only AGENTSYNC_DIR as unset and falls back to the default", () => {
     process.env.AGENTSYNC_DIR = "   ";
     expect(resolveAgentSyncHome()).toContain("agentsync");
+  });
+});
+
+describe("resolveWindowsAppData blank/unset APPDATA", () => {
+  // A relative base would make push skip the file and pull write under cwd, so
+  // every branch must stay absolute. FAKE_HOME is absolute on POSIX and Windows.
+  const FAKE_HOME = join("/fake", "home");
+
+  test("returns a set APPDATA verbatim", () => {
+    const appdata = join("C:", "Users", "foo", "AppData", "Roaming");
+    expect(resolveWindowsAppData(appdata, FAKE_HOME)).toBe(appdata);
+  });
+
+  test("trims surrounding whitespace from a set APPDATA", () => {
+    const appdata = join("C:", "Users", "foo", "AppData", "Roaming");
+    expect(resolveWindowsAppData(`  ${appdata}  `, FAKE_HOME)).toBe(appdata);
+  });
+
+  test("falls back to HOME/AppData/Roaming when APPDATA is unset", () => {
+    const result = resolveWindowsAppData(undefined, FAKE_HOME);
+    expect(result).toBe(join(FAKE_HOME, "AppData", "Roaming"));
+    expect(isAbsolute(result)).toBeTrue();
+  });
+
+  test("treats an empty APPDATA as unset, never a relative base", () => {
+    const result = resolveWindowsAppData("", FAKE_HOME);
+    expect(result).toBe(join(FAKE_HOME, "AppData", "Roaming"));
+    expect(isAbsolute(result)).toBeTrue();
+  });
+
+  test("treats a whitespace-only APPDATA as unset", () => {
+    const result = resolveWindowsAppData("   ", FAKE_HOME);
+    expect(result).toBe(join(FAKE_HOME, "AppData", "Roaming"));
+    expect(isAbsolute(result)).toBeTrue();
   });
 });

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -5,6 +5,23 @@ import { nonBlank } from "../lib/env";
 const HOME = homedir();
 const PLATFORM = process.platform;
 
+/**
+ * Resolve the Windows %APPDATA% base (= %USERPROFILE%\AppData\Roaming).
+ *
+ * nonBlank collapses an exported-but-empty APPDATA to undefined so the result
+ * stays absolute. A bare `?? ""` left an unset or blank var as a relative base,
+ * which push silently skipped (the file reads as "not found") and pull misplaced
+ * under process.cwd() instead of restoring it. This mirrors how CODEX_HOME and
+ * resolveAgentSyncHome already handle the same blank-env case. Parameterized so
+ * the blank/unset behaviour is testable on any platform.
+ */
+export function resolveWindowsAppData(
+  appdata: string | undefined = process.env.APPDATA,
+  home: string = HOME,
+): string {
+  return nonBlank(appdata) ?? join(home, "AppData", "Roaming");
+}
+
 /** Platform-aware locations for the agent files that AgentSync snapshots and restores. */
 export const AgentPaths = {
   cursor: {
@@ -20,7 +37,7 @@ export const AgentPaths = {
         return join(HOME, "Library", "Application Support", "Cursor", "User", "settings.json");
       }
       if (PLATFORM === "win32") {
-        return join(process.env.APPDATA ?? "", "Cursor", "User", "settings.json");
+        return join(resolveWindowsAppData(), "Cursor", "User", "settings.json");
       }
       return join(HOME, ".config", "Cursor", "User", "settings.json");
     })(),
@@ -82,7 +99,7 @@ export const AgentPaths = {
         return join(HOME, "Library", "Application Support", "Code", "User", "settings.json");
       }
       if (PLATFORM === "win32") {
-        return join(process.env.APPDATA ?? "", "Code", "User", "settings.json");
+        return join(resolveWindowsAppData(), "Code", "User", "settings.json");
       }
       return join(HOME, ".config", "Code", "User", "settings.json");
     })(),
@@ -93,7 +110,7 @@ export const AgentPaths = {
         return join(HOME, "Library", "Application Support", "Code", "User", "mcp.json");
       }
       if (PLATFORM === "win32") {
-        return join(process.env.APPDATA ?? "", "Code", "User", "mcp.json");
+        return join(resolveWindowsAppData(), "Code", "User", "mcp.json");
       }
       return join(HOME, ".config", "Code", "User", "mcp.json");
     })(),


### PR DESCRIPTION
## Summary

Closes #126.

Three Windows `%APPDATA%` resolvers in `src/config/paths.ts` still used `process.env.APPDATA ?? ""` — the exact pattern #117 replaced everywhere else but missed here:

- `cursor.settingsJson`
- `copilot.vscodeMcpInSettings`
- `vscode.mcpJson`

A **blank** `APPDATA` (`""`) is not nullish, so `??` never fires; an **unset** `APPDATA` falls back to `""`. Both collapse `join(...)` to a **relative** path. On Windows that resolves against the process cwd:

- **Push**: the walker stats a non-existent relative path → file treated as absent → Cursor/VS Code/Copilot config **silently dropped from the vault**.
- **Pull**: the decrypted artefact is written to `<cwd>\Cursor\User\settings.json` → **silently misplaced** instead of restored.

This is the silent data-loss class the project's "errors over fallbacks" rule exists to prevent, and it hits Windows contexts with a minimal env block (stripped service accounts, scheduled tasks — exactly where the daemon runs).

## Fix

- Extract a pure, exported `resolveWindowsAppData(appdata = process.env.APPDATA, home = HOME)` returning `nonBlank(appdata) ?? join(home, "AppData", "Roaming")` — the canonical `%APPDATA%` location (`%USERPROFILE%\AppData\Roaming`, and `homedir()` is `%USERPROFILE%` on Windows).
- Route all three win32 branches through it.

This finishes #117 and removes the inconsistency where `nonBlank` guarded `CODEX_HOME` and `resolveAgentSyncHome` but not the sibling `APPDATA` lookups. It's the same `nonBlank(...) ?? <absolute-fallback>` pattern used by both.

## Tests (`src/config/__tests__/paths.test.ts`)

`resolveWindowsAppData` is parameterized, so the tests inject `appdata`/`home` directly and run on **every** platform — covering set, trimmed, unset, empty, and whitespace-only `APPDATA`, asserting the result is always absolute. (The issue's suggested Windows-guarded tests would be skipped on the Linux CI runner, giving no real coverage.)

## Verification

Full suite **839 pass / 0 fail**; `paths.ts` 100% function coverage; typecheck + biome + spec-refs clean. Senior-review gate passed (zero findings — canonical path, function hoisting, and convention parity all validated against Microsoft docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows configuration path resolution to ensure paths remain absolute in all scenarios, preventing unintended fallback behavior.

* **Tests**
  * Added comprehensive test coverage for Windows application data directory resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/agentsync/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->