### PR TITLE
feat(config): pin machine identity to stable local state

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -101,9 +101,11 @@ Defaults are chosen so you can install and forget. Tune them only if you observe
 | `AGENTSYNC_DIR` | Base directory for AgentSync state (vault clone, private key, update-check cache; also the daemon socket on Unix — Windows uses a fixed named pipe) | `~/.config/agentsync` (Unix), `%APPDATA%/agentsync` (Windows) |
 | `AGENTSYNC_VAULT_DIR` | Vault clone directory | `<AGENTSYNC_DIR>/vault` |
 | `AGENTSYNC_KEY_PATH` | Private key file | `<AGENTSYNC_DIR>/key.txt` |
-| `AGENTSYNC_MACHINE` | Machine identifier in recipient names | `HOSTNAME` if set, else the `os.hostname()` call, else the literal `local-machine` |
-| `HOSTNAME` | Machine identifier when `AGENTSYNC_MACHINE` is unset (fallback only, not a recommended knob) | the `os.hostname()` call, else the literal `local-machine` |
+| `AGENTSYNC_MACHINE` | Machine identifier in recipient names — applies only before a name is pinned; `init` pins the resolved name | pinned machine file (`<AGENTSYNC_DIR>/machine`) if present, else `HOSTNAME`, else the `os.hostname()` call, else the literal `local-machine` |
+| `HOSTNAME` | Machine identifier when no name is pinned and `AGENTSYNC_MACHINE` is unset (fallback only, not a recommended knob) | the `os.hostname()` call, else the literal `local-machine` |
 | `CODEX_HOME` | Codex root directory | `~/.codex` |
