### PR TITLE
feat(vault): per-machine layout, integer version guard, and `vault upgrade` migration

### DIFF
--- a/docker/e2e/scenarios/14-dry-run.sh
+++ b/docker/e2e/scenarios/14-dry-run.sh
@@ -58,7 +58,7 @@ pass "vault HEAD intact at ${post_dryrun_head:0:10}"
 step "CRITICAL: vault HEAD blob does NOT contain the new mutation marker"
 # Decrypt the current vault CLAUDE.md.age and assert the new section is
 # absent — proves dry-run wrote nothing through the encryptor either.
-plaintext=$(git --git-dir="$VAULT_PATH" show "HEAD:claude/CLAUDE.md.age" \
+plaintext=$(vshow "$VAULT_PATH" "claude/CLAUDE.md.age" \
             | age -d -i "$MACHINE/.config/agentsync/key.txt")
 if echo "$plaintext" | grep -qF "new section added between snapshots"; then
   fail "dry-run leaked the new content into the vault blob"
@@ -70,7 +70,7 @@ HOME="$MACHINE" bun run src/cli.ts push --message "real push after dry-run"
 post_real_head=$(git --git-dir="$VAULT_PATH" rev-parse HEAD)
 [ "$pre_head" != "$post_real_head" ] \
   || fail "real push didn't advance vault HEAD"
-new_plaintext=$(git --git-dir="$VAULT_PATH" show "HEAD:claude/CLAUDE.md.age" \
+new_plaintext=$(vshow "$VAULT_PATH" "claude/CLAUDE.md.age" \
                 | age -d -i "$MACHINE/.config/agentsync/key.txt")
 echo "$new_plaintext" | grep -qF "new section added between snapshots" \
   || fail "real push didn't write the mutated content"

--- a/docker/e2e/scenarios/16-vscode-non-mcp.sh
+++ b/docker/e2e/scenarios/16-vscode-non-mcp.sh
@@ -38,10 +38,11 @@ sed -i 's/^vscode = false$/vscode = true/' "$TOML"
 HOME="$MACHINE_A" bun run src/cli.ts push --message "vscode mcp-only seed"
 
 step "CRITICAL: vault vscode/ subtree contains only mcp.json.age"
-# Enumerate every entry under vscode/ in HEAD. Filter to the prefix once and
-# compare to the exact-expected single line so unintended siblings fail loud.
-vscode_entries=$(git --git-dir="$VAULT_PATH" ls-tree -r HEAD \
-  | awk '{print $4}' | grep '^vscode/' || true)
+# Enumerate every vscode/ entry in HEAD. v2 prefixes paths with machines/<name>/,
+# so match the agent-relative suffix and compare to the exact-expected single
+# line so unintended siblings fail loud.
+vscode_entries=$(git --git-dir="$VAULT_PATH" ls-tree -r --name-only HEAD \
+  | grep -oE 'vscode/.*' || true)
 echo "$vscode_entries" | sed 's/^/    /'
 [ "$vscode_entries" = "vscode/mcp.json.age" ] \
   || fail "vscode/ contains more than the expected single mcp.json.age entry"

--- a/docker/e2e/scenarios/18-copilot.sh
+++ b/docker/e2e/scenarios/18-copilot.sh
@@ -63,7 +63,7 @@ step "Agent blob decrypts to plaintext markdown (NOT a tar bundle — B15)"
 # Decrypt to a temp file so we can detect tar magic vs markdown headers
 # without bash string truncation on NUL bytes (bash variables can't hold NUL).
 TMP_AGENT=/tmp/copilot-agent-dec
-git --git-dir="$VAULT_PATH" show HEAD:copilot/agents/bug-triager.agent.md.age \
+vshow "$VAULT_PATH" "copilot/agents/bug-triager.agent.md.age" \
   | age -d -i "$A_KEY" > "$TMP_AGENT"
 # Single-file shape proof: gzipped tar archives start with the gzip magic
 # bytes 0x1f 0x8b. Markdown bodies (with or without YAML frontmatter) never do.

--- a/docker/e2e/scenarios/20-home-portability.sh
+++ b/docker/e2e/scenarios/20-home-portability.sh
@@ -101,7 +101,7 @@ assert_file_exists "$A_KEY"
 
 # ─── Vault-side: placeholder is what's encrypted, not the literal path ───────
 step "Negative control: vault stores ${PLACEHOLDER} (not /tmp/alpha)"
-DEC_CLAUDE_JSON=$(git --git-dir="$VAULT_PATH" show HEAD:claude/claude.json.age \
+DEC_CLAUDE_JSON=$(vshow "$VAULT_PATH" "claude/claude.json.age" \
   | age -d -i "$A_KEY")
 case "$DEC_CLAUDE_JSON" in
   *"$PLACEHOLDER"*) pass "claude.json blob carries placeholder" ;;

--- a/docker/e2e/scenarios/_lib.sh
+++ b/docker/e2e/scenarios/_lib.sh
@@ -118,16 +118,39 @@ assert_no_literal_in_vault() {
   pass "no plaintext match for '$regex' across vault"
 }
 
-# tar_age_extract <vault-git-dir> <vault-path> <out-dir> <key-file>
-# Decrypts a tar.age skill bundle and extracts it. <vault-path> is the path
-# inside the bare git tree (e.g. "claude/skills/postgres-helper.tar.age").
+# resolve_vault_path <vault-git-dir> <logical-suffix>
+# Print the single HEAD path ending in <logical-suffix>. Vault format v2 prefixes
+# every artifact with machines/<name>/, so scenarios reference the agent-relative
+# suffix (e.g. "claude/CLAUDE.md.age") and this resolves the full path without
+# needing to know the (container-derived) machine name. Fails unless exactly one
+# entry matches.
+resolve_vault_path() {
+  local vault="$1" suffix="$2" matches count
+  matches=$(git --git-dir="$vault" ls-tree -r --name-only HEAD | grep -F "$suffix" || true)
+  count=$(printf '%s\n' "$matches" | grep -c . || true)
+  [ "$count" -eq 1 ] || fail "expected exactly one vault path matching '$suffix', got $count: $matches"
+  printf '%s' "$matches"
+}
+
+# vshow <vault-git-dir> <logical-suffix>
+# `git show HEAD:<full-path>` with the full path resolved from the logical suffix.
+vshow() {
+  local vault="$1" suffix="$2" full
+  full=$(resolve_vault_path "$vault" "$suffix")
+  git --git-dir="$vault" show "HEAD:${full}"
+}
+
+# tar_age_extract <vault-git-dir> <logical-suffix> <out-dir> <key-file>
+# Decrypts a tar.age skill bundle and extracts it. <logical-suffix> is the
+# agent-relative path (e.g. "claude/skills/postgres-helper.tar.age"); the full
+# machines/<name>/ path is resolved internally.
 tar_age_extract() {
   local vault="$1" vault_path="$2" out_dir="$3" key_file="$4"
   mkdir -p "$out_dir"
   # Skill artifact pipeline (see src/agents/skills-walker.ts:256):
   #   disk → archiveDirectory (tar.gz buffer) → base64 string → encryptString
   # On extract: age-decrypt → base64 decode → tar -xz.
-  git --git-dir="$vault" show "HEAD:${vault_path}" \
+  vshow "$vault" "$vault_path" \
     | age -d -i "$key_file" \
     | base64 -d \
     | tar -xz -C "$out_dir"

--- a/docker/e2e/scenarios/_lib.sh
+++ b/docker/e2e/scenarios/_lib.sh
@@ -126,7 +126,10 @@ assert_no_literal_in_vault() {
 # entry matches.
 resolve_vault_path() {
   local vault="$1" suffix="$2" matches count
-  matches=$(git --git-dir="$vault" ls-tree -r --name-only HEAD | grep -F "$suffix" || true)
+  # End-of-path (suffix) match, not substring, so "claude/x.age" cannot also hit
+  # a path that merely contains it mid-string.
+  matches=$(git --git-dir="$vault" ls-tree -r --name-only HEAD \
+    | awk -v s="$suffix" 'length($0) >= length(s) && substr($0, length($0) - length(s) + 1) == s')
   count=$(printf '%s\n' "$matches" | grep -c . || true)
   [ "$count" -eq 1 ] || fail "expected exactly one vault path matching '$suffix', got $count: $matches"
   printf '%s' "$matches"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,40 +134,42 @@ See [Recover from divergence](operations.md#recover-from-divergence) for the run
 
 ## Vault layout
 
-The vault is a regular Git repository. Inside it, every artefact is suffixed with `.age` and is age-encrypted to the recipient set defined in `agentsync.toml`. The on-disk layout is namespaced per agent:
+The vault is a regular Git repository. Inside it, every artefact is suffixed with `.age` and is age-encrypted to the recipient set defined in `agentsync.toml`. As of vault format v2 the layout is namespaced per machine, then per agent: each machine backs up into its own `machines/<name>/` directory so one machine never overwrites another's. The vault-global `agentsync.toml` stays at the root.
 
 ```text
 <vault-root>/
-├── agentsync.toml                 # recipient list, branch, remote, sync options
-├── claude/
-│   ├── settings.json.age
-│   ├── hooks.json.age
-│   ├── mcp.json.age
-│   ├── marketplace.json.age       # only when claudePlugins.syncMarketplace = true
-│   ├── commands/
-│   │   └── <name>.md.age
-│   ├── skills/
-│   │   └── <name>.tar.age         # tar bundle per skill
-│   └── plugins/
-│       └── <name>/                # one subtree per Claude plugin
-│           ├── plugin.json.age
-│           ├── commands/<name>.md.age
-│           ├── agents/<name>.md.age
-│           ├── hooks/<name>.json.age
-│           └── mcp.json.age
-├── codex/
-│   ├── AGENTS.md.age
-│   └── skills/<name>.tar.age
-├── cursor/
-│   ├── settings.json.age
-│   ├── rules/<name>.mdc.age
-│   └── skills/<name>.tar.age
-└── copilot/
-    ├── instructions.md.age
-    └── skills/<name>.tar.age
+├── agentsync.toml                 # version, recipient list, branch, remote, sync options
+└── machines/
+    └── <name>/                    # one directory per machine (its own backup namespace)
+        ├── claude/
+        │   ├── settings.json.age
+        │   ├── hooks.json.age
+        │   ├── mcp.json.age
+        │   ├── marketplace.json.age   # only when claudePlugins.syncMarketplace = true
+        │   ├── commands/
+        │   │   └── <name>.md.age
+        │   ├── skills/
+        │   │   └── <name>.tar.age      # tar bundle per skill
+        │   └── plugins/
+        │       └── <name>/             # one subtree per Claude plugin
+        │           ├── plugin.json.age
+        │           ├── commands/<name>.md.age
+        │           ├── agents/<name>.md.age
+        │           ├── hooks/<name>.json.age
+        │           └── mcp.json.age
+        ├── codex/
+        │   ├── AGENTS.md.age
+        │   └── skills/<name>.tar.age
+        ├── cursor/
+        │   ├── settings.json.age
+        │   ├── rules/<name>.mdc.age
+        │   └── skills/<name>.tar.age
+        └── copilot/
+            ├── instructions.md.age
+            └── skills/<name>.tar.age
 ```
 
-Skill bundles are tar archives so directory-shaped assets round-trip cleanly. Plugins under `claude/plugins/<name>/` are first-class subtrees so installing a Claude plugin on one machine and pulling on another reproduces every artefact under the same plugin namespace.
+Skill bundles are tar archives so directory-shaped assets round-trip cleanly. Plugins under `machines/<name>/claude/plugins/<name>/` are first-class subtrees so installing a Claude plugin on one machine reproduces every artefact under the same plugin namespace.
 
 `marketplace.json.age` is only emitted, and only applied on pull, when `claudePlugins.syncMarketplace = true` is set in `agentsync.toml` on both machines. The default is false so a vault snapshot does not silently propagate a Claude marketplace opt-in.
 
@@ -244,7 +246,7 @@ Every agent path is resolved through a single resolver that maps `<agent>.<dir>`
 
 ## Vault format versioning
 
-The vault carries a `version` field in `agentsync.toml` (default `"1"`) that future backwards-incompatible changes (a renamed namespace, a new sanitiser rule that would reject already-published content, a new encryption-recipient encoding) will use to gate migrations. Each migration lives under `src/migrate/` and is documented in [Migrate](migrate.md). The current schema treats the field as informational; a forward-incompatibility refusal will land alongside the first breaking change.
+The vault carries an integer `version` field in `agentsync.toml`. Format v2 sets `version = 2` and is the per-machine layout (`machines/<name>/…`). The field is the old-binary hard block: a v1 binary's schema expected a string, so it cannot load a v2 vault and write flat dirs beside `machines/`. Loading is two-phase — `peekVaultVersion` reads the raw `version` before the schema runs, so a legacy v1 vault (string or absent `version`) is routed to `agentsync vault upgrade` instead of failing with an opaque error, and an integer above the current version tells the user to upgrade agentsync itself. `agentsync vault upgrade` performs the one-time v1→v2 relocation (distinct from the cross-agent translators under `src/migrate/`, documented in [Migrate](migrate.md)).
 
 ## Source map
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -274,7 +274,7 @@ agentsync upgrade --check  # report only, install nothing
 
 ## daemon
 
-**Why**: Run AgentSync as a background process that watches your agent paths, debounces pushes, and runs periodic pulls.
+**Why**: Run AgentSync as a background process that watches your agent paths and debounces pushes on change. It is push-only and does not auto-pull.
 
 **Usage**:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -26,7 +26,7 @@ The flag-driven equivalents still work when you need scripted output:
 
 ## Daemon
 
-The daemon is a long-running process that watches your enabled agent paths and pushes on change. It debounces rapid edits, serialises sync operations through a queue so two pushes can never race, and runs periodic pulls at a configurable interval.
+The daemon is a long-running process that watches your enabled agent paths and pushes on change. It debounces rapid edits and serialises sync operations through a queue so two pushes can never race. It is push-only: the vault is per-machine backup, so the daemon never auto-pulls.
 
 ### Install per OS
 
@@ -65,7 +65,7 @@ The daemon moves through a small number of phases. Each phase has a well-defined
 |---|---|
 | Validating | Verifies the vault directory, the config file, and the encryption key are reachable. Exits immediately on failure. |
 | Second-instance check | Sends an IPC `status` ping. If a daemon is already running, exits. Unlinks a stale socket if the prior daemon died ungracefully. |
-| Running | IPC server is listening. File watchers and the periodic pull timer are active. `status` returns the current pid, consecutive-failure counter, and last error. |
+| Running | IPC server is listening and file watchers are active (push-only; no pull timer). `status` returns the current pid, consecutive-failure counter, and last error. |
 | Syncing | A push or pull is executing inside the sync queue. Only one sync runs at a time. |
 | Retry once | Automatic single retry after a transient failure. If both attempts fail, the error is recorded but the daemon stays alive so the next change can still trigger a push. |
 | Shutting down | Drains the sync queue with a hard ten-second timeout, closes IPC, stops watchers, unlinks the socket, exits cleanly. |
@@ -78,8 +78,6 @@ Daemon behaviour is driven by the `[sync]` table in `agentsync.toml`:
 [sync]
 debounceMs = 300        # quiet window after a file change before push fires; 50 to 10000
 autoPush = true         # disable to make the daemon read-only
-autoPull = true         # disable to opt out of periodic pull
-pullIntervalMs = 300000 # how often periodic pull runs, in milliseconds; minimum 1000
 
 [agents]
 cursor = true           # enable cursor adapter

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -90,7 +90,7 @@ vscode = false          # opt-in; vscode's surface is MCP-only
 syncMarketplace = false # opt-in: include ~/.claude/marketplace.json in push/pull
 ```
 
-Defaults are chosen so you can install and forget. Tune them only if you observe excessive push churn or want to widen the pull cadence. Values outside the supported range are rejected at config load.
+Defaults are chosen so you can install and forget. Tune them only if you observe excessive push churn. Values outside the supported range are rejected at config load.
 
 **Environment-variable escape hatches.** For tests, CI, and air-gapped setups, the following variables override the resolved defaults:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { skillCommand } from "./commands/skill";
 import { statusCommand } from "./commands/status";
 import { tuiCommand } from "./commands/tui";
 import { upgradeCommand } from "./commands/upgrade";
+import { vaultCommand } from "./commands/vault";
 
 /** Root CLI command that wires every user-facing subcommand into a single entry point. */
 const main = defineCommand({
@@ -32,6 +33,7 @@ const main = defineCommand({
     skill: skillCommand,
     destroy: destroyCommand,
     upgrade: upgradeCommand,
+    vault: vaultCommand,
     tui: tuiCommand,
   },
 });

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -1155,7 +1155,11 @@ describe("integration", () => {
         message.includes("AgentSync only supports fast-forward sync"),
       ),
     ).toBe(true);
-    expect(existsSync(join(machineB.vaultDir, "claude", "blocked.age"))).toBe(false);
+    expect(
+      existsSync(
+        join(machineVaultRoot(machineB.vaultDir, machineB.machineName), "claude", "blocked.age"),
+      ),
+    ).toBe(false);
   }, 20000);
 });
 
@@ -1285,13 +1289,15 @@ describe("skills sync integration guarantees", () => {
     const base64 = tarBuffer.toString("base64");
     const encrypted = await encryptString(base64, [recipient]);
 
-    const skillsVaultDir = join(machine.vaultDir, "claude", "skills");
+    // v2: apply reads this machine's namespace, so seed + apply use the same root.
+    const machineScopedRoot = machineVaultRoot(machine.vaultDir, machine.machineName);
+    const skillsVaultDir = join(machineScopedRoot, "claude", "skills");
     await mkdirAsync(skillsVaultDir, { recursive: true });
     const vaultFile = join(skillsVaultDir, "my-skill.tar.age");
     await writeFileAsync(vaultFile, encrypted, "utf8");
 
     // First pull: populates the local ~/.claude/skills/my-skill/ directory.
-    await claude.applyClaudeVault(machine.vaultDir, identity, false, createTestAgentSyncConfig());
+    await claude.applyClaudeVault(machineScopedRoot, identity, false, createTestAgentSyncConfig());
 
     const localSkillDir = join(mutableClaudePaths.skillsDir, "my-skill");
     expect(existsSync(join(localSkillDir, "SKILL.md"))).toBe(true);
@@ -1304,7 +1310,7 @@ describe("skills sync integration guarantees", () => {
     // Second pull against the now-empty vault. The local skill directory
     // MUST remain intact, no file added, no file removed: vault delete is
     // additive-only on the pull side.
-    await claude.applyClaudeVault(machine.vaultDir, identity, false, createTestAgentSyncConfig());
+    await claude.applyClaudeVault(machineScopedRoot, identity, false, createTestAgentSyncConfig());
 
     expect(existsSync(join(localSkillDir, "SKILL.md"))).toBe(true);
     expect(existsSync(join(localSkillDir, "notes.md"))).toBe(true);

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -13,7 +13,9 @@ import { createRequire } from "node:module";
 import { join } from "node:path";
 import type { CommandDef } from "citty";
 import type { SnapshotArtifact } from "../../agents/_utils";
-import { loadConfig, resolveConfigPath, writeConfig } from "../../config/loader";
+import { loadConfig, peekVaultVersion, resolveConfigPath, writeConfig } from "../../config/loader";
+import { machineVaultRoot } from "../../config/paths";
+import { CURRENT_VAULT_VERSION } from "../../config/schema";
 import {
   createAgeIdentity,
   createBareRepo,
@@ -170,6 +172,8 @@ beforeAll(async () => {
 describe("integration", () => {
   let tmpDir: string;
   let vaultDir: string;
+  // v2: this machine's artifacts live under machines/<machineName>/ in the vault.
+  let machineRoot: string;
   let keyPath: string;
   let machine: TestMachineFixture;
   const machineName = "test-machine";
@@ -180,6 +184,7 @@ describe("integration", () => {
     const bareRepoPath = await createBareRepo(tmpDir);
     machine = await createMachineFixture(tmpDir, machineName);
     vaultDir = machine.vaultDir;
+    machineRoot = machineVaultRoot(vaultDir, machineName);
     keyPath = machine.keyPath;
 
     for (const key of RUNTIME_ENV_KEYS) {
@@ -239,6 +244,8 @@ describe("integration", () => {
     const configContent = await readFile(join(initMachine.vaultDir, "agentsync.toml"), "utf8");
     expect(configContent).toMatch(/recipients/);
     expect(configContent).toMatch(/init-machine/);
+    // v2: a fresh init writes the integer version, not the legacy string "1".
+    expect(await peekVaultVersion(resolveConfigPath(initMachine.vaultDir))).toEqual({ kind: "v2" });
     expect(runGit(["rev-parse", "--abbrev-ref", "HEAD"], initMachine.vaultDir)).toBe("main");
 
     // init pins the resolved machine name to local state (outside the vault) so
@@ -435,7 +442,7 @@ describe("integration", () => {
     seedVaultRepo({ machine: machineA, bareRepoPath });
 
     await writeConfig(resolveConfigPath(machineB.vaultDir), {
-      version: "1",
+      version: CURRENT_VAULT_VERSION,
       recipients: { [machineB.machineName]: machineB.recipient },
       agents: {
         cursor: false,
@@ -451,8 +458,6 @@ describe("integration", () => {
       sync: {
         debounceMs: 300,
         autoPush: true,
-        autoPull: true,
-        pullIntervalMs: 300_000,
       },
       claudePlugins: { syncMarketplace: false },
     });
@@ -623,7 +628,7 @@ describe("integration", () => {
     seedVaultRepo({ machine: machineA, bareRepoPath });
 
     await writeConfig(resolveConfigPath(machineB.vaultDir), {
-      version: "1",
+      version: CURRENT_VAULT_VERSION,
       recipients: { [machineB.machineName]: machineB.recipient },
       agents: {
         cursor: false,
@@ -639,8 +644,6 @@ describe("integration", () => {
       sync: {
         debounceMs: 300,
         autoPush: true,
-        autoPull: true,
-        pullIntervalMs: 300_000,
       },
       claudePlugins: { syncMarketplace: false },
     });
@@ -687,7 +690,7 @@ describe("integration", () => {
     expect(result.pushed).toBe(1);
     expect(result.errors).toHaveLength(0);
 
-    const ageFile = join(vaultDir, "claude", "CLAUDE.age");
+    const ageFile = join(machineRoot, "claude", "CLAUDE.age");
     expect(existsSync(ageFile)).toBe(true);
 
     const content = await readFile(ageFile, "utf8");
@@ -700,7 +703,8 @@ describe("integration", () => {
     expect(result.fatal).toBe(false);
     expect(result.errors).toHaveLength(0);
     expect(result.applied).toBe(1);
-    expect(fakeApplyCalls).toContain(vaultDir);
+    // v2: pull applies from this machine's namespace, not the flat vault root.
+    expect(fakeApplyCalls).toContain(machineRoot);
   });
 
   test("performPush aborts when an artifact warning contains 'Detected literal secret'", async () => {
@@ -814,7 +818,7 @@ describe("integration", () => {
     expect(configContent).toContain("work-laptop");
     expect(configContent).toContain(newRecipient);
 
-    const ageFile = join(vaultDir, "claude", "CLAUDE.age");
+    const ageFile = join(machineRoot, "claude", "CLAUDE.age");
     expect(existsSync(ageFile)).toBe(true);
     const content = await readFile(ageFile, "utf8");
     expect(content).toContain("BEGIN AGE ENCRYPTED FILE");
@@ -900,7 +904,7 @@ describe("integration", () => {
     const configBefore = await loadConfig(configPath);
     const oldKeyContent = await readFile(keyPath, "utf8");
 
-    writeFileSync(join(vaultDir, "claude", "broken.age"), "not a valid age payload", "utf8");
+    writeFileSync(join(machineRoot, "claude", "broken.age"), "not a valid age payload", "utf8");
     fakeLogs.error.length = 0;
     process.exitCode = 0;
 
@@ -932,7 +936,7 @@ describe("integration", () => {
       cmd: {} as never,
     } as never);
 
-    expect(existsSync(join(vaultDir, "claude", "dry-cli.age"))).toBe(false);
+    expect(existsSync(join(machineRoot, "claude", "dry-cli.age"))).toBe(false);
   });
 
   test("pushCommand.run with dryRun=true aborts when an artifact warning reports a literal secret", async () => {
@@ -962,7 +966,7 @@ describe("integration", () => {
     expect(fakeLogs.error.some((message) => message.includes("Detected literal secret"))).toBe(
       true,
     );
-    expect(existsSync(join(vaultDir, "claude", "leaky-cli.age"))).toBe(false);
+    expect(existsSync(join(machineRoot, "claude", "leaky-cli.age"))).toBe(false);
 
     fakeArtifacts.length = 0;
     process.exitCode = 0;
@@ -1002,7 +1006,7 @@ describe("integration", () => {
     expect(authJsonLines[0]).toContain("SKIP");
     expect(authJsonLines[0]).toContain("never-sync");
     expect(fakeLogs.warn.some((m) => m.includes("matches never-sync pattern"))).toBe(false);
-    expect(existsSync(join(vaultDir, "claude", "auth.json.age"))).toBe(false);
+    expect(existsSync(join(machineRoot, "claude", "auth.json.age"))).toBe(false);
 
     fakeArtifacts.length = 0;
   });
@@ -1075,8 +1079,8 @@ describe("integration", () => {
         (e) => e.includes("/fake/.claude/auth.json") && e.includes("matches never-sync pattern"),
       ),
     ).toBe(true);
-    expect(existsSync(join(vaultDir, "claude", "auth.json.age"))).toBe(false);
-    expect(existsSync(join(vaultDir, "claude", "sibling.age"))).toBe(true);
+    expect(existsSync(join(machineRoot, "claude", "auth.json.age"))).toBe(false);
+    expect(existsSync(join(machineRoot, "claude", "sibling.age"))).toBe(true);
 
     fakeArtifacts.length = 0;
   });
@@ -1095,7 +1099,7 @@ describe("integration", () => {
       cmd: {} as never,
     } as never);
 
-    expect(existsSync(join(vaultDir, "claude", "cli-push.age"))).toBe(true);
+    expect(existsSync(join(machineRoot, "claude", "cli-push.age"))).toBe(true);
   });
 
   test("performPush returns early when no agents match requested name", async () => {
@@ -1348,7 +1352,11 @@ describe("skills sync integration guarantees", () => {
     expect(result.pushed).toBeGreaterThanOrEqual(1);
 
     // Assertion 1: no vendored.tar.age artifact was written.
-    const skillsVaultDir = join(machine.vaultDir, "claude", "skills");
+    const skillsVaultDir = join(
+      machineVaultRoot(machine.vaultDir, machine.machineName),
+      "claude",
+      "skills",
+    );
     expect(existsSync(join(skillsVaultDir, "vendored.tar.age"))).toBe(false);
 
     // Assertion 2: decrypt every .tar.age in claude/skills/, extract it to a

--- a/src/commands/__tests__/push.test.ts
+++ b/src/commands/__tests__/push.test.ts
@@ -12,7 +12,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
-import { AgentPaths } from "../../config/paths";
+import { AgentPaths, machineVaultRoot } from "../../config/paths";
 import {
   createBareRepo,
   createMachineFixture,
@@ -174,12 +174,26 @@ describe("performPush — never-sync inside skill", () => {
 
     // Belt and braces: no skill artifacts should have been written for either
     // skill — the gate aborts before any encryption.
-    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "clean-skill.tar.age"))).toBe(
-      false,
-    );
-    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "dirty-skill.tar.age"))).toBe(
-      false,
-    );
+    expect(
+      existsSync(
+        join(
+          machineVaultRoot(machine.vaultDir, machine.machineName),
+          "copilot",
+          "skills",
+          "clean-skill.tar.age",
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      existsSync(
+        join(
+          machineVaultRoot(machine.vaultDir, machine.machineName),
+          "copilot",
+          "skills",
+          "dirty-skill.tar.age",
+        ),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -261,7 +275,12 @@ describe("performPush — additive default for local deletes", () => {
     expect(firstResult.fatal).toBe(false);
     expect(firstResult.pushed).toBeGreaterThanOrEqual(1);
 
-    const vaultArtifact = join(machine.vaultDir, "copilot", "skills", "long-lived-skill.tar.age");
+    const vaultArtifact = join(
+      machineVaultRoot(machine.vaultDir, machine.machineName),
+      "copilot",
+      "skills",
+      "long-lived-skill.tar.age",
+    );
     expect(existsSync(vaultArtifact)).toBe(true);
     const firstBytes = await readFile(vaultArtifact);
     expect(firstBytes.length).toBeGreaterThan(0);
@@ -373,9 +392,16 @@ describe("performPush — literal secret embedded in markdown body", () => {
     expect(result.errors.some((e) => e.includes("leaky.prompt.md"))).toBe(true);
 
     // Belt and braces: no encrypted artifact written for the prompt.
-    expect(existsSync(join(machine.vaultDir, "copilot", "prompts", "leaky.prompt.md.age"))).toBe(
-      false,
-    );
+    expect(
+      existsSync(
+        join(
+          machineVaultRoot(machine.vaultDir, machine.machineName),
+          "copilot",
+          "prompts",
+          "leaky.prompt.md.age",
+        ),
+      ),
+    ).toBe(false);
   });
 
   test("vaultPaths allowlist skips the secret scan for unselected files", async () => {
@@ -402,11 +428,26 @@ describe("performPush — literal secret embedded in markdown body", () => {
     // Push succeeds because the leaky file is filtered out before the scan.
     expect(result.fatal).toBe(false);
     expect(result.pushed).toBeGreaterThan(0);
-    expect(existsSync(join(machine.vaultDir, "copilot", "instructions.md.age"))).toBe(true);
+    expect(
+      existsSync(
+        join(
+          machineVaultRoot(machine.vaultDir, machine.machineName),
+          "copilot",
+          "instructions.md.age",
+        ),
+      ),
+    ).toBe(true);
     // The unselected leaky file was never encrypted.
-    expect(existsSync(join(machine.vaultDir, "copilot", "prompts", "leaky.prompt.md.age"))).toBe(
-      false,
-    );
+    expect(
+      existsSync(
+        join(
+          machineVaultRoot(machine.vaultDir, machine.machineName),
+          "copilot",
+          "prompts",
+          "leaky.prompt.md.age",
+        ),
+      ),
+    ).toBe(false);
   });
 
   test("vaultPaths allowlist still aborts when a SELECTED file contains a secret", async () => {
@@ -523,9 +564,16 @@ describe("performPush — literal secret embedded inside a skill bundle body", (
 
     // No encrypted artifact written for the leaky skill — the walker drops
     // the artifact before encryption.
-    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "leaky-bundle.tar.age"))).toBe(
-      false,
-    );
+    expect(
+      existsSync(
+        join(
+          machineVaultRoot(machine.vaultDir, machine.machineName),
+          "copilot",
+          "skills",
+          "leaky-bundle.tar.age",
+        ),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -629,7 +677,14 @@ describe("performPush — dry-run still runs Phase 1 security gates", () => {
 
     // No encrypted artifact written even though the operation was a dry-run.
     expect(
-      existsSync(join(machine.vaultDir, "copilot", "prompts", "dry-leaky.prompt.md.age")),
+      existsSync(
+        join(
+          machineVaultRoot(machine.vaultDir, machine.machineName),
+          "copilot",
+          "prompts",
+          "dry-leaky.prompt.md.age",
+        ),
+      ),
     ).toBe(false);
   });
 
@@ -661,12 +716,26 @@ describe("performPush — dry-run still runs Phase 1 security gates", () => {
     // Phase 1 aborts before any preview entry is emitted.
     expect(previews).toHaveLength(0);
 
-    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "clean-skill.tar.age"))).toBe(
-      false,
-    );
-    expect(existsSync(join(machine.vaultDir, "copilot", "skills", "dirty-skill.tar.age"))).toBe(
-      false,
-    );
+    expect(
+      existsSync(
+        join(
+          machineVaultRoot(machine.vaultDir, machine.machineName),
+          "copilot",
+          "skills",
+          "clean-skill.tar.age",
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      existsSync(
+        join(
+          machineVaultRoot(machine.vaultDir, machine.machineName),
+          "copilot",
+          "skills",
+          "dirty-skill.tar.age",
+        ),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/commands/__tests__/shared.test.ts
+++ b/src/commands/__tests__/shared.test.ts
@@ -421,4 +421,28 @@ describe("loadVaultConfigOrExit", () => {
     // process.exit must NOT fire — that path is reserved for the missing-vault case.
     expect(exitCalledWith).toBeNull();
   });
+
+  test("stops a v1 (flat) vault with the `vault upgrade` hint", async () => {
+    const { loadVaultConfigOrExit } = await import("../shared");
+
+    const vaultDir = join(tmpDir, "v1-vault");
+    await mkdir(vaultDir, { recursive: true });
+    await writeFile(join(vaultDir, "agentsync.toml"), 'version = "1"\n', "utf8");
+
+    await expect(loadVaultConfigOrExit(vaultDir)).rejects.toThrow("__test_exit__");
+    expect(exitCalledWith).toBe(1);
+    expect(fakeLogs.error[0]).toContain("vault upgrade");
+  });
+
+  test("stops a newer-format vault with the `upgrade agentsync` hint", async () => {
+    const { loadVaultConfigOrExit } = await import("../shared");
+
+    const vaultDir = join(tmpDir, "v3-vault");
+    await mkdir(vaultDir, { recursive: true });
+    await writeFile(join(vaultDir, "agentsync.toml"), "version = 3\n", "utf8");
+
+    await expect(loadVaultConfigOrExit(vaultDir)).rejects.toThrow("__test_exit__");
+    expect(exitCalledWith).toBe(1);
+    expect(fakeLogs.error[0]).toContain("upgrade");
+  });
 });

--- a/src/commands/__tests__/skill.test.ts
+++ b/src/commands/__tests__/skill.test.ts
@@ -212,7 +212,7 @@ describe("performSkillRemove — contract rows", () => {
   test("rejects a path-traversal --machine before touching the vault", async () => {
     // --machine becomes a vault directory segment; `..` would escape the
     // namespace and let the commit/push delete an arbitrary vault path.
-    for (const bad of ["..", "../../etc", "a/b"]) {
+    for (const bad of ["..", "../../etc", "a/b", ""]) {
       const result = await skillMod.performSkillRemove({
         agent: "claude",
         name: "x",

--- a/src/commands/__tests__/skill.test.ts
+++ b/src/commands/__tests__/skill.test.ts
@@ -12,7 +12,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { rm, stat } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
-import { AgentPaths } from "../../config/paths";
+import { AgentPaths, machineVaultRoot } from "../../config/paths";
 import {
   createBareRepo,
   createMachineFixture,
@@ -156,7 +156,11 @@ describe("performSkillRemove — contract rows", () => {
     // only `stat`s the file and then unlinks it. The file must be committed
     // (and pushed) first so that the subsequent unlink+commit actually has a
     // file to remove from git's index.
-    const skillsVaultDir = join(machine.vaultDir, "claude", "skills");
+    const skillsVaultDir = join(
+      machineVaultRoot(machine.vaultDir, machine.machineName),
+      "claude",
+      "skills",
+    );
     mkdirSync(skillsVaultDir, { recursive: true });
     writeFileSync(join(skillsVaultDir, "my-skill.tar.age"), "placeholder-bytes", "utf8");
     runGit(["add", "."], machine.vaultDir);
@@ -202,6 +206,19 @@ describe("performSkillRemove — contract rows", () => {
     if (result.status === "unknown-agent") {
       expect(result.provided).toBe("vscode");
       expect(result.supported).toEqual(["claude", "cursor", "codex", "copilot"]);
+    }
+  });
+
+  test("rejects a path-traversal --machine before touching the vault", async () => {
+    // --machine becomes a vault directory segment; `..` would escape the
+    // namespace and let the commit/push delete an arbitrary vault path.
+    for (const bad of ["..", "../../etc", "a/b"]) {
+      const result = await skillMod.performSkillRemove({
+        agent: "claude",
+        name: "x",
+        machine: bad,
+      });
+      expect(result.status).toBe("invalid-machine");
     }
   });
 
@@ -294,7 +311,11 @@ describe("skillCommand — citty wrapper", () => {
   });
 
   test("success leaves process.exitCode at 0 and logs the commit sha", async () => {
-    const skillsVaultDir = join(machine.vaultDir, "claude", "skills");
+    const skillsVaultDir = join(
+      machineVaultRoot(machine.vaultDir, machine.machineName),
+      "claude",
+      "skills",
+    );
     mkdirSync(skillsVaultDir, { recursive: true });
     writeFileSync(join(skillsVaultDir, "cli-skill.tar.age"), "placeholder", "utf8");
     runGit(["add", "."], machine.vaultDir);

--- a/src/commands/__tests__/status.test.ts
+++ b/src/commands/__tests__/status.test.ts
@@ -4,7 +4,7 @@ import { mkdir, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import pc from "picocolors";
-import { AgentPaths } from "../../config/paths";
+import { AgentPaths, machineVaultRoot } from "../../config/paths";
 import {
   createBareRepo,
   createMachineFixture,
@@ -204,7 +204,12 @@ describe("status surfaces skill drift", () => {
     const recipient = machine.recipient;
     const encrypted = await encryptString(snap.artifacts[0]?.plaintext ?? "", [recipient]);
 
-    const vaultArtPath = join(machine.vaultDir, "copilot", "skills", "drift-test-skill.tar.age");
+    const vaultArtPath = join(
+      machineVaultRoot(machine.vaultDir, machine.machineName),
+      "copilot",
+      "skills",
+      "drift-test-skill.tar.age",
+    );
     await mkdir(dirname(vaultArtPath), { recursive: true });
     writeFileSync(vaultArtPath, encrypted, "utf8");
 
@@ -240,7 +245,12 @@ describe("status surfaces skill drift", () => {
     const encryptedV1 = await encryptString(snapV1.artifacts[0]?.plaintext ?? "", [
       machine.recipient,
     ]);
-    const vaultArtPath = join(machine.vaultDir, "copilot", "skills", "mutating-skill.tar.age");
+    const vaultArtPath = join(
+      machineVaultRoot(machine.vaultDir, machine.machineName),
+      "copilot",
+      "skills",
+      "mutating-skill.tar.age",
+    );
     await mkdir(dirname(vaultArtPath), { recursive: true });
     writeFileSync(vaultArtPath, encryptedV1, "utf8");
 

--- a/src/commands/__tests__/vault.test.ts
+++ b/src/commands/__tests__/vault.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { loadConfig, resolveConfigPath } from "../../config/loader";
+import { machineVaultRoot } from "../../config/paths";
+import {
+  createBareRepo,
+  createMachineFixture,
+  createTmpDir,
+  runGit,
+  type TestMachineFixture,
+} from "../../test-helpers/fixtures";
+import { performVaultUpgrade } from "../vault";
+
+const RUNTIME_ENV_KEYS = [
+  "AGENTSYNC_VAULT_DIR",
+  "AGENTSYNC_KEY_PATH",
+  "AGENTSYNC_MACHINE",
+  "AGENTSYNC_MACHINE_FILE",
+];
+
+function applyMachineEnv(machine: TestMachineFixture): void {
+  process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+  process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+  process.env.AGENTSYNC_MACHINE = machine.machineName;
+  process.env.AGENTSYNC_MACHINE_FILE = machine.machineFilePath;
+}
+
+/** Seed a flat (v1) vault with the given agent dirs and push it to the bare remote. */
+function seedFlatV1Vault(machine: TestMachineFixture, bareRepoPath: string, agentDirs: string[]) {
+  mkdirSync(machine.vaultDir, { recursive: true });
+  writeFileSync(
+    join(machine.vaultDir, "agentsync.toml"),
+    [
+      'version = "1"',
+      "[recipients]",
+      `${machine.machineName} = "${machine.recipient}"`,
+      "[agents]",
+      "claude = true",
+      "cursor = true",
+      "codex = true",
+      "copilot = true",
+      "vscode = false",
+      "[remote]",
+      `url = "${bareRepoPath}"`,
+      'branch = "main"',
+      "[sync]",
+      "debounceMs = 300",
+      "autoPush = true",
+      "autoPull = true",
+      "pullIntervalMs = 300000",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  for (const agent of agentDirs) {
+    mkdirSync(join(machine.vaultDir, agent), { recursive: true });
+    writeFileSync(join(machine.vaultDir, agent, "artifact.age"), `${agent}-bytes`, "utf8");
+  }
+  runGit(["init"], machine.vaultDir);
+  runGit(["symbolic-ref", "HEAD", "refs/heads/main"], machine.vaultDir);
+  runGit(["config", "user.name", "Agent Sync Test"], machine.vaultDir);
+  runGit(["config", "user.email", "test@agentsync.local"], machine.vaultDir);
+  runGit(["remote", "add", "origin", bareRepoPath], machine.vaultDir);
+  runGit(["add", "-A"], machine.vaultDir);
+  runGit(["commit", "-m", "seed flat v1 vault"], machine.vaultDir);
+  runGit(["push", "-u", "origin", "main"], machine.vaultDir);
+}
+
+describe("performVaultUpgrade", () => {
+  let tmpDir: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    for (const key of RUNTIME_ENV_KEYS) savedEnv[key] = process.env[key];
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("migrates a flat v1 vault to machines/<self>/, bumps version, and pushes fast-forward", async () => {
+    const bareRepoPath = await createBareRepo(tmpDir);
+    const machine = await createMachineFixture(tmpDir, "alpha");
+    // createMachineFixture pre-creates an empty vaultDir; seed the v1 content into it.
+    seedFlatV1Vault(machine, bareRepoPath, ["claude", "cursor"]);
+    applyMachineEnv(machine);
+
+    const result = await performVaultUpgrade();
+
+    expect(result.status).toBe("upgraded");
+    if (result.status === "upgraded") {
+      expect(result.movedAgents.sort()).toEqual(["claude", "cursor"]);
+    }
+
+    const root = machineVaultRoot(machine.vaultDir, "alpha");
+    // Relocated under the machine namespace; the flat dirs are gone.
+    expect(existsSync(join(root, "claude", "artifact.age"))).toBe(true);
+    expect(existsSync(join(root, "cursor", "artifact.age"))).toBe(true);
+    expect(existsSync(join(machine.vaultDir, "claude"))).toBe(false);
+    expect(existsSync(join(machine.vaultDir, "cursor"))).toBe(false);
+
+    // Version bumped to the integer 2 and the down-sync fields dropped.
+    const config = await loadConfig(resolveConfigPath(machine.vaultDir));
+    expect(config.version).toBe(2);
+    expect((config.sync as Record<string, unknown>).autoPull).toBeUndefined();
+
+    // History preserved via git mv (the relocated file is followable).
+    const followLog = runGit(
+      ["log", "--follow", "--format=%s", "--", "machines/alpha/claude/artifact.age"],
+      machine.vaultDir,
+    );
+    expect(followLog).toContain("seed flat v1 vault");
+
+    // Pushed fast-forward: the bare remote now holds the upgrade commit.
+    const localHead = runGit(["rev-parse", "HEAD"], machine.vaultDir);
+    const remoteHead = runGit(["rev-parse", "origin/main"], machine.vaultDir);
+    expect(localHead).toBe(remoteHead);
+  });
+
+  test("is an idempotent no-op on a vault already at v2", async () => {
+    const bareRepoPath = await createBareRepo(tmpDir);
+    const machine = await createMachineFixture(tmpDir, "beta");
+    seedFlatV1Vault(machine, bareRepoPath, ["claude"]);
+    applyMachineEnv(machine);
+
+    expect((await performVaultUpgrade()).status).toBe("upgraded");
+    // Re-running sees a v2 vault and does nothing.
+    expect((await performVaultUpgrade()).status).toBe("already-v2");
+  });
+
+  test("reports not-initialized when the vault has no config", async () => {
+    const machine = await createMachineFixture(tmpDir, "gamma");
+    applyMachineEnv(machine);
+    const result = await performVaultUpgrade();
+    expect(result.status).toBe("not-initialized");
+  });
+});
+
+describe("per-machine namespace isolation", () => {
+  let tmpDir: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    for (const key of RUNTIME_ENV_KEYS) savedEnv[key] = process.env[key];
+  });
+
+  afterEach(async () => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("after upgrade, a second machine's content lives in its own namespace", async () => {
+    // Two machines upgrade their own flat content into distinct namespaces in
+    // separate clones; the layout never collides on the agent directory name.
+    const bareA = await createBareRepo(join(tmpDir, "a"));
+    const machineA = await createMachineFixture(tmpDir, "host-a");
+    seedFlatV1Vault(machineA, bareA, ["claude"]);
+    applyMachineEnv(machineA);
+    await performVaultUpgrade();
+
+    const bareB = await createBareRepo(join(tmpDir, "b"));
+    const machineB = await createMachineFixture(tmpDir, "host-b");
+    seedFlatV1Vault(machineB, bareB, ["claude"]);
+    applyMachineEnv(machineB);
+    await performVaultUpgrade();
+
+    expect(existsSync(join(machineVaultRoot(machineA.vaultDir, "host-a"), "claude"))).toBe(true);
+    expect(existsSync(join(machineVaultRoot(machineB.vaultDir, "host-b"), "claude"))).toBe(true);
+    // Neither machine wrote into the other's namespace.
+    expect(existsSync(join(machineA.vaultDir, "machines", "host-b"))).toBe(false);
+    expect(existsSync(join(machineB.vaultDir, "machines", "host-a"))).toBe(false);
+  });
+});

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,8 +2,9 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
-import { loadConfig, resolveConfigPath, writeConfig } from "../config/loader";
+import { loadConfig, peekVaultVersion, resolveConfigPath, writeConfig } from "../config/loader";
 import { resolveAgentSyncHome } from "../config/paths";
+import { CURRENT_VAULT_VERSION } from "../config/schema";
 import { generateIdentity, identityToRecipient } from "../core/encryptor";
 import { GitClient } from "../core/git";
 import {
@@ -24,8 +25,6 @@ const DEFAULT_AGENTS = {
 const DEFAULT_SYNC = {
   debounceMs: 300,
   autoPush: true,
-  autoPull: true,
-  pullIntervalMs: 300_000,
 };
 
 /** Discriminated result of a `performInit` invocation — lets non-CLI callers
@@ -41,6 +40,8 @@ export type InitResult =
       privateKeyPath: string;
     }
   | { status: "remote-probe-failed"; error: string }
+  | { status: "vault-needs-upgrade"; vaultDir: string }
+  | { status: "unsupported-version"; version: number }
   | { status: "failed"; error: string; keyRolledBack: boolean };
 
 export interface InitOptions {
@@ -77,6 +78,25 @@ async function ensureKeypair(
       );
     }
     throw err;
+  }
+}
+
+/**
+ * Remove a key generated on this invocation when init aborts, so a retry is not
+ * bound to material that never made it into a successful init. A pre-existing
+ * key (keyIsNew false) is preserved untouched. Returns whether it removed one.
+ */
+async function rollbackFreshKey(keyIsNew: boolean, path: string): Promise<boolean> {
+  if (!keyIsNew) return false;
+  try {
+    await rm(path, { force: true });
+    return true;
+  } catch (rmErr) {
+    const rmMessage = rmErr instanceof Error ? rmErr.message : String(rmErr);
+    log.warn(
+      `Failed to roll back freshly generated key at ${path}: ${rmMessage}.\nRemove key.txt manually before retrying.`,
+    );
+    return false;
   }
 }
 
@@ -132,6 +152,19 @@ export async function performInit(options: InitOptions): Promise<InitResult> {
 
     const configPath = resolveConfigPath(runtime.vaultDir);
 
+    // Refuse to join a vault this binary cannot safely write. A v1 vault must be
+    // upgraded first — otherwise the v2 schema fails to load it, we treat it as
+    // fresh, and re-create a config that drops every other machine's recipient.
+    const probe = await peekVaultVersion(configPath);
+    if (probe.kind === "v1" || probe.kind === "unsupported") {
+      // Refusing to join — roll back a key generated this run so it does not
+      // linger unused (mirrors the failure path below).
+      await rollbackFreshKey(keyIsNew, runtime.privateKeyPath);
+      return probe.kind === "v1"
+        ? { status: "vault-needs-upgrade", vaultDir: runtime.vaultDir }
+        : { status: "unsupported-version", version: probe.version };
+    }
+
     let existing = null;
     try {
       existing = await loadConfig(configPath);
@@ -142,8 +175,8 @@ export async function performInit(options: InitOptions): Promise<InitResult> {
     const joinedExistingVault =
       existing !== null && existing.recipients[runtime.machineName] !== recipient;
 
-    const config = {
-      version: existing?.version ?? "1",
+    await writeConfig(configPath, {
+      version: CURRENT_VAULT_VERSION,
       recipients: {
         ...(existing?.recipients ?? {}),
         [runtime.machineName]: recipient,
@@ -155,9 +188,7 @@ export async function performInit(options: InitOptions): Promise<InitResult> {
       },
       sync: existing?.sync ?? DEFAULT_SYNC,
       claudePlugins: existing?.claudePlugins ?? { syncMarketplace: false },
-    };
-
-    await writeConfig(configPath, config);
+    });
 
     // Pin the machine name to local state so a later hostname change cannot
     // re-derive a different name and orphan this machine's vault namespace
@@ -185,22 +216,10 @@ export async function performInit(options: InitOptions): Promise<InitResult> {
       privateKeyPath: runtime.privateKeyPath,
     };
   } catch (err) {
-    // The remote probe passed but a later step failed. If we generated the
-    // key on this invocation, delete it so a retry is not bound to material
-    // that never made it into a successful init. A pre-existing key is
-    // preserved untouched.
-    let keyRolledBack = false;
-    if (keyIsNew) {
-      try {
-        await rm(runtime.privateKeyPath, { force: true });
-        keyRolledBack = true;
-      } catch (rmErr) {
-        const rmMessage = rmErr instanceof Error ? rmErr.message : String(rmErr);
-        log.warn(
-          `Failed to roll back freshly generated key at ${runtime.privateKeyPath}: ${rmMessage}.\nRemove key.txt manually before retrying.`,
-        );
-      }
-    }
+    // The remote probe passed but a later step failed. Roll back a key generated
+    // this invocation so a retry is not bound to material that never made it into
+    // a successful init. A pre-existing key is preserved untouched.
+    const keyRolledBack = await rollbackFreshKey(keyIsNew, runtime.privateKeyPath);
     return {
       status: "failed",
       error: err instanceof Error ? err.message : String(err),
@@ -233,6 +252,22 @@ export const initCommand = defineCommand({
 
     if (result.status === "remote-probe-failed") {
       log.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+
+    if (result.status === "vault-needs-upgrade") {
+      log.error(
+        `Vault at ${result.vaultDir} uses the old flat layout. An existing member must run \`agentsync vault upgrade\` to migrate it before this machine can join.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    if (result.status === "unsupported-version") {
+      log.error(
+        `Vault uses format v${result.version}, newer than this agentsync. Run \`agentsync upgrade\` to update agentsync first.`,
+      );
       process.exitCode = 1;
       return;
     }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -127,6 +127,7 @@ export async function performInit(options: InitOptions): Promise<InitResult> {
   let git = new GitClient(runtime.vaultDir);
 
   let keyIsNew = false;
+  let pushAttempted = false;
   try {
     const { recipient, isNew } = await ensureKeypair(runtime.privateKeyPath);
     keyIsNew = isNew;
@@ -203,6 +204,7 @@ export async function performInit(options: InitOptions): Promise<InitResult> {
 
     const committed = await git.commit({ message: `init: ${runtime.machineName}` });
     if (committed) {
+      pushAttempted = true;
       await git.push("origin", options.branch, remoteState.exists ? [] : ["--set-upstream"]);
     }
 
@@ -218,8 +220,12 @@ export async function performInit(options: InitOptions): Promise<InitResult> {
   } catch (err) {
     // The remote probe passed but a later step failed. Roll back a key generated
     // this invocation so a retry is not bound to material that never made it into
-    // a successful init. A pre-existing key is preserved untouched.
-    const keyRolledBack = await rollbackFreshKey(keyIsNew, runtime.privateKeyPath);
+    // a successful init. A pre-existing key is preserved untouched. Do NOT roll
+    // back once a push was attempted: the commit (registering this machine's
+    // recipient) may already be local or pushed, and a retry must reuse this key.
+    const keyRolledBack = pushAttempted
+      ? false
+      : await rollbackFreshKey(keyIsNew, runtime.privateKeyPath);
     return {
       status: "failed",
       error: err instanceof Error ? err.message : String(err),

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,6 +1,7 @@
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
 import { type AgentDefinition, type AgentName, Agents } from "../agents/registry";
+import { machineVaultRoot } from "../config/paths";
 import { identityToRecipient } from "../core/encryptor";
 import { GitClient } from "../core/git";
 import { loadPrivateKey, loadVaultConfigOrExit, resolveRuntimeContext } from "./shared";
@@ -41,6 +42,10 @@ export async function performPull(
       force: options.dryRun ? false : options.force,
     });
 
+    // v2: restore only from THIS machine's namespace. Copying another machine's
+    // artifacts is the `copy` command's job, not pull's.
+    const machineRoot = machineVaultRoot(runtime.vaultDir, runtime.machineName);
+
     const requestedAgent = options.agent as AgentName | undefined;
     const agentsToSync = agentDefinitions.filter((a) => {
       if (requestedAgent) return a.name === requestedAgent;
@@ -49,7 +54,7 @@ export async function performPull(
 
     for (const agent of agentsToSync) {
       try {
-        await agent.apply(runtime.vaultDir, key, options.dryRun ?? false, config);
+        await agent.apply(machineRoot, key, options.dryRun ?? false, config);
         applied++;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -4,6 +4,7 @@ import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
 import { type AgentDefinition, type AgentName, Agents } from "../agents/registry";
 import { NEVER_SYNC_WARNING_PREFIX, WALKER_SECRET_WARNING_PREFIX } from "../agents/skills-walker";
+import { machineVaultRoot } from "../config/paths";
 import { encryptString } from "../core/encryptor";
 import { GitClient } from "../core/git";
 import { scanForSecrets, shouldNeverSync } from "../core/sanitizer";
@@ -81,6 +82,8 @@ export async function performPush(
 
   const runtime = await resolveRuntimeContext();
   const config = await loadVaultConfigOrExit(runtime.vaultDir);
+  // v2: every artifact lands under this machine's namespace, never the flat root.
+  const machineRoot = machineVaultRoot(runtime.vaultDir, runtime.machineName);
   const recipients = Object.values(config.recipients);
 
   if (recipients.length === 0) {
@@ -228,7 +231,7 @@ export async function performPush(
     }
 
     for (const artifact of snapshot.artifacts) {
-      const target = join(runtime.vaultDir, artifact.vaultPath);
+      const target = join(machineRoot, artifact.vaultPath);
 
       // Guard: never sync files matching global never-sync patterns. In
       // dry-run, the SKIP signal goes only through onPreview so the CLI

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -6,6 +6,7 @@ import {
   formatConfigError,
   isConfigParseError,
   loadConfig,
+  peekVaultVersion,
   resolveConfigPath,
 } from "../config/loader";
 import { resolveAgentSyncHome } from "../config/paths";
@@ -150,15 +151,41 @@ export async function loadPrivateKey(path: string): Promise<string> {
  */
 export async function loadVaultConfigOrExit(vaultDir: string): Promise<AgentSyncConfig> {
   const configPath = resolveConfigPath(vaultDir);
+
+  // Two-phase load: probe the raw version before the v2 schema runs so a v1
+  // vault routes to `vault upgrade` instead of failing with an opaque Zod type
+  // error, and a newer format tells the user to upgrade agentsync.
   try {
-    return await loadConfig(configPath);
-  } catch (err) {
-    if (isFileNotFoundError(err)) {
+    const probe = await peekVaultVersion(configPath);
+    if (probe.kind === "absent") {
       log.error(
         `Vault not initialized at ${vaultDir}. Run \`agentsync init --remote <git-url>\` first.`,
       );
       process.exit(1);
     }
+    if (probe.kind === "v1") {
+      log.error(
+        `Vault at ${vaultDir} uses the old flat layout. Run \`agentsync vault upgrade\` to migrate it to the per-machine format.`,
+      );
+      process.exit(1);
+    }
+    if (probe.kind === "unsupported") {
+      log.error(
+        `Vault at ${vaultDir} uses format v${probe.version}, newer than this agentsync. Run \`agentsync upgrade\` to update agentsync first.`,
+      );
+      process.exit(1);
+    }
+  } catch (err) {
+    // Malformed TOML surfaces here (peek parses too); format it the same way.
+    if (isConfigParseError(err)) {
+      throw new Error(formatConfigError(err, configPath));
+    }
+    throw err;
+  }
+
+  try {
+    return await loadConfig(configPath);
+  } catch (err) {
     if (isConfigParseError(err)) {
       throw new Error(formatConfigError(err, configPath));
     }

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -2,8 +2,14 @@ import { stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
+import { machineVaultRoot } from "../config/paths";
 import { GitClient } from "../core/git";
-import { loadVaultConfigOrExit, resolveRuntimeContext } from "./shared";
+import {
+  InvalidMachineNameError,
+  loadVaultConfigOrExit,
+  resolveRuntimeContext,
+  validateMachineName,
+} from "./shared";
 
 /**
  * Agents that participate in the skill sync feature. `vscode` is intentionally
@@ -20,6 +26,7 @@ function isSkillBearingAgent(value: string): value is SkillBearingAgent {
 export type SkillRemoveResult =
   | { status: "success"; path: string; commitSha: string | null }
   | { status: "unknown-agent"; provided: string; supported: readonly string[] }
+  | { status: "invalid-machine"; provided: string; reason: string }
   | { status: "not-found"; path: string }
   | { status: "reconcile-error"; error: string }
   | { status: "git-error"; path: string; error: string };
@@ -36,11 +43,13 @@ export type SkillRemoveResult =
  *
  * @param options.agent Name of the skill-bearing agent.
  * @param options.name  Basename of the skill in the vault (no `.tar.age` suffix).
+ * @param options.machine Namespace to remove from; defaults to this machine.
  * @returns A {@link SkillRemoveResult} describing the outcome.
  */
 export async function performSkillRemove(options: {
   agent: string;
   name: string;
+  machine?: string;
 }): Promise<SkillRemoveResult> {
   if (!isSkillBearingAgent(options.agent)) {
     return {
@@ -50,9 +59,31 @@ export async function performSkillRemove(options: {
     };
   }
 
+  // A user-supplied --machine becomes a vault directory segment, so it must
+  // pass the same path-traversal gate as the resolved machine name; otherwise
+  // `--machine ..` would escape the namespace and delete (and push) arbitrary
+  // vault paths. The resolved machineName is already validated upstream.
+  if (options.machine !== undefined) {
+    try {
+      validateMachineName(options.machine);
+    } catch (err) {
+      if (err instanceof InvalidMachineNameError) {
+        return { status: "invalid-machine", provided: err.provided, reason: err.reason };
+      }
+      throw err;
+    }
+  }
+
   const runtime = await resolveRuntimeContext();
   const config = await loadVaultConfigOrExit(runtime.vaultDir);
-  const targetPath = join(runtime.vaultDir, options.agent, "skills", `${options.name}.tar.age`);
+  // Default to this machine's namespace; --machine targets another machine's.
+  const targetMachine = options.machine ?? runtime.machineName;
+  const targetPath = join(
+    machineVaultRoot(runtime.vaultDir, targetMachine),
+    options.agent,
+    "skills",
+    `${options.name}.tar.age`,
+  );
 
   try {
     await stat(targetPath);
@@ -154,11 +185,16 @@ export const skillCommand = defineCommand({
           required: true,
           description: "Basename of the skill in the vault",
         },
+        machine: {
+          type: "string",
+          description: "Machine namespace to remove from (defaults to this machine)",
+        },
       },
       async run({ args }) {
         const result = await performSkillRemove({
           agent: String(args.agent),
           name: String(args.name),
+          machine: args.machine ? String(args.machine) : undefined,
         });
 
         switch (result.status) {
@@ -171,6 +207,11 @@ export const skillCommand = defineCommand({
             log.error(
               `Unknown agent: ${result.provided}. Supported: ${result.supported.join(", ")}`,
             );
+            process.exitCode = 1;
+            return;
+          }
+          case "invalid-machine": {
+            log.error(`Invalid --machine ${JSON.stringify(result.provided)}: ${result.reason}.`);
             process.exitCode = 1;
             return;
           }

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -194,7 +194,9 @@ export const skillCommand = defineCommand({
         const result = await performSkillRemove({
           agent: String(args.agent),
           name: String(args.name),
-          machine: args.machine ? String(args.machine) : undefined,
+          // Preserve an explicit --machine "" so it reaches validation (rejected)
+          // rather than being coerced to "use this machine".
+          machine: args.machine !== undefined ? String(args.machine) : undefined,
         });
 
         switch (result.status) {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,6 +7,7 @@ import { defineCommand } from "citty";
 import pc from "picocolors";
 import type { AgentDefinition, SnapshotArtifact } from "../agents/registry";
 import { Agents } from "../agents/registry";
+import { machineVaultRoot } from "../config/paths";
 import type { AgentSyncConfig } from "../config/schema";
 import { decryptString } from "../core/encryptor";
 import {
@@ -109,6 +110,8 @@ export async function computeSyncStatus(
   const registry = opts.agentsOverride ?? agentDefinitionsForStatus;
   const enabledAgents = registry.filter((a) => config.agents[a.name as keyof typeof config.agents]);
   const rows: SyncRow[] = [];
+  // v2: status compares local state against THIS machine's namespace only.
+  const machineRoot = machineVaultRoot(runtime.vaultDir, runtime.machineName);
 
   for (const agent of enabledAgents) {
     let artifacts: SnapshotArtifact[] = [];
@@ -132,7 +135,7 @@ export async function computeSyncStatus(
     }
 
     for (const artifact of artifacts) {
-      const vaultAbsPath = join(runtime.vaultDir, artifact.vaultPath);
+      const vaultAbsPath = join(machineRoot, artifact.vaultPath);
       const localHash = sha256(artifact.plaintext);
       const isSkill = artifact.vaultPath.endsWith(".tar.age");
       let vaultHash: string | null = null;
@@ -173,8 +176,8 @@ export async function computeSyncStatus(
   if (privateKey) {
     const knownVaultPaths = new Set(rows.map((r) => r.vaultPath));
     for (const agent of enabledAgents) {
-      const agentVaultDir = join(runtime.vaultDir, agent.name);
-      const ageFiles = await collectAgeFiles(agentVaultDir, runtime.vaultDir);
+      const agentVaultDir = join(machineRoot, agent.name);
+      const ageFiles = await collectAgeFiles(agentVaultDir, machineRoot);
       for (const vaultRelPath of ageFiles) {
         if (!knownVaultPaths.has(vaultRelPath)) {
           rows.push({
@@ -182,7 +185,7 @@ export async function computeSyncStatus(
             displayName: stripAgeExt(vaultRelPath),
             sourcePath: null,
             vaultPath: vaultRelPath,
-            vaultAbsPath: join(runtime.vaultDir, vaultRelPath),
+            vaultAbsPath: join(machineRoot, vaultRelPath),
             isSkill: vaultRelPath.endsWith(".tar.age"),
             status: "vault-only",
             detail: "not on this machine",

--- a/src/commands/tui/__tests__/sync-tab.test.ts
+++ b/src/commands/tui/__tests__/sync-tab.test.ts
@@ -520,12 +520,13 @@ describe("computeSyncStatus — structured output", () => {
     const { mkdtempSync, mkdirSync, writeFileSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
+    const { machineVaultRoot } = await import("../../../config/paths");
     const { computeSyncStatus, __setStatusAgentsForTesting } = await import("../../status");
 
     const tmp = mkdtempSync(join(tmpdir(), "sync-status-"));
     const vaultDir = join(tmp, "vault");
     // v2: status reads this machine's namespace (machineName "test" below).
-    const agentDir = join(vaultDir, "machines", "test", "test-agent");
+    const agentDir = join(machineVaultRoot(vaultDir, "test"), "test-agent");
     mkdirSync(agentDir, { recursive: true });
     writeFileSync(join(agentDir, "x.age"), "encrypted-bytes", "utf8");
 

--- a/src/commands/tui/__tests__/sync-tab.test.ts
+++ b/src/commands/tui/__tests__/sync-tab.test.ts
@@ -524,8 +524,10 @@ describe("computeSyncStatus — structured output", () => {
 
     const tmp = mkdtempSync(join(tmpdir(), "sync-status-"));
     const vaultDir = join(tmp, "vault");
-    mkdirSync(join(vaultDir, "test-agent"), { recursive: true });
-    writeFileSync(join(vaultDir, "test-agent", "x.age"), "encrypted-bytes", "utf8");
+    // v2: status reads this machine's namespace (machineName "test" below).
+    const agentDir = join(vaultDir, "machines", "test", "test-agent");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, "x.age"), "encrypted-bytes", "utf8");
 
     const fakeAgent = {
       name: "test-agent" as const,

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -66,11 +66,18 @@ export async function performVaultUpgrade(): Promise<VaultUpgradeResult> {
     return { status: "unsupported", version: initialProbe.version };
   }
 
-  const branch =
-    ((await readRawConfig(configPath)).remote as { branch?: string } | undefined)?.branch ?? "main";
   // The branch is read from the raw (pre-schema) config of a possibly shared
-  // vault and passed to git. simple-git uses argv (no shell), but a leading dash
-  // could still be read as a flag, so reject it before it reaches fetch/push.
+  // vault, so it is not yet type-narrowed and is passed to git. Reject a
+  // non-string, and a leading dash (simple-git uses argv, but a dash could still
+  // be read as a flag), before it reaches fetch/push.
+  const rawBranch = (await readRawConfig(configPath)).remote as { branch?: unknown } | undefined;
+  const branch = rawBranch?.branch ?? "main";
+  if (typeof branch !== "string") {
+    return {
+      status: "git-error",
+      error: "Invalid remote.branch in agentsync.toml: expected a string.",
+    };
+  }
   if (branch.startsWith("-")) {
     return { status: "git-error", error: `Refusing unsafe branch name: ${JSON.stringify(branch)}` };
   }

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -1,0 +1,182 @@
+import { mkdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { log } from "@clack/prompts";
+import { parse } from "@iarna/toml";
+import { defineCommand } from "citty";
+import { Agents } from "../agents/registry";
+import { peekVaultVersion, resolveConfigPath, writeConfig } from "../config/loader";
+import { machineVaultRoot } from "../config/paths";
+import { AgentSyncConfigSchema, CURRENT_VAULT_VERSION } from "../config/schema";
+import { GitClient } from "../core/git";
+import { resolveRuntimeContext } from "./shared";
+
+/** Discriminated result of a `vault upgrade` invocation (no throw / no exit). */
+export type VaultUpgradeResult =
+  | { status: "upgraded"; movedAgents: string[]; commitSha: string | null }
+  | { status: "already-v2" }
+  | { status: "not-initialized"; vaultDir: string }
+  | { status: "unsupported"; version: number }
+  | { status: "reconcile-error"; error: string }
+  | { status: "git-error"; error: string };
+
+/** Read and TOML-parse the raw vault config (pre-schema) for migration. */
+async function readRawConfig(configPath: string): Promise<Record<string, unknown>> {
+  const raw = await readFile(configPath, "utf8");
+  // structuredClone strips the Symbol metadata @iarna/toml attaches to tables,
+  // which otherwise trips Zod's record key walk (mirrors loader.ts:loadConfig).
+  return structuredClone(parse(raw)) as Record<string, unknown>;
+}
+
+/** True when `<vaultDir>/<name>` exists and is a directory. */
+async function isDir(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Short HEAD sha for the success line; null if git cannot be invoked (non-fatal). */
+function readHeadShortSha(repoDir: string): string | null {
+  const result = Bun.spawnSync(["git", "-C", repoDir, "rev-parse", "--short=7", "HEAD"]);
+  if (result.exitCode !== 0) return null;
+  const out = new TextDecoder().decode(result.stdout).trim();
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Migrate a flat v1 vault to the per-machine v2 layout: relocate every top-level
+ * agent directory under `machines/<thisMachine>/`, drop the down-sync schema
+ * fields, bump `version` to the integer 2, then commit and fast-forward push.
+ *
+ * Baked-in assumption: the existing flat content belongs to the machine running
+ * the upgrade (it is this machine's backup). Idempotent — a vault already at v2
+ * is a no-op. The relocation is a normal commit; history is preserved via
+ * `git mv` and the remote is never force-pushed.
+ */
+export async function performVaultUpgrade(): Promise<VaultUpgradeResult> {
+  const runtime = await resolveRuntimeContext();
+  const configPath = resolveConfigPath(runtime.vaultDir);
+
+  const initialProbe = await peekVaultVersion(configPath);
+  if (initialProbe.kind === "absent") {
+    return { status: "not-initialized", vaultDir: runtime.vaultDir };
+  }
+  if (initialProbe.kind === "unsupported") {
+    return { status: "unsupported", version: initialProbe.version };
+  }
+
+  const branch =
+    ((await readRawConfig(configPath)).remote as { branch?: string } | undefined)?.branch ?? "main";
+  // The branch is read from the raw (pre-schema) config of a possibly shared
+  // vault and passed to git. simple-git uses argv (no shell), but a leading dash
+  // could still be read as a flag, so reject it before it reaches fetch/push.
+  if (branch.startsWith("-")) {
+    return { status: "git-error", error: `Refusing unsafe branch name: ${JSON.stringify(branch)}` };
+  }
+
+  const git = new GitClient(runtime.vaultDir);
+  try {
+    // Reconcile first: another machine may have already upgraded and pushed v2,
+    // in which case the fast-forward brings it down and the re-probe below sees v2.
+    await git.reconcileWithRemote({ remote: "origin", branch, allowMissingRemote: true });
+  } catch (err) {
+    return { status: "reconcile-error", error: err instanceof Error ? err.message : String(err) };
+  }
+
+  const probe = await peekVaultVersion(configPath);
+  if (probe.kind === "v2") return { status: "already-v2" };
+  if (probe.kind === "unsupported") return { status: "unsupported", version: probe.version };
+
+  try {
+    const machineRoot = machineVaultRoot(runtime.vaultDir, runtime.machineName);
+    await mkdir(machineRoot, { recursive: true });
+
+    // Relocate each top-level agent dir into this machine's namespace. The
+    // config and .gitignore stay at the vault root (vault-global).
+    const movedAgents: string[] = [];
+    for (const agent of Agents) {
+      if (await isDir(join(runtime.vaultDir, agent.name))) {
+        await git.move(agent.name, join("machines", runtime.machineName, agent.name));
+        movedAgents.push(agent.name);
+      }
+    }
+
+    // Rewrite the config to v2: integer version, no down-sync fields. Validate
+    // through the v2 schema so a malformed legacy file fails loudly here.
+    const raw = await readRawConfig(configPath);
+    const sync = (raw.sync ?? {}) as Record<string, unknown>;
+    delete sync.autoPull;
+    delete sync.pullIntervalMs;
+    const v2Config = AgentSyncConfigSchema.parse({ ...raw, version: CURRENT_VAULT_VERSION, sync });
+    await writeConfig(configPath, v2Config);
+
+    const committed = await git.commit({
+      message: `vault upgrade: migrate to per-machine layout v2 (${runtime.machineName})`,
+    });
+    if (committed) {
+      await git.push("origin", branch);
+    }
+    return {
+      status: "upgraded",
+      movedAgents,
+      commitSha: committed ? readHeadShortSha(runtime.vaultDir) : null,
+    };
+  } catch (err) {
+    return { status: "git-error", error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Thin citty wrapper: translates the result into log output and exit code. */
+export const vaultCommand = defineCommand({
+  meta: {
+    name: "vault",
+    description: "Manage the vault format",
+  },
+  subCommands: {
+    upgrade: defineCommand({
+      meta: {
+        name: "upgrade",
+        description:
+          "Migrate a flat (v1) vault to the per-machine layout. Assumes the existing flat content belongs to this machine.",
+      },
+      async run() {
+        const result = await performVaultUpgrade();
+        switch (result.status) {
+          case "upgraded": {
+            const moved =
+              result.movedAgents.length > 0
+                ? result.movedAgents.join(", ")
+                : "no agent directories";
+            const shaFragment = result.commitSha ? ` (commit ${result.commitSha})` : "";
+            log.success(`Upgraded vault to v2 — relocated ${moved} under machines/${shaFragment}`);
+            return;
+          }
+          case "already-v2":
+            log.info("Vault is already at format v2. Nothing to do.");
+            return;
+          case "not-initialized":
+            log.error(
+              `Vault not initialized at ${result.vaultDir}. Run \`agentsync init --remote <git-url>\` first.`,
+            );
+            process.exitCode = 1;
+            return;
+          case "unsupported":
+            log.error(
+              `Vault uses format v${result.version}, newer than this agentsync. Run \`agentsync upgrade\` to update agentsync first.`,
+            );
+            process.exitCode = 1;
+            return;
+          case "reconcile-error":
+            log.error(result.error);
+            process.exitCode = 1;
+            return;
+          case "git-error":
+            log.error(`Upgrade staged but not completed: ${result.error}`);
+            process.exitCode = 1;
+            return;
+        }
+      },
+    }),
+  },
+});

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -8,10 +8,11 @@ import {
   formatConfigError,
   isConfigParseError,
   loadConfig,
+  peekVaultVersion,
   resolveConfigPath,
   writeConfig,
 } from "../loader";
-import { AgentSyncConfigSchema } from "../schema";
+import { AgentSyncConfigSchema, CURRENT_VAULT_VERSION } from "../schema";
 
 // Defensive re-install of the real node:fs/promises — see migrate.test.ts
 // for the full explanation of the bleed this guards against.
@@ -22,7 +23,7 @@ import { AgentSyncConfigSchema } from "../schema";
 }
 
 const MINIMAL_TOML = `
-version = "1"
+version = 2
 
 [recipients]
 alice = "age1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs8xmq8"
@@ -41,8 +42,6 @@ branch = "main"
 [sync]
 debounceMs = 300
 autoPush = true
-autoPull = true
-pullIntervalMs = 300000
 `;
 
 describe("loader", () => {
@@ -63,7 +62,7 @@ describe("loader", () => {
   test("loadConfig parses a valid TOML file", async () => {
     await writeFile(configPath, MINIMAL_TOML, "utf8");
     const config = await loadConfig(configPath);
-    expect(config.version).toBe("1");
+    expect(config.version).toBe(2);
     expect(config.remote.url).toBe("git@github.com:alice/vault.git");
     expect(config.agents.cursor).toBeTrue();
     expect(config.agents.vscode).toBeFalse();
@@ -103,7 +102,7 @@ describe("loader", () => {
     // The temp file must have been renamed over the destination, not left behind.
     const leftovers = (await readdir(tmpDir)).filter((f) => f.endsWith(".tmp"));
     expect(leftovers).toEqual([]);
-    expect((await loadConfig(configPath)).version).toBe("1");
+    expect((await loadConfig(configPath)).version).toBe(2);
   });
 
   test("writeConfig preserves the destination and removes the temp when rename fails", async () => {
@@ -126,7 +125,38 @@ describe("loader", () => {
     const config = await loadConfig(configPath);
     await expect(writeConfig(nestedPath, config)).resolves.toBeUndefined();
     const reloaded = await loadConfig(nestedPath);
-    expect(reloaded.version).toBe("1");
+    expect(reloaded.version).toBe(2);
+  });
+
+  // peekVaultVersion — the two-phase load probe (routes v1 to `vault upgrade`)
+
+  test("peekVaultVersion reports absent for a missing config file", async () => {
+    expect(await peekVaultVersion(join(tmpDir, "nope.toml"))).toEqual({ kind: "absent" });
+  });
+
+  test("peekVaultVersion reports v2 for the integer version 2", async () => {
+    await writeFile(configPath, 'version = 2\n[remote]\nurl = "x"\n', "utf8");
+    expect(await peekVaultVersion(configPath)).toEqual({ kind: "v2" });
+  });
+
+  test("peekVaultVersion reports v1 for a string version (the legacy flat layout)", async () => {
+    await writeFile(configPath, 'version = "1"\n[remote]\nurl = "x"\n', "utf8");
+    expect(await peekVaultVersion(configPath)).toEqual({ kind: "v1" });
+  });
+
+  test("peekVaultVersion reports v1 when the version field is absent", async () => {
+    await writeFile(configPath, '[remote]\nurl = "x"\n', "utf8");
+    expect(await peekVaultVersion(configPath)).toEqual({ kind: "v1" });
+  });
+
+  test("peekVaultVersion reports unsupported for an integer above the current version", async () => {
+    await writeFile(configPath, 'version = 3\n[remote]\nurl = "x"\n', "utf8");
+    expect(await peekVaultVersion(configPath)).toEqual({ kind: "unsupported", version: 3 });
+  });
+
+  test("peekVaultVersion propagates a TOML parse error", async () => {
+    await writeFile(configPath, "this is = not [ valid toml", "utf8");
+    await expect(peekVaultVersion(configPath)).rejects.toThrow();
   });
 
   // resolveConfigPath
@@ -144,10 +174,11 @@ describe("formatConfigError", () => {
   // produces a single isolated issue, independent of Zod's issue ordering or
   // formatConfigError's 3-issue cap.
   const validBase = {
+    version: CURRENT_VAULT_VERSION,
     recipients: { me: "age1qpzry9x8gf2tvdw0s3jn54khce6mua7l" },
     agents: { cursor: true, claude: true, codex: true, copilot: true, vscode: false },
     remote: { url: "git@github.com:user/vault.git", branch: "main" },
-    sync: { debounceMs: 300, autoPush: true, autoPull: true, pullIntervalMs: 300_000 },
+    sync: { debounceMs: 300, autoPush: true },
   };
 
   test("names the offending recipient alias for a schema (Zod) error", () => {

--- a/src/config/__tests__/schema.test.ts
+++ b/src/config/__tests__/schema.test.ts
@@ -7,7 +7,7 @@ import { AgentSyncConfigSchema, AgePublicKeySchema } from "../schema";
 const VALID_RECIPIENT = "age1qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 
 const VALID_BASE = {
-  version: "1",
+  version: 2,
   recipients: { local: VALID_RECIPIENT },
   agents: {
     cursor: true,
@@ -20,8 +20,6 @@ const VALID_BASE = {
   sync: {
     debounceMs: 300,
     autoPush: true,
-    autoPull: true,
-    pullIntervalMs: 300_000,
   },
 } as const;
 
@@ -120,8 +118,6 @@ describe("AgentSyncConfigSchema", () => {
       sync: {
         debounceMs: 10,
         autoPush: true,
-        autoPull: true,
-        pullIntervalMs: 300_000,
       },
     });
     expect(result.success).toBe(false);
@@ -133,8 +129,6 @@ describe("AgentSyncConfigSchema", () => {
       sync: {
         debounceMs: 99_999,
         autoPush: true,
-        autoPull: true,
-        pullIntervalMs: 300_000,
       },
     });
     expect(result.success).toBe(false);
@@ -159,15 +153,21 @@ describe("AgentSyncConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  test("version field accepts any string", () => {
-    const parsed = AgentSyncConfigSchema.parse({ ...VALID_BASE, version: "2" });
-    expect(parsed.version).toBe("2");
+  test("version must be the integer 2 (the v2 format)", () => {
+    const parsed = AgentSyncConfigSchema.parse(VALID_BASE);
+    expect(parsed.version).toBe(2);
   });
 
-  test("defaults version to '1' when omitted", () => {
+  test("rejects a string version — the old-binary block", () => {
+    // v1 wrote `version` as a string; the v2 schema must reject it so a v1
+    // vault never loads under v2 (and vice versa) without going through upgrade.
+    expect(AgentSyncConfigSchema.safeParse({ ...VALID_BASE, version: "2" }).success).toBe(false);
+    expect(AgentSyncConfigSchema.safeParse({ ...VALID_BASE, version: "1" }).success).toBe(false);
+  });
+
+  test("rejects a missing version", () => {
     const { version: _v, ...withoutVersion } = VALID_BASE;
-    const parsed = AgentSyncConfigSchema.parse(withoutVersion);
-    expect(parsed.version).toBe("1");
+    expect(AgentSyncConfigSchema.safeParse(withoutVersion).success).toBe(false);
   });
 });
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3,7 +3,7 @@ import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { parse, stringify } from "@iarna/toml";
 import { z } from "zod";
-import { type AgentSyncConfig, AgentSyncConfigSchema } from "./schema";
+import { type AgentSyncConfig, AgentSyncConfigSchema, CURRENT_VAULT_VERSION } from "./schema";
 
 /** Read and validate the vault config, stripping TOML symbol metadata before Zod parsing. */
 export async function loadConfig(configPath: string): Promise<AgentSyncConfig> {
@@ -13,6 +13,40 @@ export async function loadConfig(configPath: string): Promise<AgentSyncConfig> {
   // Zod v4 z.record() uses Reflect.ownKeys() which includes Symbol keys, causing
   // ZodError 'invalid_key'. structuredClone() strips Symbol-keyed properties.
   return AgentSyncConfigSchema.parse(structuredClone(parsed));
+}
+
+/** Result of probing a vault's format version before the v2 Zod schema runs. */
+export type VaultVersionProbe =
+  | { kind: "absent" }
+  | { kind: "v1" }
+  | { kind: "v2" }
+  | { kind: "unsupported"; version: number };
+
+/**
+ * Read the vault format version WITHOUT the v2 schema so commands can route a v1
+ * vault to `vault upgrade` instead of failing with an opaque Zod type error. v1
+ * wrote `version` as a string ("1") or omitted it; v2 writes the integer 2. A
+ * missing config file is `absent` (fresh init). A non-integer, missing, or <2
+ * version is legacy (`v1`); an integer >2 is a newer format this binary cannot
+ * read. A malformed TOML file throws (a TomlError) so callers format it the same
+ * way loadConfig does.
+ */
+export async function peekVaultVersion(configPath: string): Promise<VaultVersionProbe> {
+  let raw: string;
+  try {
+    raw = await readFile(configPath, "utf8");
+  } catch (err) {
+    if (err instanceof Error && (err as { code?: string }).code === "ENOENT") {
+      return { kind: "absent" };
+    }
+    throw err;
+  }
+  const version = (parse(raw) as { version?: unknown }).version;
+  if (typeof version === "number" && Number.isInteger(version)) {
+    if (version === CURRENT_VAULT_VERSION) return { kind: "v2" };
+    if (version > CURRENT_VAULT_VERSION) return { kind: "unsupported", version };
+  }
+  return { kind: "v1" };
 }
 
 /**

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -6,6 +6,17 @@ const HOME = homedir();
 const PLATFORM = process.platform;
 
 /**
+ * Root of one machine's namespace inside the vault: `<vaultDir>/machines/<name>`.
+ * Vault format v2 stores every artifact under this prefix so each machine backs
+ * up into its own directory and never overwrites another's. The single
+ * chokepoint for the per-machine layout — push writes here, and pull/status read
+ * from here by passing this as the "vault dir" to the apply/scan layer.
+ */
+export function machineVaultRoot(vaultDir: string, machineName: string): string {
+  return join(vaultDir, "machines", machineName);
+}
+
+/**
  * Resolve the Windows %APPDATA% base (= %USERPROFILE%\AppData\Roaming).
  *
  * nonBlank collapses an exported-but-empty APPDATA to undefined so the result

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -30,9 +30,17 @@ const RemoteUrlSchema = z
     message: "remote.url does not look like a git URL (expected ':' or '/')",
   });
 
+/**
+ * Current vault format. v2 lays the vault out as `machines/<name>/<agent>/…`
+ * and writes `version` as an INTEGER. This is the old-binary hard block: a v1
+ * binary's `version: z.string()` schema throws on the integer, so it can never
+ * load a v2 vault and write flat dirs beside `machines/`.
+ */
+export const CURRENT_VAULT_VERSION = 2;
+
 /** Schema for the vault configuration file shared by every command and test. */
 export const AgentSyncConfigSchema = z.object({
-  version: z.string().default("1"),
+  version: z.literal(CURRENT_VAULT_VERSION),
   recipients: z
     .record(z.string().min(1), AgePublicKeySchema)
     .refine((r) => Object.keys(r).length > 0, {
@@ -52,8 +60,6 @@ export const AgentSyncConfigSchema = z.object({
   sync: z.object({
     debounceMs: z.number().int().min(50).max(10_000).default(300),
     autoPush: z.boolean().default(true),
-    autoPull: z.boolean().default(true),
-    pullIntervalMs: z.number().int().min(1_000).default(300_000),
   }),
   // Per-agent plugin opt-ins (issue #31). Optional with safe defaults so
   // existing agentsync.toml files continue to validate without changes.

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -360,6 +360,11 @@ export class GitClient {
     await this.git.push(remote, branch, options);
   }
 
+  /** Move a tracked path with `git mv` so the file history is preserved across the rename. */
+  async move(from: string, to: string): Promise<void> {
+    await this.git.raw(["mv", from, to]);
+  }
+
   /** Return the checked-out local branch name for this repository. */
   async currentBranch(): Promise<string> {
     const branch = await this.git.branchLocal();

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -41,9 +41,8 @@ const watcherAdds: Array<{
 let listenedSocketPath = "";
 let watcherClosed = false;
 let ipcClosed = false;
-let scheduledIntervalMs = 0;
+// Captured to assert the push-only daemon arms NO periodic pull (stays null).
 let scheduledIntervalCallback: null | (() => Promise<void>) = null;
-let clearedIntervalToken: unknown = null;
 let exitCode: number | null = null;
 
 const originalSetInterval = globalThis.setInterval;
@@ -106,15 +105,12 @@ beforeAll(async () => {
     watcherClosed = true;
   });
 
-  globalThis.setInterval = ((callback: TimerHandler, delay?: number) => {
+  globalThis.setInterval = ((callback: TimerHandler) => {
     scheduledIntervalCallback = callback as () => Promise<void>;
-    scheduledIntervalMs = delay ?? 0;
     return "daemon-interval" as unknown as ReturnType<typeof setInterval>;
   }) as unknown as typeof setInterval;
 
-  globalThis.clearInterval = ((token?: unknown) => {
-    clearedIntervalToken = token ?? null;
-  }) as typeof clearInterval;
+  globalThis.clearInterval = (() => {}) as typeof clearInterval;
 
   process.on = ((event: NodeJS.Signals, listener: () => Promise<void>) => {
     signalHandlers.set(String(event), listener);
@@ -175,7 +171,7 @@ beforeEach(async () => {
   await writeFile(
     join(vaultDir, "agentsync.toml"),
     [
-      'version = "1"',
+      "version = 2",
       "[recipients]",
       `daemon = "${recipient}"`,
       "[agents]",
@@ -190,8 +186,6 @@ beforeEach(async () => {
       "[sync]",
       "debounceMs = 300",
       "autoPush = true",
-      "autoPull = true",
-      "pullIntervalMs = 12345",
       "",
     ].join("\n"),
     "utf8",
@@ -215,9 +209,7 @@ beforeEach(async () => {
   listenedSocketPath = "";
   watcherClosed = false;
   ipcClosed = false;
-  scheduledIntervalMs = 0;
   scheduledIntervalCallback = null;
-  clearedIntervalToken = null;
   exitCode = null;
 
   // Reset to default: clean start (no existing socket)
@@ -231,7 +223,7 @@ afterEach(async () => {
 });
 
 describe("startDaemon", () => {
-  test("registers IPC handlers, watcher targets, and the pull interval from config", async () => {
+  test("registers IPC handlers and watcher targets, and schedules no auto-pull timer", async () => {
     await daemonModule.startDaemon();
 
     expect(listenedSocketPath).toBe(resolveDaemonSocketPath());
@@ -246,7 +238,8 @@ describe("startDaemon", () => {
       AgentPaths.copilot.instructionsDir,
     ]);
     expect(watcherAdds.every((entry) => entry.debounceMs === 2000)).toBe(true);
-    expect(scheduledIntervalMs).toBe(12_345);
+    // v2: the vault is push-only backup, so the daemon arms no periodic pull.
+    expect(scheduledIntervalCallback).toBeNull();
     expect(signalHandlers.has("SIGTERM")).toBe(true);
     expect(signalHandlers.has("SIGINT")).toBe(true);
   });
@@ -257,13 +250,11 @@ describe("startDaemon", () => {
     await ipcHandlers.get("pull")?.();
     await ipcHandlers.get("push")?.();
     await watcherAdds[0]?.callback(watcherAdds[0].target);
-    await scheduledIntervalCallback?.();
     await signalHandlers.get("SIGTERM")?.();
 
     expect(errorLogs.length).toBeGreaterThan(0);
     expect(errorLogs.some((message) => message.includes("fatal:"))).toBe(true);
     expect(watcherClosed).toBe(true);
-    expect(clearedIntervalToken).toBe("daemon-interval");
     expect(exitCode).toBe(0);
   });
 });
@@ -306,14 +297,12 @@ describe("clean shutdown", () => {
 
     expect(exitCode).toBe(0);
     expect(watcherClosed).toBe(true);
-    expect(clearedIntervalToken).toBe("daemon-interval");
   });
 
-  test("shutdown sequence: clearInterval → ipc.close → watcher.close → exit(0)", async () => {
+  test("shutdown sequence: ipc.close → watcher.close → exit(0)", async () => {
     await daemonModule.startDaemon();
     await signalHandlers.get("SIGTERM")?.();
 
-    expect(clearedIntervalToken).toBe("daemon-interval");
     expect(ipcClosed).toBe(true);
     expect(watcherClosed).toBe(true);
     expect(exitCode).toBe(0);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -106,8 +106,6 @@ export async function startDaemon(): Promise<void> {
     // ENOENT = no socket file, clean start — continue
   }
 
-  const pullIntervalMs = config.sync.pullIntervalMs ?? 5 * 60 * 1000;
-
   // ── SyncQueue ──────────────────────────────────────────────────────
   const queue = new SyncQueue();
 
@@ -201,33 +199,12 @@ export async function startDaemon(): Promise<void> {
     });
   }
 
-  // Periodic pull using interval from config
-  const pullTimer = setInterval(async () => {
-    await queue
-      .enqueue(async () => {
-        try {
-          const result = await withRetry(() => performPull());
-          if (result.fatal) {
-            for (const err of result.errors) {
-              log.error(`${ts()} ${err}`);
-            }
-            recordFailure("pull", result.errors.join("; "));
-          } else {
-            recordSuccess();
-          }
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          recordFailure("pull", msg);
-        }
-      })
-      .catch(() => {
-        // Queue closed during shutdown — safe to ignore
-      });
-  }, pullIntervalMs);
+  // No periodic pull: the vault is push-only backup. Each machine's local
+  // config is its own source of truth, so the daemon only auto-pushes on change.
+  // A manual pull remains available over IPC.
 
   // ── Graceful shutdown ──────────────────────────────────────────────
   const shutdown = async () => {
-    clearInterval(pullTimer);
     ipc.close();
     queue.close();
     // Drain in-flight sync operations with a hard timeout

--- a/src/test-helpers/fixtures.ts
+++ b/src/test-helpers/fixtures.ts
@@ -7,7 +7,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { stringify as tomlStringify } from "@iarna/toml";
-import type { AgentSyncConfig } from "../config/schema";
+import { type AgentSyncConfig, CURRENT_VAULT_VERSION } from "../config/schema";
 import { generateIdentity, identityToRecipient } from "../core/encryptor";
 
 /**
@@ -22,11 +22,11 @@ export function createTestAgentSyncConfig(
   overrides: Partial<AgentSyncConfig> = {},
 ): AgentSyncConfig {
   return {
-    version: "1",
+    version: CURRENT_VAULT_VERSION,
     recipients: {},
     agents: { cursor: true, claude: true, codex: true, copilot: true, vscode: true },
     remote: { url: "test://vault", branch: "main" },
-    sync: { debounceMs: 300, autoPush: true, autoPull: true, pullIntervalMs: 300_000 },
+    sync: { debounceMs: 300, autoPush: true },
     claudePlugins: { syncMarketplace: false },
     ...overrides,
   };
@@ -43,8 +43,6 @@ const DEFAULT_AGENTS = {
 const DEFAULT_SYNC = {
   debounceMs: 300,
   autoPush: true,
-  autoPull: true,
-  pullIntervalMs: 300_000,
 };
 
 /** Runtime fixture paths and key material for one logical machine. */
@@ -152,7 +150,7 @@ export function seedVaultRepo(options: {
   const { machine, bareRepoPath } = options;
   const branch = options.branch ?? "main";
   const configData = {
-    version: "1",
+    version: CURRENT_VAULT_VERSION,
     recipients: options.recipients ?? { [machine.machineName]: machine.recipient },
     agents: {
       ...DEFAULT_AGENTS,


### PR DESCRIPTION
## Summary

Implements the v2 vault format pivot (epic #161). Closes #156.

Every command now writes and reads agent snapshots under a per-machine namespace (`machines/<name>/`) inside the vault, enforced by a single `machineVaultRoot()` chokepoint. A new integer `version: 2` schema field lets a v1 binary fail fast with a clear upgrade prompt, and the new `agentsync vault upgrade` command migrates a v1 flat layout in-place via `git mv` (history preserved) without ever force-pushing.

## Changes

### Config / schema (`src/config/`)

- `version` changed from `z.string()` to `z.literal(2)` (`CURRENT_VAULT_VERSION = 2`). A v1 binary throws on the integer — the intentional old-binary hard block.
- Added `peekVaultVersion(configPath)` — reads raw TOML before Zod, returns `v1` (string/absent) / `v2` (int 2) / `unsupported` (>2) / `absent`.
- `loadVaultConfigOrExit` probes version first; a v1 or unsupported vault stops every command with a "run `agentsync vault upgrade`" diagnostic.
- New `machineVaultRoot(vaultDir, machineName)` = `<vaultDir>/machines/<name>` in `src/config/paths.ts` — the single path chokepoint.
- `sync.autoPull` and `sync.pullIntervalMs` removed from the v2 schema (daemon is push-only now).

### Commands

- **push**: writes snapshots under `machines/<self>/`.
- **pull / status**: scope their vault dir to `machines/<self>/` via `machineVaultRoot` and pass it to the transparent apply/scan layer (no adapter signature change).
- **skill remove**: gains a `--machine` flag; the value is validated through `validateMachineName` before any vault path is constructed (closes a path traversal where `--machine ..` could delete + push arbitrary vault paths).
- **key add / rotate**: unchanged — the existing recursive `findAgeFiles` already covers `machines/**/`.
- **init**: refuses to join a v1 or unsupported vault (so it never re-creates a fresh v2 config that would silently drop other machines' recipients), and rolls back a freshly generated key on refusal.
- **vault** (new): parent command with an `upgrade` subcommand → `performVaultUpgrade()`.
- **daemon**: auto-pull timer removed; push-only. Auto-pull tests reworked.

### `vault upgrade` (`src/commands/vault.ts`)

- Reconciles fast-forward-only, then `git mv`s each top-level agent dir into `machines/<self>/` (preserving `--follow` history).
- Drops `autoPull`/`pullIntervalMs`, writes `version = 2`, commits, fast-forward pushes. Never force-pushes.
- Idempotent on a v2 vault (clear no-op). Rejects a leading-dash `branch` read from raw vault config before it reaches git.

### Docs

- `docs/architecture.md`: layout diagram now shows the `machines/<name>/` structure; the version paragraph describes the integer guard + two-phase load + `vault upgrade`.
- `docs/commands.md` and `docs/operations.md`: daemon is push-only (no periodic pull); sync config no longer lists `autoPull`/`pullIntervalMs`.

## Layout

```mermaid
graph TD
  VD["vault repo root"]:::unchanged
  VD --> AG["agentsync.toml<br/>version = 2"]:::new
  VD --> MC["machines/"]:::new
  MC --> M1["machines/laptop/"]:::new
  MC --> M2["machines/workstation/"]:::new
  M1 --> A1["claude/ cursor/ codex/ ..."]:::new
  CMD["push / pull / status / skill remove"]:::unchanged --> MR["machineVaultRoot<br/>vaultDir + machines + name"]:::new
  MR --> M1
  VU["vault upgrade"]:::new --> GV["git mv agent to machines/self/agent<br/>version 1 to 2<br/>ff push, no force"]:::new
  classDef new fill:#27ae60,color:#ffffff
  classDef unchanged fill:#2c3e50,color:#ffffff
```

**Before (v1):** agent dirs lived at the vault root (`<vault>/claude/`, `<vault>/cursor/`, …); `version` was a string; no machine isolation.
**After (v2):** all agent dirs live under `machines/<name>/`; `version` is the integer `2`; `machineVaultRoot()` is the single chokepoint for push, pull, status, and skill remove.

## Test plan

- `peekVaultVersion`: v1 string / v2 integer / unsupported integer / absent / malformed-TOML.
- `vault upgrade`: real `git mv` + `--follow` history check + fast-forward push; idempotency on v2; multi-machine namespace isolation (two machines, no cross-contamination).
- `loadVaultConfigOrExit`: v1 and unsupported vaults halt with the actionable hint.
- Schema: rejects a string / `"1"` / missing `version`.
- `init`: fresh init produces `version = 2`; rolls back the generated key on a v1/unsupported join.
- `skill remove --machine`: rejects `..`, `../../etc`, `a/b` via `validateMachineName`.
- All push / status / skill / integration fixtures moved to `machines/<name>/`.
- Full suite: 0 failing markers; daemon auto-pull tests reworked for the push-only model.

## Risks / follow-ups

- `pull` remains but is machine-scoped; restore-path and TUI removal are #157.
- Plugin manifest + reinstall: #159. Full public docs sweep: #160. Multi-machine `copy`: #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `vault upgrade` command to migrate vaults to new per-machine layout.
  * Added `--machine` flag to skill remove for cross-machine operations.
  * CLI now supports vault management commands.

* **Bug Fixes**
  * Daemon now operates as push-only; removed periodic auto-pull behavior.

* **Documentation**
  * Updated architecture, commands, and operations guides for v2 vault format and push-only daemon.

* **Tests**
  * Updated test fixtures and integration tests for v2 vault layout and new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->