### PR TITLE
ci(packaging): execute the macOS arm64 release binary in the smoke gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -163,15 +163,19 @@ jobs:
         run: bun build --compile ${{ matrix.bun_target && format('--target {0}', matrix.bun_target) || '' }} src/cli.ts --outfile dist/${{ matrix.target }}
 
       - name: Smoke-test native binary
-        # Linux host-native target only (no bun_target -> host os/arch). Running
-        # before checksum/attest/upload stops a broken artifact from being signed
-        # and shipped. macOS arm64 is excluded: Apple Silicon SIGKILLs unsigned
-        # arm64 binaries, and `bun build --compile` output is not reliably
-        # signed, so executing it on the macOS runner could fail for signing
-        # reasons unrelated to the code. Cross-compiled and Windows binaries
-        # cannot run on the host at all and stay on the checksum + attestation
-        # checks.
-        if: ${{ runner.os == 'Linux' && !matrix.bun_target }}
+        # Host-native targets only (no bun_target -> built for this runner's
+        # os/arch): linux-x64 on the ubuntu runner and macos-arm64 on the Apple
+        # Silicon runner. Executing before checksum/attest/upload stops a broken
+        # artifact from being signed and shipped. macOS arm64 runs here because
+        # `bun build --compile` ad-hoc signs its darwin output itself
+        # (flags=adhoc,linker-signed), which is what Apple Silicon requires to
+        # not SIGKILL an arm64 binary. Bun 1.3.12 shipped that signature
+        # truncated (oven-sh/bun#29120, fixed in 1.3.13); the pinned 1.3.14 is
+        # good, and executing the published binary here now fails the release
+        # loudly if a future Bun reintroduces that class of regression instead
+        # of publishing an unrunnable binary. Cross-compiled and Windows targets
+        # cannot run on the host and stay on the checksum + attestation checks.
+        if: ${{ !matrix.bun_target }}
         run: ./dist/${{ matrix.target }} --version
 
       - name: Generate SHA256 checksum

--- a/src/commands/__tests__/release-workflow.test.ts
+++ b/src/commands/__tests__/release-workflow.test.ts
@@ -32,6 +32,33 @@ describe("release workflow publishing contract", () => {
     );
   });
 
+  test("executes the macOS arm64 release binary before attesting and uploading it", async () => {
+    const workflow = await readFile(workflowPath, "utf8");
+
+    // The native smoke gate runs every host-native target (no bun_target ->
+    // built for its own runner), not Linux-only. Apple Silicon was previously
+    // excluded because Bun 1.3.12 produced an unsigned arm64 binary that
+    // SIGKILLed; Bun >=1.3.13 ad-hoc signs it, so executing the published
+    // binary here guards that regression class from shipping again.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting on the literal GitHub Actions `${{ }}` expression in the workflow YAML, not a JS template.
+    expect(workflow).toContain("if: ${{ !matrix.bun_target }}");
+    expect(workflow).not.toContain("runner.os == 'Linux' && !matrix.bun_target");
+
+    // macos-arm64 must stay host-native (no bun_target) or `bun build
+    // --compile` would cross-compile it and the gate above would skip it,
+    // shipping an unexecuted binary. Assert the invariant on the entry itself
+    // (bounded to the build matrix) so reordering the matrix cannot mask a
+    // bun_target sneaking onto this target.
+    const matrixRegion = workflow.match(/include:\n([\s\S]*?)\n {4}runs-on:/)?.[1] ?? "";
+    const arm64Entry =
+      matrixRegion
+        .split(/\n\s*- os:/)
+        .find((entry) => entry.includes("target: agentsync-macos-arm64")) ?? "";
+
+    expect(arm64Entry).not.toBe("");
+    expect(arm64Entry).not.toContain("bun_target");
+  });
+
   test("pins the CI unit-test job to the publish validation Node and npm toolchain", async () => {
     const ciWorkflow = await readFile(ciWorkflowPath, "utf8");
 


### PR DESCRIPTION
## What

The release pipeline's native-binary smoke step executed **only** the Linux host-native target, so the published `agentsync-macos-arm64` binary was attested and uploaded **without ever being executed**. This broadens the smoke gate to every host-native target so the macOS arm64 binary runs before attest/upload.

```
- if: ${{ runner.os == 'Linux' && !matrix.bun_target }}
+ if: ${{ !matrix.bun_target }}
```

`!matrix.bun_target` selects exactly the host-native targets — `linux-x64` (ubuntu runner) and `macos-arm64` (Apple Silicon runner). The three cross-compiled targets (`linux-arm64`, `macos-x64`, `windows-x64`) carry a `bun_target`, cannot run on their build host, and stay on the checksum + attestation checks.

## Why this is safe now (the issue's core uncertainty, resolved)

Issue #150 reported the macOS arm64 binary SIGKILLing (exit 137) as unsigned, and worried the shipped binary might not run for users. Investigation proved this was a **Bun 1.3.12-only regression** — [oven-sh/bun#29120](https://github.com/oven-sh/bun/issues/29120): a `sig_size` miscalculation truncated the ad-hoc signature that `bun build --compile` normally embeds. Fixed in **1.3.13**.

Verified empirically by compiling with each official `darwin-aarch64` build:

| Bun | `codesign -dv` | run |
|-----|----------------|-----|
| 1.3.12 | not signed | SIGKILL (137) |
| 1.3.13 | `adhoc,linker-signed` | exit 0 |
| **1.3.14** (pipeline pin) | `adhoc,linker-signed` | exit 0 |

So the shipped binary is already correctly signed and runnable. **No codesign step is added** — Bun self-signs, and `codesign -s -` actually fails on Bun's compile output. Executing the binary in the gate now turns any future regression of this class into a loud release failure instead of a silently-unrunnable artifact.

## Tests

`release-workflow.test.ts` gains a reorder-proof guard: it extracts the `macos-arm64` matrix entry (bounded to the build matrix) and asserts it stays host-native (no `bun_target`) — a `bun_target` sneaking onto that entry would drop it from the smoke gate. Mutation-checked to confirm the guard fails on regression. Full suite: 842 pass / 0 fail.

## Scope note

Per-PR CI (`ci.yml`) stays Linux-only intentionally — macOS runners are slower/costlier and shipped-binary validation belongs in the release pipeline.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