+
+`init` pins the resolved machine name to `<AGENTSYNC_DIR>/machine` (a sibling of the private key) so a later hostname change cannot re-derive a different name and orphan this machine's vault namespace. Once pinned, the pinned name wins over every other source, including `AGENTSYNC_MACHINE`; the chain below applies only until the pin exists.
 
 `HOSTNAME` is consulted only as a fallback for the machine identifier. It is a bash-shell convenience variable, not a portable environment variable: it is generally absent under `sh`/`dash`/`zsh`, absent on macOS and Windows, and defaults to the container ID inside Docker. Two machines with the same `os.hostname()` but different exported `HOSTNAME` therefore resolve to different recipient names, and conversely, when neither variable is set, two machines whose `os.hostname()` returns the same value resolve to the same name. Set `AGENTSYNC_MACHINE` explicitly to make the identifier deterministic. See [Recipient naming](#recipient-naming) for why this value matters.
 
@@ -139,7 +141,7 @@ Rotation requires the existing private key to still be readable, because every v
 
 ### Recipient naming
 
-Recipient names are stable config keys. Use machine names that describe the device clearly (`work-mbp`, `home-desktop`). Names are visible to anyone who can read the vault repository — they are not secret, but they should not encode anything you do not want associated with a public Git remote. When `AGENTSYNC_MACHINE` is unset the name is derived automatically; see the [Configuration](#configuration) section for the full `HOSTNAME` → `os.hostname()` → `local-machine` resolution chain.
+Recipient names are stable config keys. Use machine names that describe the device clearly (`work-mbp`, `home-desktop`). Names are visible to anyone who can read the vault repository — they are not secret, but they should not encode anything you do not want associated with a public Git remote. When no name is pinned and `AGENTSYNC_MACHINE` is unset the name is derived automatically; see the [Configuration](#configuration) section for the full pinned-file → `AGENTSYNC_MACHINE` → `HOSTNAME` → `os.hostname()` → `local-machine` resolution chain.
 
 ## Verifying release binaries
 

--- a/src/commands/__tests__/destroy.test.ts
+++ b/src/commands/__tests__/destroy.test.ts
@@ -202,6 +202,7 @@ describe("performDestroy", () => {
       machineName: "ghost",
       vaultDir: join(tmpDir, "ghost-vault"),
       keyPath: join(tmpDir, "ghost-key.txt"),
+      machineFilePath: join(tmpDir, "ghost-machine"),
       identity: "AGE-SECRET-KEY-1NEVERUSED",
       recipient: "age1never",
     };

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -77,7 +77,12 @@ let pullMod: PullMod;
 let initMod: InitMod;
 let keyMod: KeyMod;
 
-const RUNTIME_ENV_KEYS = ["AGENTSYNC_VAULT_DIR", "AGENTSYNC_KEY_PATH", "AGENTSYNC_MACHINE"];
+const RUNTIME_ENV_KEYS = [
+  "AGENTSYNC_VAULT_DIR",
+  "AGENTSYNC_KEY_PATH",
+  "AGENTSYNC_MACHINE",
+  "AGENTSYNC_MACHINE_FILE",
+];
 
 async function withMachineEnv<T>(machine: TestMachineFixture, run: () => Promise<T>): Promise<T> {
   const saved = Object.fromEntries(RUNTIME_ENV_KEYS.map((key) => [key, process.env[key]]));
@@ -85,6 +90,7 @@ async function withMachineEnv<T>(machine: TestMachineFixture, run: () => Promise
   process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
   process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
   process.env.AGENTSYNC_MACHINE = machine.machineName;
+  process.env.AGENTSYNC_MACHINE_FILE = machine.machineFilePath;
 
   try {
     return await run();
@@ -182,6 +188,7 @@ describe("integration", () => {
     process.env.AGENTSYNC_VAULT_DIR = vaultDir;
     process.env.AGENTSYNC_KEY_PATH = keyPath;
     process.env.AGENTSYNC_MACHINE = machineName;
+    process.env.AGENTSYNC_MACHINE_FILE = machine.machineFilePath;
 
     seedVaultRepo({ machine, bareRepoPath });
   });
@@ -233,6 +240,43 @@ describe("integration", () => {
     expect(configContent).toMatch(/recipients/);
     expect(configContent).toMatch(/init-machine/);
     expect(runGit(["rev-parse", "--abbrev-ref", "HEAD"], initMachine.vaultDir)).toBe("main");
+
+    // init pins the resolved machine name to local state (outside the vault) so
+    // a later hostname change cannot re-derive a different namespace.
+    expect(existsSync(initMachine.machineFilePath)).toBe(true);
+    expect((await readFile(initMachine.machineFilePath, "utf8")).trim()).toBe("init-machine");
+  });
+
+  test("a hostname change after init does not change the resolved machine name", async () => {
+    const initRoot = join(tmpDir, "init-host-rename");
+    mkdirSync(initRoot, { recursive: true });
+    const initBare = await createBareRepo(initRoot);
+    const initMachine = await createMachineFixture(initRoot, "pinned-host");
+
+    await withMachineEnv(initMachine, async () => {
+      await initMod.initCommand.run?.({
+        args: { remote: initBare, branch: "main" },
+        rawArgs: [],
+        cmd: {} as never,
+      } as never);
+
+      // Simulate a host rename: drop AGENTSYNC_MACHINE so resolution would fall
+      // through to HOSTNAME/os.hostname() if the pin were not honored.
+      const prevMachine = process.env.AGENTSYNC_MACHINE;
+      const prevHostname = process.env.HOSTNAME;
+      delete process.env.AGENTSYNC_MACHINE;
+      process.env.HOSTNAME = "renamed-host";
+      try {
+        const { resolveRuntimeContext } = await import("../../commands/shared");
+        const ctx = await resolveRuntimeContext();
+        expect(ctx.machineName).toBe("pinned-host");
+      } finally {
+        if (prevMachine === undefined) delete process.env.AGENTSYNC_MACHINE;
+        else process.env.AGENTSYNC_MACHINE = prevMachine;
+        if (prevHostname === undefined) delete process.env.HOSTNAME;
+        else process.env.HOSTNAME = prevHostname;
+      }
+    });
   });
 
   test("init joins an existing remote vault without creating a non-fast-forward local-first history", async () => {

--- a/src/commands/__tests__/shared.test.ts
+++ b/src/commands/__tests__/shared.test.ts
@@ -13,6 +13,7 @@ describe("resolveRuntimeContext", () => {
   let prevVaultDir: string | undefined;
   let prevKeyPath: string | undefined;
   let prevMachine: string | undefined;
+  let prevMachineFile: string | undefined;
   let prevHostname: string | undefined;
   let prevDir: string | undefined;
 
@@ -21,6 +22,7 @@ describe("resolveRuntimeContext", () => {
     prevVaultDir = process.env.AGENTSYNC_VAULT_DIR;
     prevKeyPath = process.env.AGENTSYNC_KEY_PATH;
     prevMachine = process.env.AGENTSYNC_MACHINE;
+    prevMachineFile = process.env.AGENTSYNC_MACHINE_FILE;
     prevHostname = process.env.HOSTNAME;
     prevDir = process.env.AGENTSYNC_DIR;
     // Redirect the AgentSync base dir into the per-test temp dir so the
@@ -38,6 +40,7 @@ describe("resolveRuntimeContext", () => {
     restore("AGENTSYNC_VAULT_DIR", prevVaultDir);
     restore("AGENTSYNC_KEY_PATH", prevKeyPath);
     restore("AGENTSYNC_MACHINE", prevMachine);
+    restore("AGENTSYNC_MACHINE_FILE", prevMachineFile);
     restore("HOSTNAME", prevHostname);
     restore("AGENTSYNC_DIR", prevDir);
     await rm(tmpDir, { recursive: true, force: true });
@@ -57,6 +60,21 @@ describe("resolveRuntimeContext", () => {
     expect(ctx.vaultDir).toBe(vaultDir);
     expect(ctx.privateKeyPath).toBe(keyPath);
     expect(ctx.machineName).toBe("ci-runner");
+  });
+
+  test("prefers the pinned machine file over AGENTSYNC_MACHINE", async () => {
+    const { resolveRuntimeContext } = await import("../shared");
+
+    const keyPath = join(tmpDir, "key.txt");
+    process.env.AGENTSYNC_KEY_PATH = keyPath;
+    process.env.AGENTSYNC_VAULT_DIR = join(tmpDir, "vault");
+    // A hostname change (env) must NOT win once a name is pinned, otherwise the
+    // machine's vault namespace (machines/<name>/ in v2) would silently orphan.
+    process.env.AGENTSYNC_MACHINE = "env-machine";
+    await writeFile(join(tmpDir, "machine"), "pinned-machine\n", "utf8");
+
+    const ctx = await resolveRuntimeContext();
+    expect(ctx.machineName).toBe("pinned-machine");
   });
 
   test("falls back to HOSTNAME env var when AGENTSYNC_MACHINE is unset", async () => {
@@ -169,6 +187,144 @@ describe("resolveRuntimeContext", () => {
     const ctx = await resolveRuntimeContext();
     expect(ctx.vaultDir).toBe(join(tmpDir, "vault"));
     expect(ctx.privateKeyPath).toBe(join(tmpDir, "key.txt"));
+  });
+
+  test("machineFilePath defaults to a sibling of the resolved key path", async () => {
+    const { resolveRuntimeContext } = await import("../shared");
+
+    const keyDir = join(tmpDir, "state");
+    await mkdir(keyDir, { recursive: true });
+    process.env.AGENTSYNC_KEY_PATH = join(keyDir, "key.txt");
+    process.env.AGENTSYNC_MACHINE = "host-1";
+
+    const ctx = await resolveRuntimeContext();
+    expect(ctx.machineFilePath).toBe(join(keyDir, "machine"));
+  });
+
+  test("AGENTSYNC_MACHINE_FILE overrides the pin path", async () => {
+    const { resolveRuntimeContext } = await import("../shared");
+
+    const pinPath = join(tmpDir, "custom-machine");
+    await writeFile(pinPath, "pinned-elsewhere\n", "utf8");
+    process.env.AGENTSYNC_MACHINE_FILE = pinPath;
+    process.env.AGENTSYNC_MACHINE = "env-machine";
+
+    const ctx = await resolveRuntimeContext();
+    expect(ctx.machineFilePath).toBe(pinPath);
+    expect(ctx.machineName).toBe("pinned-elsewhere");
+  });
+
+  test("a blank pin file falls through to the env chain", async () => {
+    const { resolveRuntimeContext } = await import("../shared");
+
+    process.env.AGENTSYNC_KEY_PATH = join(tmpDir, "key.txt");
+    await writeFile(join(tmpDir, "machine"), "  \n", "utf8");
+    process.env.AGENTSYNC_MACHINE = "env-machine";
+
+    const ctx = await resolveRuntimeContext();
+    expect(ctx.machineName).toBe("env-machine");
+  });
+
+  test("rejects an invalid resolved machine name", async () => {
+    const { resolveRuntimeContext, InvalidMachineNameError } = await import("../shared");
+
+    process.env.AGENTSYNC_KEY_PATH = join(tmpDir, "key.txt");
+    process.env.AGENTSYNC_MACHINE = "bad/name";
+
+    await expect(resolveRuntimeContext()).rejects.toBeInstanceOf(InvalidMachineNameError);
+  });
+
+  test("rejects a hand-edited pin containing a path separator", async () => {
+    const { resolveRuntimeContext } = await import("../shared");
+
+    process.env.AGENTSYNC_KEY_PATH = join(tmpDir, "key.txt");
+    await writeFile(join(tmpDir, "machine"), "evil/../escape\n", "utf8");
+
+    await expect(resolveRuntimeContext()).rejects.toThrow("path separator");
+  });
+});
+
+describe("validateMachineName", () => {
+  test("rejects empty, dot, traversal, control, and separator names", async () => {
+    const { validateMachineName } = await import("../shared");
+
+    for (const bad of ["", ".", "..", ".hidden", "a/b", "a\\b", "tab\tname"]) {
+      expect(() => validateMachineName(bad)).toThrow();
+    }
+  });
+
+  test("rejects names illegal as a directory segment on Windows", async () => {
+    const { validateMachineName } = await import("../shared");
+
+    // The vault is created on one OS and checked out on another, so a name
+    // pinned on Unix must still be a legal Windows path segment. `:` is the
+    // sharpest (NTFS name:stream), plus reserved chars, device names, and
+    // trailing dot/space.
+    for (const bad of [
+      "host:stream",
+      "name*",
+      'q"x',
+      "a<b",
+      "a>b",
+      "a|b",
+      "trail.",
+      "trail ",
+      "con",
+      "NUL",
+      "Com1",
+      "lpt9",
+    ]) {
+      expect(() => validateMachineName(bad)).toThrow();
+    }
+  });
+
+  test("accepts ordinary host-like names", async () => {
+    const { validateMachineName } = await import("../shared");
+
+    // Spaces are neither a path separator nor a control char, so they are kept.
+    for (const ok of ["my-laptop", "ci-runner", "host_01", "Work.Mac", "name with space"]) {
+      expect(() => validateMachineName(ok)).not.toThrow();
+    }
+  });
+});
+
+describe("pinMachineNameIfAbsent", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("writes the name when no pin exists", async () => {
+    const { pinMachineNameIfAbsent } = await import("../shared");
+
+    const path = join(tmpDir, "machine");
+    const wrote = await pinMachineNameIfAbsent(path, "my-laptop");
+
+    expect(wrote).toBe(true);
+    expect((await Bun.file(path).text()).trim()).toBe("my-laptop");
+  });
+
+  test("does not overwrite an existing pin", async () => {
+    const { pinMachineNameIfAbsent } = await import("../shared");
+
+    const path = join(tmpDir, "machine");
+    await writeFile(path, "first\n", "utf8");
+    const wrote = await pinMachineNameIfAbsent(path, "second");
+
+    expect(wrote).toBe(false);
+    expect((await Bun.file(path).text()).trim()).toBe("first");
+  });
+
+  test("refuses to pin an invalid name", async () => {
+    const { pinMachineNameIfAbsent } = await import("../shared");
+
+    const path = join(tmpDir, "machine");
+    await expect(pinMachineNameIfAbsent(path, "bad/name")).rejects.toThrow("path separator");
   });
 });
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -161,7 +161,10 @@ export async function performInit(options: InitOptions): Promise<InitResult> {
 
     // Pin the machine name to local state so a later hostname change cannot
     // re-derive a different name and orphan this machine's vault namespace
-    // (machines/<name>/ in v2). Idempotent: a no-op once pinned.
+    // (machines/<name>/ in v2). Idempotent: a no-op once pinned. The name is
+    // already validated in resolveRuntimeContext, and the pin is deliberately
+    // NOT part of the key rollback below: it is local identity, so a retry must
+    // resolve to the same namespace and reuse it.
     await pinMachineNameIfAbsent(runtime.machineFilePath, runtime.machineName);
 
     const gitignorePath = join(runtime.vaultDir, ".gitignore");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,12 @@ import { loadConfig, resolveConfigPath, writeConfig } from "../config/loader";
 import { resolveAgentSyncHome } from "../config/paths";
 import { generateIdentity, identityToRecipient } from "../core/encryptor";
 import { GitClient } from "../core/git";
-import { isFileNotFoundError, loadPrivateKey, resolveRuntimeContext } from "./shared";
+import {
+  isFileNotFoundError,
+  loadPrivateKey,
+  pinMachineNameIfAbsent,
+  resolveRuntimeContext,
+} from "./shared";
 
 const DEFAULT_AGENTS = {
   cursor: true,
@@ -153,6 +158,11 @@ export async function performInit(options: InitOptions): Promise<InitResult> {
     };
 
     await writeConfig(configPath, config);
+
+    // Pin the machine name to local state so a later hostname change cannot
+    // re-derive a different name and orphan this machine's vault namespace
+    // (machines/<name>/ in v2). Idempotent: a no-op once pinned.
+    await pinMachineNameIfAbsent(runtime.machineFilePath, runtime.machineName);
 
     const gitignorePath = join(runtime.vaultDir, ".gitignore");
     await writeFile(gitignorePath, "*.tmp\n", "utf8");

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -94,8 +94,9 @@ export async function resolveRuntimeContext(): Promise<RuntimeContext> {
   await mkdir(baseDir, { recursive: true });
 
   const privateKeyPath = nonBlank(process.env.AGENTSYNC_KEY_PATH) ?? join(baseDir, "key.txt");
-  // Sibling of key.txt by default (identical to resolveAgentSyncHome()/machine
-  // in the default layout); follows AGENTSYNC_KEY_PATH so a sandboxed key path
+  // Defaults to dirname(privateKeyPath)/machine (a sibling of key.txt); in the
+  // default layout both resolve under baseDir, so the pin lands at
+  // <AGENTSYNC_DIR>/machine. Follows AGENTSYNC_KEY_PATH so a sandboxed key path
   // keeps the pin isolated. AGENTSYNC_MACHINE_FILE is the per-machine test seam.
   const machineFilePath =
     nonBlank(process.env.AGENTSYNC_MACHINE_FILE) ?? join(dirname(privateKeyPath), "machine");

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -1,6 +1,6 @@
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { hostname } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { log } from "@clack/prompts";
 import {
   formatConfigError,
@@ -17,23 +17,118 @@ export interface RuntimeContext {
   vaultDir: string;
   privateKeyPath: string;
   machineName: string;
+  machineFilePath: string;
 }
 
-/** Resolve the working directories and machine label that all commands share. */
+/** A machine name that cannot safely become a vault namespace directory. */
+export class InvalidMachineNameError extends Error {
+  constructor(
+    readonly provided: string,
+    readonly reason: string,
+  ) {
+    super(
+      `Invalid machine name ${JSON.stringify(provided)}: ${reason}. ` +
+        "Set a valid name via AGENTSYNC_MACHINE, or fix the pinned name in the machine file.",
+    );
+    this.name = "InvalidMachineNameError";
+  }
+}
+
+/**
+ * Reject names that cannot safely become a directory segment. In vault format
+ * v2 the machine name is the namespace directory under `machines/`, and a vault
+ * pinned on one OS is cloned and walked on another, so the name must be a legal
+ * path segment on EVERY platform. Beyond the POSIX checks shared with
+ * validateSkillName / validatePluginName (separators, control chars, dot
+ * names), this rejects the Windows-illegal set so a name pinned on Unix cannot
+ * break — or, via the NTFS `name:stream` syntax, mis-target — a Windows
+ * checkout. Fail loudly rather than pinning or using a bad name.
+ */
+export function validateMachineName(name: string): void {
+  if (name.length === 0) throw new InvalidMachineNameError(name, "empty");
+  if (name === "." || name === "..") throw new InvalidMachineNameError(name, "reserved name");
+  if (name.startsWith(".")) {
+    throw new InvalidMachineNameError(name, "leading dot is reserved for hidden entries");
+  }
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i);
+    if (code < 0x20) throw new InvalidMachineNameError(name, "contains control character");
+    if (code === 0x2f || code === 0x5c) {
+      throw new InvalidMachineNameError(name, "contains path separator");
+    }
+  }
+  // Cross-OS path-segment safety: the vault is created on one platform and
+  // checked out on another, so reject names that are illegal directory
+  // segments on Windows even when the current host is Unix.
+  if (/[:*?"<>|]/.test(name)) {
+    throw new InvalidMachineNameError(name, "contains a Windows-reserved character");
+  }
+  if (name.endsWith(".") || name.endsWith(" ")) {
+    throw new InvalidMachineNameError(name, "trailing dot or space is not a valid directory name");
+  }
+  const stem = (name.split(".")[0] ?? "").toUpperCase();
+  if (/^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/.test(stem)) {
+    throw new InvalidMachineNameError(name, "Windows-reserved device name");
+  }
+}
+
+/** Read the pinned machine name, treating a missing or blank file as absent. */
+async function readPinnedMachineName(path: string): Promise<string | undefined> {
+  try {
+    return nonBlank(await readFile(path, "utf8"));
+  } catch (err) {
+    if (isFileNotFoundError(err)) return undefined;
+    throw err;
+  }
+}
+
+/**
+ * Resolve the working directories and machine label that all commands share.
+ * The machine name prefers the pinned file so a hostname change after init
+ * cannot silently orphan a machine's vault namespace; the env chain is only the
+ * first-run fallback. The resolved name is validated because v2 turns it into a
+ * directory segment. This resolver is read-only — `init` owns pinning the file.
+ */
 export async function resolveRuntimeContext(): Promise<RuntimeContext> {
   const baseDir = resolveAgentSyncHome();
   await mkdir(baseDir, { recursive: true });
 
+  const privateKeyPath = nonBlank(process.env.AGENTSYNC_KEY_PATH) ?? join(baseDir, "key.txt");
+  // Sibling of key.txt by default (identical to resolveAgentSyncHome()/machine
+  // in the default layout); follows AGENTSYNC_KEY_PATH so a sandboxed key path
+  // keeps the pin isolated. AGENTSYNC_MACHINE_FILE is the per-machine test seam.
+  const machineFilePath =
+    nonBlank(process.env.AGENTSYNC_MACHINE_FILE) ?? join(dirname(privateKeyPath), "machine");
+
+  const machineName =
+    (await readPinnedMachineName(machineFilePath)) ??
+    nonBlank(process.env.AGENTSYNC_MACHINE) ??
+    nonBlank(process.env.HOSTNAME) ??
+    nonBlank(hostname()) ??
+    "local-machine";
+  validateMachineName(machineName);
+
   return {
     vaultDir: nonBlank(process.env.AGENTSYNC_VAULT_DIR) ?? join(baseDir, "vault"),
-    privateKeyPath: nonBlank(process.env.AGENTSYNC_KEY_PATH) ?? join(baseDir, "key.txt"),
-    // AGENTSYNC_MACHINE env var > HOSTNAME env var > os.hostname() > static fallback
-    machineName:
-      nonBlank(process.env.AGENTSYNC_MACHINE) ??
-      nonBlank(process.env.HOSTNAME) ??
-      nonBlank(hostname()) ??
-      "local-machine",
+    privateKeyPath,
+    machineName,
+    machineFilePath,
   };
+}
+
+/**
+ * Persist the resolved machine name once so the namespace is stable across
+ * hostname changes. No-op on a later run that observes an existing pin. Returns
+ * true when it wrote. Called by `init`.
+ */
+export async function pinMachineNameIfAbsent(path: string, name: string): Promise<boolean> {
+  if ((await readPinnedMachineName(path)) !== undefined) return false;
+  validateMachineName(name);
+  // The pin can sit outside the key dir (AGENTSYNC_MACHINE_FILE), so ensure its
+  // parent exists rather than assuming a prior key write created it.
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${name}\n`, { mode: 0o600 });
+  return true;
 }
 
 /** Read the local age identity and trim trailing newlines before use. */

--- a/src/test-helpers/fixtures.ts
+++ b/src/test-helpers/fixtures.ts
@@ -52,6 +52,9 @@ export interface TestMachineFixture {
   machineName: string;
   vaultDir: string;
   keyPath: string;
+  // Per-machine pinned-identity file. Machines share a fixture root, so the
+  // default sibling-of-key path would collide; each machine gets its own.
+  machineFilePath: string;
   identity: string;
   recipient: string;
 }
@@ -122,6 +125,7 @@ export async function createMachineFixture(
 ): Promise<TestMachineFixture> {
   const vaultDir = join(root, `${machineName}-vault`);
   const keyPath = join(root, `${machineName}-key.txt`);
+  const machineFilePath = join(root, `${machineName}-machine`);
   const { identity, recipient } = await createAgeIdentity();
 
   mkdirSync(vaultDir, { recursive: true });
@@ -131,6 +135,7 @@ export async function createMachineFixture(
     machineName,
     vaultDir,
     keyPath,
+    machineFilePath,
     identity,
     recipient,
   };


### PR DESCRIPTION
## Summary

Closes #155. Part 1 of 6 in the per-machine-vault v2 pivot (epic #161).

In v2 the vault layout becomes `vault/machines/<machineName>/...`, which makes `machineName` a directory segment, not just a recipients-map key. Previously it was re-derived from `os.hostname()` on every run, meaning a hostname change would silently orphan a machine's entire namespace. This PR pins the resolved name once at `init` so identity is stable for the lifetime of an installation.

Scope is limited to identity pinning only — the `machines/<name>/` vault layout change is #156.

## Changes

### `src/commands/shared.ts` — runtime context

- `resolveRuntimeContext` resolves `machineName` via the chain: pinned file `??` `AGENTSYNC_MACHINE` env `??` `HOSTNAME` env `??` `os.hostname()` `??` `"local-machine"`, then validates it. The resolver stays read-only.
- New `machineFilePath` field on `RuntimeContext`. Defaults to `dirname(key.txt)/machine` (equivalent to `<AGENTSYNC_DIR>/machine` in the default layout); overridable via `AGENTSYNC_MACHINE_FILE` for test isolation.
- `validateMachineName` rejects: empty, `.`, `..`, leading dot, control characters, path separators, and the Windows-illegal set (`: * ? " < > |`, trailing dot/space, reserved names `CON`/`PRN`/`AUX`/`NUL`/`COM1-9`/`LPT1-9`). Cross-platform validation is necessary because a name pinned on macOS may become a directory segment checked out on Windows.

### `src/commands/init.ts` — pinning

- `pinMachineNameIfAbsent` writes the resolved name to `machineFilePath` at mode `0o600` on first `init`. No-op if the file already exists. Refuses to write an invalid name, and ensures the parent directory exists.
- Pinning happens only at `init`, never lazily inside the resolver, to prevent test runs from writing to `~/.config/agentsync` and to avoid cross-contaminating `machineName` between resolver calls.
- Existing installations are not pinned in place — that is deferred to the `vault upgrade` migration in #156.

### `docs/operations.md`

- Precedence table and surrounding prose updated to reflect pin-first resolution order.

## Resolution chain

```mermaid
flowchart LR
  classDef after fill:#27ae60,color:#ffffff
  classDef neutral fill:#2c3e50,color:#ffffff
  classDef env fill:#ecf0f1,color:#2c3e50

  pinFile["pin file"]:::after -->|"present"| validate["validateMachineName"]:::neutral
  pinFile -->|"absent"| envVar["AGENTSYNC_MACHINE"]:::env
  envVar -->|"set"| validate
  envVar -->|"unset"| hostnameEnv["HOSTNAME"]:::env
  hostnameEnv -->|"set"| validate
  hostnameEnv -->|"unset"| osHost["os.hostname"]:::env
  osHost -->|"non-blank"| validate
  osHost -->|"blank"| fallback["local-machine"]:::neutral
  fallback --> validate
  validate --> ctx["RuntimeContext.machineName"]:::after
  initCmd["agentsync init"]:::after -->|"pinMachineNameIfAbsent 0o600"| pinFile
```

Before this PR `machineName` was sourced exclusively from `os.hostname()` on every run with no persistence, so a hostname change would silently break vault routing in v2.

## Test plan

- Unit: pin-first precedence, `machineFilePath` default and `AGENTSYNC_MACHINE_FILE` override, blank-pin fall-through, `validateMachineName` (POSIX and Windows illegal names), `pinMachineNameIfAbsent` write / no-overwrite / refuse-invalid.
- Integration: `init` writes the pin file; a simulated hostname change between runs keeps the pinned name.
- Full suite: 0 failures. New `shared.ts` helpers at 100% coverage.
- Senior-review findings applied: Windows validation gap closed, `pinMachineNameIfAbsent` creates parent directory if absent, stale docs precedence table corrected.

## Risks / follow-ups

- Existing users have no pin file and keep resolving from `os.hostname()` until `vault upgrade` (#156) pins them.
- The `machines/<name>/` vault layout is not touched here — that is #156.
- Downstream commands (`push`, `pull`, `status`, daemon) are unaffected; they read `machineName` from `RuntimeContext` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine names are now pinned during initialization to prevent vault namespace changes when the hostname changes.

* **Documentation**
  * Updated environment variable documentation to clarify machine name pinning semantics and the resolution chain for deriving recipient names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->