### PR TITLE
fix(config): surface schema and TOML errors as one-line diagnostics

### DIFF
--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -10,9 +10,8 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { rm, symlink } from "node:fs/promises";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
-import { AgentSyncConfigSchema } from "../../config/schema";
 import { createTmpDir } from "../../test-helpers/fixtures";
-import { buildSkillsDirChecks, formatSchemaError } from "../doctor";
+import { buildSkillsDirChecks } from "../doctor";
 
 type MutablePaths = {
   claude: { skillsDir: string };
@@ -128,61 +127,5 @@ describe("buildSkillsDirChecks", () => {
     const claudeRow = rows.find((r) => r.name === "Claude skills directory");
     expect(claudeRow?.status).toBe("warn");
     expect(claudeRow?.detail).toContain("Symlinked skills root");
-  });
-});
-
-describe("formatSchemaError", () => {
-  test("names the offending recipient alias on a non-age1 value", () => {
-    const result = AgentSyncConfigSchema.safeParse({
-      recipients: { alice: "notage1xyz" },
-      agents: {
-        cursor: true,
-        claude: true,
-        codex: true,
-        copilot: true,
-        vscode: false,
-      },
-      remote: { url: "git@github.com:user/vault.git", branch: "main" },
-      sync: {
-        debounceMs: 300,
-        autoPush: true,
-        autoPull: true,
-        pullIntervalMs: 300_000,
-      },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const detail = formatSchemaError(result.error);
-      expect(detail).toContain("recipients.alice");
-    }
-  });
-
-  test("names remote.branch on empty branch", () => {
-    const result = AgentSyncConfigSchema.safeParse({
-      recipients: { me: "age1qpzry9x8gf2tvdw0s3jn54khce6mua7l" },
-      agents: {
-        cursor: true,
-        claude: true,
-        codex: true,
-        copilot: true,
-        vscode: false,
-      },
-      remote: { url: "git@github.com:user/vault.git", branch: "" },
-      sync: {
-        debounceMs: 300,
-        autoPush: true,
-        autoPull: true,
-        pullIntervalMs: 300_000,
-      },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const detail = formatSchemaError(result.error);
-      expect(detail).toContain("remote.branch");
-    }
-  });
-
-  test("falls back to String(err) for non-Zod errors", () => {
-    expect(formatSchemaError(new Error("disk full"))).toBe("Invalid: Error: disk full");
   });
 });

--- a/src/commands/__tests__/shared.test.ts
+++ b/src/commands/__tests__/shared.test.ts
@@ -251,15 +251,18 @@ describe("loadVaultConfigOrExit", () => {
     expect(fakeLogs.error[0]).not.toContain("at async");
   });
 
-  test("re-throws non-ENOENT errors so callers see schema/parse failures intact", async () => {
+  test("re-throws non-ENOENT config errors with a friendly one-line message", async () => {
     const { loadVaultConfigOrExit } = await import("../shared");
 
     const vaultDir = join(tmpDir, "broken-vault");
     await mkdir(vaultDir, { recursive: true });
     await writeFile(join(vaultDir, "agentsync.toml"), "this is = not [ valid toml", "utf8");
 
-    await expect(loadVaultConfigOrExit(vaultDir)).rejects.toThrow();
-    // Should NOT have called process.exit — only ENOENT triggers the friendly path.
+    // Parse failures re-throw so callers (performPull/performPush/daemon) can
+    // aggregate them; only ENOENT exits. The thrown message is the one-line
+    // diagnostic naming the file, not a raw Zod/Toml stack trace.
+    await expect(loadVaultConfigOrExit(vaultDir)).rejects.toThrow("agentsync.toml");
+    // process.exit must NOT fire — that path is reserved for the missing-vault case.
     expect(exitCalledWith).toBeNull();
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,28 +6,9 @@ import { join, relative } from "node:path";
 import { promisify } from "node:util";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
-import { z } from "zod";
-import { loadConfig, resolveConfigPath } from "../config/loader";
+import { formatConfigError, loadConfig, resolveConfigPath } from "../config/loader";
 import { AgentPaths } from "../config/paths";
 import { resolveRuntimeContext } from "./shared";
-
-/**
- * Render a ZodError as a one-line `field: message` summary so the
- * doctor row points the user at the offending field (e.g. the recipient
- * alias, `remote.branch`, `remote.url`) instead of dumping `[ZodError: ...]`.
- * Caps at three issues to keep the row readable.
- */
-export function formatSchemaError(err: unknown): string {
-  if (err instanceof z.ZodError) {
-    const parts = err.issues.slice(0, 3).map((issue) => {
-      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
-      return `${path}: ${issue.message}`;
-    });
-    const suffix = err.issues.length > 3 ? ` (+${err.issues.length - 3} more)` : "";
-    return `Invalid: ${parts.join("; ")}${suffix}`;
-  }
-  return `Invalid: ${String(err)}`;
-}
 
 /** Single diagnostic check row rendered by the doctor command. */
 export interface Check {
@@ -184,7 +165,7 @@ export const doctorCommand = defineCommand({
       checks.push({
         name: "agentsync.toml schema",
         status: "fail",
-        detail: formatSchemaError(err),
+        detail: formatConfigError(err, resolveConfigPath(runtime.vaultDir)),
       });
     }
 

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -2,7 +2,12 @@ import { mkdir, readFile } from "node:fs/promises";
 import { hostname } from "node:os";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
-import { loadConfig, resolveConfigPath } from "../config/loader";
+import {
+  formatConfigError,
+  isConfigParseError,
+  loadConfig,
+  resolveConfigPath,
+} from "../config/loader";
 import { resolveAgentSyncHome } from "../config/paths";
 import type { AgentSyncConfig } from "../config/schema";
 import { nonBlank } from "../lib/env";
@@ -38,10 +43,14 @@ export async function loadPrivateKey(path: string): Promise<string> {
 }
 
 /**
- * Load the vault config; if it is missing, print a friendly "vault not
- * initialized" error and exit 1 instead of letting the raw ENOENT bubble up as
- * a Node stack trace. Other errors (e.g. schema parse failures) are re-thrown
- * unchanged so callers and test harnesses can still see them.
+ * Load the vault config. A missing file prints the friendly "vault not
+ * initialized" hint and exits 1. Schema (Zod) and TOML syntax errors are
+ * re-thrown with a single-line diagnostic message (via formatConfigError)
+ * instead of the raw Zod/Toml stack trace, so the error stays catchable:
+ * performPull/performPush and the daemon fold it into their errors[] /
+ * retry logic, and anything that reaches the CLI top level shows the
+ * one-line message rather than a multi-line blob. Only ENOENT exits here,
+ * preserving the contract those callers depend on.
  */
 export async function loadVaultConfigOrExit(vaultDir: string): Promise<AgentSyncConfig> {
   const configPath = resolveConfigPath(vaultDir);
@@ -53,6 +62,9 @@ export async function loadVaultConfigOrExit(vaultDir: string): Promise<AgentSync
         `Vault not initialized at ${vaultDir}. Run \`agentsync init --remote <git-url>\` first.`,
       );
       process.exit(1);
+    }
+    if (isConfigParseError(err)) {
+      throw new Error(formatConfigError(err, configPath));
     }
     throw err;
   }

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -2,8 +2,16 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
+import { parse as parseToml } from "@iarna/toml";
 import { createTmpDir } from "../../test-helpers/fixtures";
-import { loadConfig, resolveConfigPath, writeConfig } from "../loader";
+import {
+  formatConfigError,
+  isConfigParseError,
+  loadConfig,
+  resolveConfigPath,
+  writeConfig,
+} from "../loader";
+import { AgentSyncConfigSchema } from "../schema";
 
 // Defensive re-install of the real node:fs/promises — see migrate.test.ts
 // for the full explanation of the bleed this guards against.
@@ -126,5 +134,74 @@ describe("loader", () => {
   test("resolveConfigPath appends agentsync.toml to vaultDir", () => {
     const result = resolveConfigPath("/my/vault");
     expect(result).toBe("/my/vault/agentsync.toml");
+  });
+});
+
+describe("formatConfigError", () => {
+  const CONFIG_PATH = "/vault/agentsync.toml";
+
+  // A fully valid config; each test overrides exactly one field so the parse
+  // produces a single isolated issue, independent of Zod's issue ordering or
+  // formatConfigError's 3-issue cap.
+  const validBase = {
+    recipients: { me: "age1qpzry9x8gf2tvdw0s3jn54khce6mua7l" },
+    agents: { cursor: true, claude: true, codex: true, copilot: true, vscode: false },
+    remote: { url: "git@github.com:user/vault.git", branch: "main" },
+    sync: { debounceMs: 300, autoPush: true, autoPull: true, pullIntervalMs: 300_000 },
+  };
+
+  test("names the offending recipient alias for a schema (Zod) error", () => {
+    const result = AgentSyncConfigSchema.safeParse({
+      ...validBase,
+      recipients: { alice: "notage1xyz" },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = formatConfigError(result.error, CONFIG_PATH);
+      expect(msg).toContain(CONFIG_PATH);
+      expect(msg).toContain("recipients.alice");
+      expect(msg).toContain("Invalid config");
+    }
+  });
+
+  test("names remote.branch for an empty-branch schema error", () => {
+    const result = AgentSyncConfigSchema.safeParse({
+      ...validBase,
+      remote: { url: "git@github.com:user/vault.git", branch: "" },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(formatConfigError(result.error, CONFIG_PATH)).toContain("remote.branch");
+    }
+  });
+
+  test("renders a TOML syntax error as one line with the path, no stack trace", () => {
+    let tomlErr: unknown;
+    try {
+      parseToml("a = ");
+    } catch (e) {
+      tomlErr = e;
+    }
+    expect(isConfigParseError(tomlErr)).toBeTrue();
+    const msg = formatConfigError(tomlErr, CONFIG_PATH);
+    expect(msg).toContain("Invalid TOML");
+    expect(msg).toContain(CONFIG_PATH);
+    expect(msg).not.toContain("\n");
+  });
+
+  test("isConfigParseError is true for a ZodError and false for ENOENT", () => {
+    const zodResult = AgentSyncConfigSchema.safeParse({});
+    expect(zodResult.success).toBe(false);
+    if (!zodResult.success) {
+      expect(isConfigParseError(zodResult.error)).toBeTrue();
+    }
+    const enoent = Object.assign(new Error("no file"), { code: "ENOENT" });
+    expect(isConfigParseError(enoent)).toBeFalse();
+  });
+
+  test("falls back to a single generic line for non-config errors", () => {
+    expect(formatConfigError(new Error("disk full"), CONFIG_PATH)).toBe(
+      `Failed to load config ${CONFIG_PATH}: disk full`,
+    );
   });
 });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { parse, stringify } from "@iarna/toml";
+import { z } from "zod";
 import { type AgentSyncConfig, AgentSyncConfigSchema } from "./schema";
 
 /** Read and validate the vault config, stripping TOML symbol metadata before Zod parsing. */
@@ -74,4 +75,35 @@ export async function writeConfig(configPath: string, config: AgentSyncConfig): 
 /** Build the canonical config path inside a vault directory. */
 export function resolveConfigPath(vaultDir: string): string {
   return join(vaultDir, "agentsync.toml");
+}
+
+/** True when a loadConfig failure is a schema (Zod) or TOML syntax error. */
+export function isConfigParseError(err: unknown): boolean {
+  return err instanceof z.ZodError || (err instanceof Error && err.name === "TomlError");
+}
+
+/**
+ * Render a loadConfig failure as a single actionable line instead of a raw
+ * Zod/Toml stack trace. loadConfig can throw a ZodError (schema), a TomlError
+ * (syntax), or a generic error; each collapses to `<path>: what is wrong` so
+ * CLI users and the supervised daemon get a parseable diagnostic rather than a
+ * multi-line blob. Zod issues are capped at three to keep the line readable.
+ */
+export function formatConfigError(err: unknown, configPath: string): string {
+  if (err instanceof z.ZodError) {
+    const parts = err.issues.slice(0, 3).map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      return `${path}: ${issue.message}`;
+    });
+    const suffix = err.issues.length > 3 ? ` (+${err.issues.length - 3} more)` : "";
+    return `Invalid config in ${configPath}: ${parts.join("; ")}${suffix}`;
+  }
+  if (err instanceof Error && err.name === "TomlError") {
+    // @iarna/toml's message already names the row/col with a caret diagram; its
+    // first line carries the human-readable location, so keep just that.
+    const firstLine = (err.message.split("\n", 1)[0] ?? "").replace(/:\s*$/, "");
+    return `Invalid TOML in ${configPath}: ${firstLine}`;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return `Failed to load config ${configPath}: ${message}`;
 }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -4,7 +4,12 @@ import { log } from "@clack/prompts";
 import { performPull } from "../commands/pull";
 import { performPush } from "../commands/push";
 import { resolveRuntimeContext } from "../commands/shared";
-import { loadConfig, resolveConfigPath } from "../config/loader";
+import {
+  formatConfigError,
+  isConfigParseError,
+  loadConfig,
+  resolveConfigPath,
+} from "../config/loader";
 import { AgentPaths } from "../config/paths";
 import { DaemonStatusSchema } from "../config/schema";
 import { IpcClient, IpcServer } from "../core/ipc";
@@ -54,7 +59,7 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
  */
 export async function startDaemon(): Promise<void> {
   // ── Startup validation ──────────────────────────
-  let runtime: Awaited<ReturnType<typeof resolveRuntimeContext>>;
+  let runtime: Awaited<ReturnType<typeof resolveRuntimeContext>> | undefined;
   try {
     runtime = await resolveRuntimeContext();
     // Eagerly load config to validate vault accessibility
@@ -62,7 +67,14 @@ export async function startDaemon(): Promise<void> {
     // Validate encryption key is readable
     await access(runtime.privateKeyPath);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    // A schema/TOML failure here would otherwise log a multi-line Zod/Toml blob
+    // into the launchd/systemd journal; collapse it to one parseable line.
+    const msg =
+      runtime && isConfigParseError(err)
+        ? formatConfigError(err, resolveConfigPath(runtime.vaultDir))
+        : err instanceof Error
+          ? err.message
+          : String(err);
     log.error(`${ts()} Startup failed: ${msg}`);
     process.exit(1);
     return; // unreachable but satisfies TS control flow


### PR DESCRIPTION
## Summary

Closes #129.

`loadConfig` throws three error shapes — `ENOENT`, `TomlError`, `ZodError` — but only `ENOENT` had a friendly message. A malformed or stale `agentsync.toml` (a missing quote, a stale schema field) printed a **raw Zod/Toml stack trace** on every non-doctor path (`push`, `pull`, `status`, `key`, `skill`, `destroy`, `init`, the daemon, the TUI), and the supervised daemon logged the multi-line Zod blob into its journal. The one friendly formatter — doctor's `formatSchemaError` — was Zod-only and trapped inside `doctor`.

## Fix

- **`src/config/loader.ts`**: promote a unified `formatConfigError(err, configPath)` + `isConfigParseError(err)`:
  - `ZodError` → `Invalid config in <path>: field: message; …` (capped at 3 issues).
  - `TomlError` → `Invalid TOML in <path>: <first line with row/col>`.
  - generic → `Failed to load config <path>: <message>`.
- **`src/commands/shared.ts`**: `loadVaultConfigOrExit` re-throws a friendly one-line `Error` for parse failures instead of the raw Zod/Toml error. **Kept as a throw, not `process.exit`** — `performPull`/`performPush`/the daemon catch it and fold it into their `errors[]`/retry logic; making it exit would crash the supervised daemon on a transient bad config (and breaks the `performPull` contract). `ENOENT` still exits with the init hint.
- **`src/commands/doctor.ts`**: delete the duplicate `formatSchemaError` (+ its `z` import); use the shared helper.
- **`src/daemon/index.ts`**: startup catch formats config parse errors via `formatConfigError`, so the journal gets one parseable line instead of a Zod blob.

## Why re-throw, not exit

The first draft made `loadVaultConfigOrExit` exit on parse errors — that broke the documented `performPull` contract (`pull.test.ts:148`: parse error → `errors[]` row, `fatal=true`) and would kill the daemon mid-loop. The shipped version re-throws a friendly-**message** error, so the message is clean everywhere it surfaces (errors[] rows, daemon log, propagation) while the control flow callers depend on is preserved.

## Tests

- `loader.test.ts`: `formatConfigError` for Zod (recipient + branch, each a single isolated issue), TOML (one line, no newline), and generic; plus `isConfigParseError` true/false.
- `shared.test.ts`: non-ENOENT errors re-throw a friendly message naming `agentsync.toml`, and `process.exit` is not called.
- `doctor.test.ts`: stale `formatSchemaError` tests removed (helper re-homed in loader).

Full suite **841 pass / 0 fail**; typecheck + biome + spec-refs clean. Senior-review gate passed (2 iterations; caught and fixed a `process.exit`-regression before shipping, then tightened test isolation and removed dead code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)