### PR TITLE
test(packaging): execute built artifacts in CI and release, not just stat them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,11 @@ jobs:
       - name: Build binary
         run: bun build --compile src/cli.ts --outfile dist/agentsync
 
-      - name: Verify binary artifact
-        run: test -f dist/agentsync
+      - name: Smoke-test binary
+        # Execute the compiled artifact, not just test -f: a zero-byte file, a
+        # startup segfault, or a broken @opentui/core native loader all pass an
+        # existence check but fail here.
+        run: ./dist/agentsync --version
 
   build-package:
     name: Package Smoke Test
@@ -152,4 +155,11 @@ jobs:
         run: npm install --global npm@11.5.1
 
       - name: Build and verify package
-        run: bun run build:package && npm pack --dry-run
+        # Execute the bundle between build and pack: npm pack --dry-run only
+        # lists files, so a mangled shebang, a Bun-minifier syntax regression,
+        # a missing dynamic import, or broken @opentui/core external resolution
+        # would ship undetected. Running it with the published entry catches all.
+        run: |
+          bun run build:package
+          bun dist/cli.js --version
+          npm pack --dry-run

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Build package
         run: bun run build:package
 
+      - name: Smoke-test package bundle
+        # Execute the exact bundle about to hit the npm registry. Build success
+        # does not prove the bundle runs: a mangled shebang, a syntax regression,
+        # or broken @opentui/core external resolution would publish undetected.
+        run: bun dist/cli.js --version
+
       - name: Publish package
         run: npm publish --provenance --access public
 
@@ -155,6 +161,18 @@ jobs:
 
       - name: Build binary
         run: bun build --compile ${{ matrix.bun_target && format('--target {0}', matrix.bun_target) || '' }} src/cli.ts --outfile dist/${{ matrix.target }}
+
+      - name: Smoke-test native binary
+        # Linux host-native target only (no bun_target -> host os/arch). Running
+        # before checksum/attest/upload stops a broken artifact from being signed
+        # and shipped. macOS arm64 is excluded: Apple Silicon SIGKILLs unsigned
+        # arm64 binaries, and `bun build --compile` output is not reliably
+        # signed, so executing it on the macOS runner could fail for signing
+        # reasons unrelated to the code. Cross-compiled and Windows binaries
+        # cannot run on the host at all and stay on the checksum + attestation
+        # checks.
+        if: ${{ runner.os == 'Linux' && !matrix.bun_target }}
+        run: ./dist/${{ matrix.target }} --version
 
       - name: Generate SHA256 checksum
         working-directory: dist


### PR DESCRIPTION
## Summary

Closes #142.

CI and release built every shippable artifact but **never executed any** before upload/publish. Every "verify" was a filesystem/metadata check:
- `ci.yml`: `test -f dist/agentsync` (a zero-byte file or a binary that segfaults on startup both pass) and `npm pack --dry-run` (file list only).
- `release-please.yml`: five binaries + the npm bundle built through build → checksum → attest → upload/publish with **no execution** anywhere. A broken `@opentui/core` native loader, a mangled shebang, or a Bun-minifier regression would ship — and the binary would even receive a provenance attestation vouching for an artifact that cannot start.

## Fix (YAML only)

**`ci.yml`**
- `Build Binary`: `test -f dist/agentsync` → `./dist/agentsync --version`.
- `Package Smoke Test`: `bun run build:package` → `bun dist/cli.js --version` → `npm pack --dry-run`.

**`release-please.yml`**
- `build-and-upload`: a `Smoke-test native binary` step **before** checksum/attest/upload, so a broken artifact is never signed or shipped.
- `publish-package`: `bun dist/cli.js --version` **before** `npm publish`.

## Why `--version`

It's a side-effect-free liveness probe: it exercises module load, the citty wiring, and (for the compiled binary) the `@opentui/core` native loader, without opening the TUI (`--version` takes the `runMain` branch, not the no-args TUI branch). Exactly the failure class #142 targets.

## Scope of the release binary smoke

Gated `if: ${{ runner.os == 'Linux' && !matrix.bun_target }}` → fires on **only** the `linux-x64` host-native target:
- Cross-compiled (`linux-arm64`, `macos-x64`, `windows-x64`) binaries can't run on the host → stay on existence + checksum + attestation.
- `macos-arm64` is **deliberately excluded**: Apple Silicon SIGKILLs unsigned arm64 binaries (reproduced locally: exit 137, `codesign` reports the binary unsigned), and `bun build --compile` output is not reliably signed, so executing it on the macos runner could fail for signing reasons unrelated to the code and break every release. Tracked separately in #150.

This is strictly a net improvement: pre-change, **zero** artifacts were executed.

## Validation

- `actionlint` passes on both files (the only finding is a pre-existing SC2035 on the untouched `cat *.sha256` line).
- `bun dist/cli.js --version` runs locally → prints `0.1.11`, exit 0.
- `packaging.test.ts` already executes the bundle in the unit suite; full suite green.
- Senior-review gate passed (zero blocking findings — matrix condition, step ordering, and macOS exclusion all validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)