### PR TITLE
fix(packaging): declare engines.bun to enforce the documented Bun floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
     "lefthook": "^2.1.4",
     "typescript": "^6.0.0"
   },
+  "engines": {
+    "bun": ">=1.3.9"
+  },
   "volta": {
     "node": "24.15.0"
   }

--- a/src/commands/__tests__/packaging.test.ts
+++ b/src/commands/__tests__/packaging.test.ts
@@ -33,6 +33,11 @@ const packageJsonSchema = z.object({
   homepage: z.string(),
   bugs: z.object({ url: z.string() }),
   license: z.string(),
+  // Required: the documented Bun >=1.3.9 runtime floor must be machine-enforced,
+  // not just prose in CLAUDE.md. A missing engines.bun fails this parse.
+  engines: z.object({
+    bun: z.string(),
+  }),
   volta: z
     .object({
       node: z.string(),
@@ -89,6 +94,8 @@ describe("package release surface", () => {
     expect(packageJson.bugs.url).toBe("https://github.com/chrisleekr/agentsync/issues");
     expect(packageJson.homepage).toBe("https://github.com/chrisleekr/agentsync#readme");
     expect(packageJson.license).toBe("MIT");
+    // Enforces the Bun runtime floor documented in CLAUDE.md (Bun >=1.3.9).
+    expect(packageJson.engines.bun).toBe(">=1.3.9");
   });
 
   test("package build emits a Bun-shebang CLI whose version matches the manifest", async () => {


### PR DESCRIPTION
## Summary

Closes #141.

`package.json` had no `engines` field, so the **Bun >=1.3.9** runtime floor documented in CLAUDE.md, README, and the docs site was prose only — nothing machine-readable for a consumer's tooling to check. The existing `volta.node` entry pins the *dev toolchain*, not the runtime.

## Fix

- `package.json`: add `"engines": { "bun": ">=1.3.9" }`.
  - Only `engines.bun` is declared, **not** `engines.node`: the published artifact is a Bun CLI (`#!/usr/bin/env bun`, `bin.agentsync` → `dist/cli.js`) installed via `bun install -g` / `bunx`. It does not run on a bare Node runtime, so an `engines.node` entry would be misleading.
  - `>=1.3.9` is a semver *range* (floor), consistent with CI (`latest`), release pin (`1.3.14`), and the docs (`1.3.9`).
- `src/commands/__tests__/packaging.test.ts`: `engines` is now a **required** field in `packageJsonSchema` (a missing block fails the parse), and the manifest test asserts the exact `>=1.3.9` value — so a drop or drift fails CI.

## Notes

- Install-safe: `engines` is not part of the `bun install --frozen-lockfile` lockfile comparison, and Bun does not hard-fail installs on `engines` mismatch by default. The field is the standard machine-readable floor declaration for an npm-published package, which is exactly what #141 asks for ("documented but not enforced" → now declared).

## Testing

Packaging suite passes (5/5); full suite **841 pass / 0 fail**; typecheck + biome + spec-refs clean. Senior-review gate passed (zero findings — value/format, install-safety, and the omit-`engines.node` decision all validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)