### PR TITLE
feat(tui): add Machines tab to browse namespaces and copy

### DIFF
--- a/src/commands/copy.ts
+++ b/src/commands/copy.ts
@@ -19,7 +19,7 @@ export type CopyResult =
   | { status: "error"; error: string };
 
 /** List the machine namespace directories under `<vaultDir>/machines/`. */
-async function listMachines(vaultDir: string): Promise<string[]> {
+export async function listMachines(vaultDir: string): Promise<string[]> {
   try {
     const entries = await readdir(join(vaultDir, "machines"), { withFileTypes: true });
     return entries

--- a/src/commands/tui/__tests__/machines.test.ts
+++ b/src/commands/tui/__tests__/machines.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import type { KeyEvent } from "@opentui/core";
+import {
+  createBareRepo,
+  createMachineFixture,
+  createTmpDir,
+  seedVaultRepo,
+  type TestMachineFixture,
+} from "../../../test-helpers/fixtures";
+import { createInitialState } from "../state";
+import { createStore } from "../store";
+import { ensureMachinesLoaded, onMachinesKey } from "../tabs/machines";
+
+function key(name: string): KeyEvent {
+  return { name, sequence: name, ctrl: false, meta: false, shift: false } as unknown as KeyEvent;
+}
+
+function readyStore(list: string[], cursor = 0) {
+  const store = createStore(createInitialState());
+  store.dispatch((d) => {
+    d.activeTab = "machines";
+    d.machines.phase = "ready";
+    d.machines.list = list;
+    d.machines.cursor = cursor;
+  });
+  return store;
+}
+
+describe("onMachinesKey — navigation", () => {
+  test("down/up move the cursor within bounds", () => {
+    const store = readyStore(["a", "b", "c"]);
+    expect(onMachinesKey(key("down"), store)).toBe(true);
+    expect(store.getState().machines.cursor).toBe(1);
+    onMachinesKey(key("down"), store);
+    onMachinesKey(key("down"), store); // clamps at last
+    expect(store.getState().machines.cursor).toBe(2);
+    onMachinesKey(key("up"), store);
+    expect(store.getState().machines.cursor).toBe(1);
+  });
+
+  test("keys are ignored until the list is ready and non-empty", () => {
+    const idle = createStore(createInitialState());
+    expect(onMachinesKey(key("down"), idle)).toBe(false);
+    const empty = readyStore([]);
+    expect(onMachinesKey(key("down"), empty)).toBe(false);
+  });
+});
+
+describe("ensureMachinesLoaded", () => {
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  const savedEnv: Record<string, string | undefined> = {};
+  const KEYS = [
+    "AGENTSYNC_VAULT_DIR",
+    "AGENTSYNC_KEY_PATH",
+    "AGENTSYNC_MACHINE",
+    "AGENTSYNC_MACHINE_FILE",
+  ];
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    const bare = await createBareRepo(tmpDir);
+    machine = await createMachineFixture(tmpDir, "host-self");
+    seedVaultRepo({ machine, bareRepoPath: bare });
+    // Seed two machine namespaces in the vault.
+    await mkdir(join(machine.vaultDir, "machines", "host-a"), { recursive: true });
+    await mkdir(join(machine.vaultDir, "machines", "host-b"), { recursive: true });
+    for (const k of KEYS) savedEnv[k] = process.env[k];
+    process.env.AGENTSYNC_VAULT_DIR = machine.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = machine.keyPath;
+    process.env.AGENTSYNC_MACHINE = machine.machineName;
+    process.env.AGENTSYNC_MACHINE_FILE = machine.machineFilePath;
+  });
+
+  afterEach(async () => {
+    for (const k of KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("lists the vault machine namespaces and flips phase to ready", async () => {
+    const store = createStore(createInitialState());
+    ensureMachinesLoaded(store);
+    // The load runs through runOperation; wait for it to settle.
+    for (let i = 0; i < 50 && store.getState().machines.phase === "loading"; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const m = store.getState().machines;
+    expect(m.phase).toBe("ready");
+    expect(m.list).toEqual(["host-a", "host-b"]);
+  });
+
+  test("is idempotent — a second call while ready does not reload", () => {
+    const store = readyStore(["x"]);
+    ensureMachinesLoaded(store);
+    // Still the directly-seeded list; no load was kicked off.
+    expect(store.getState().machines.list).toEqual(["x"]);
+  });
+
+  test("enter copies the selected machine via performCopy and records lastCopy", async () => {
+    // host-a's namespace exists but is empty, so every per-agent performCopy
+    // returns not-found and is skipped — exercising the copy loop + onSuccess
+    // accumulation without writing to local agent paths.
+    const store = readyStore(["host-a"]);
+    expect(onMachinesKey(key("return"), store)).toBe(true);
+    for (let i = 0; i < 50 && store.getState().machines.lastCopy === null; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const last = store.getState().machines.lastCopy;
+    expect(last?.machine).toBe("host-a");
+    expect(last?.ok).toBe(true);
+    expect(last?.message).toContain("0 artifact");
+  });
+});

--- a/src/commands/tui/app.ts
+++ b/src/commands/tui/app.ts
@@ -17,6 +17,7 @@ import {
 import { createStore, type Store } from "./store";
 import { renderActivity } from "./tabs/activity";
 import { renderDashboard } from "./tabs/dashboard";
+import { ensureMachinesLoaded, onMachinesKey, renderMachines } from "./tabs/machines";
 import { onMigrateKey, renderMigrate } from "./tabs/migrate";
 import { ensureSyncLoaded, onSyncKey, renderSync, runSyncOp } from "./tabs/sync";
 
@@ -25,6 +26,7 @@ const POLL_INTERVAL_MS = 1500;
 const TAB_LABELS: Record<TabId, string> = {
   dashboard: "Dashboard",
   sync: "Sync",
+  machines: "Machines",
   migrate: "Migrate",
   activity: "Activity",
 };
@@ -256,7 +258,7 @@ function handleKey(key: KeyEvent, ctx: AppContext, quit: () => void): void {
     });
   }
 
-  if (key.name >= "1" && key.name <= "4") {
+  if (key.name >= "1" && key.name <= "9") {
     const idx = Number(key.name) - 1;
     if (idx >= 0 && idx < TAB_IDS.length) {
       ctx.store.dispatch((d) => {
@@ -381,6 +383,9 @@ function delegateTabKey(key: KeyEvent, ctx: AppContext): void {
     case "sync":
       onSyncKey(key, ctx.store);
       break;
+    case "machines":
+      onMachinesKey(key, ctx.store);
+      break;
     case "migrate":
       onMigrateKey(key, ctx.store);
       break;
@@ -492,7 +497,7 @@ function activeKeyHint(state: AppState): string | null {
 function actionLabelFor(key: KeyEvent, state: AppState): { key: string; label: string } | null {
   if (state.helpOpen) return null;
   const name = key.name;
-  if (name >= "1" && name <= "4") {
+  if (name >= "1" && name <= "9") {
     const idx = Number(name) - 1;
     if (idx < TAB_IDS.length) return { key: name, label: TAB_LABELS[TAB_IDS[idx]] };
   }
@@ -567,6 +572,10 @@ function renderActiveTab(
         ensureSyncLoaded(store);
         renderSync(renderer, host, state);
         break;
+      case "machines":
+        ensureMachinesLoaded(store);
+        renderMachines(renderer, host, state);
+        break;
       case "migrate":
         renderMigrate(renderer, host, state);
         break;
@@ -581,7 +590,7 @@ function renderHelp(renderer: CliRenderer, host: BoxRenderable, state: AppState)
   const help = [
     "",
     "  Global keys",
-    "    1 – 4         Jump to tab",
+    "    1 – 5         Jump to tab",
     "    Tab / Sh+Tab  Cycle tabs",
     "    p             Push vault (direct)",
     "    r             Refresh current tab",
@@ -607,6 +616,10 @@ function renderHelp(renderer: CliRenderer, host: BoxRenderable, state: AppState)
     "    x             Remove selected skills — opens y/n confirm modal",
     "    s             Toggle synced section (collapsed by default)",
     "    k             Load private key for accurate status",
+    "",
+    "  Machines",
+    "    ↑ / ↓         Move cursor through machine namespaces",
+    "    enter         Copy the selected machine's config to this machine",
     "",
     "  Sync — skill drill-in",
     "    ↑ / ↓         Move cursor through files in bundle",
@@ -667,6 +680,13 @@ function contextActionsForTab(state: AppState): ContextAction[] {
       ];
       if (state.selection.size > 0) base.push({ key: "x", label: "remove" });
       if (!state.sync.keyLoaded) base.push({ key: "k", label: "load key" });
+      return base;
+    }
+    case "machines": {
+      const base: ContextAction[] = [{ key: "↑↓", label: "move" }];
+      if (state.machines.phase === "ready" && state.machines.list.length > 0) {
+        base.push({ key: "enter", label: "copy here" });
+      }
       return base;
     }
     case "migrate":

--- a/src/commands/tui/state.ts
+++ b/src/commands/tui/state.ts
@@ -2,7 +2,7 @@ import type { DaemonStatus } from "../../config/schema";
 import { detectInstallMethod, type InstallMethod } from "../../core/version-check";
 import type { SyncRow } from "../status";
 
-export const TAB_IDS = ["dashboard", "sync", "migrate", "activity"] as const;
+export const TAB_IDS = ["dashboard", "sync", "machines", "migrate", "activity"] as const;
 export type TabId = (typeof TAB_IDS)[number];
 
 export const AGENTS = ["claude", "cursor", "codex", "copilot", "vscode"] as const;
@@ -15,7 +15,7 @@ export type MigrateField = "from" | "to" | "type" | "preview" | "apply";
 
 export interface ActivityEntry {
   ts: Date;
-  kind: "push" | "pull" | "skill-rm" | "migrate" | "preview" | "error" | "info";
+  kind: "push" | "pull" | "copy" | "skill-rm" | "migrate" | "preview" | "error" | "info";
   status: "ok" | "fail" | "running" | "info";
   message: string;
 }
@@ -30,10 +30,12 @@ export interface DaemonState {
 export type OpKind =
   | "push"
   | "pull"
+  | "copy"
   | "migrate"
   | "migrate-preview"
   | "skill-rm"
   | "sync-load"
+  | "machines-load"
   | "upgrade";
 
 /** Background update-check result. Populated once the TUI's startup check
@@ -199,6 +201,17 @@ export interface ContextAction {
   label: string;
 }
 
+/** Machines tab — browse other machines' vault namespaces and copy from them. */
+export interface MachinesSlice {
+  phase: LoadablePhase;
+  /** Machine namespace names under `vault/machines/`, sorted. */
+  list: string[];
+  cursor: number;
+  error: string | null;
+  /** Result of the most recent copy triggered from this tab. */
+  lastCopy: { machine: string; ok: boolean; message: string } | null;
+}
+
 export interface AppState {
   activeTab: TabId;
   daemon: DaemonState;
@@ -209,6 +222,7 @@ export interface AppState {
   keyHint: { key: string; expiresAt: number } | null;
   helpOpen: boolean;
   sync: SyncSlice;
+  machines: MachinesSlice;
   migrate: MigrateSlice;
   inFlight: Record<string, OperationStatus>;
   opSeq: number;
@@ -246,6 +260,13 @@ export function createInitialState(): AppState {
       lastOp: null,
       scrollOffset: 0,
       confirmRemove: null,
+    },
+    machines: {
+      phase: "idle",
+      list: [],
+      cursor: 0,
+      error: null,
+      lastCopy: null,
     },
     migrate: {
       from: "claude",

--- a/src/commands/tui/store.ts
+++ b/src/commands/tui/store.ts
@@ -16,7 +16,7 @@ export interface RunOpOptions<R> {
   onSuccess?: (draft: AppState, result: R) => void;
   onError?: (draft: AppState, err: Error) => void;
   /** When set, the terminal phase pushes an ActivityEntry with this kind. */
-  activityKind?: "push" | "pull" | "skill-rm" | "migrate" | "preview" | "info";
+  activityKind?: "push" | "pull" | "copy" | "skill-rm" | "migrate" | "preview" | "info";
   /** Override the terminal toast text; defaults to label + outcome. */
   successToast?: string;
   errorToastPrefix?: string;

--- a/src/commands/tui/tabs/dashboard.ts
+++ b/src/commands/tui/tabs/dashboard.ts
@@ -72,15 +72,16 @@ export function renderDashboard(renderer: CliRenderer, host: BoxRenderable, stat
 
   // Hint panel
   const hint = new TextRenderable(renderer, {
-    height: 4,
+    height: 6,
     width: "100%",
     fg: "#6c7886",
     bg: "#11151a",
     content: [
       "",
-      "  [2] Sync     side-by-side vault ↔ local with status, diff, push, pull",
-      "  [3] Migrate  translate config from one agent to another",
-      "  [4] Activity recent operation log",
+      "  [2] Sync     side-by-side vault ↔ local with status, diff, push",
+      "  [3] Machines browse other machines' namespaces and copy from them",
+      "  [4] Migrate  translate config from one agent to another",
+      "  [5] Activity recent operation log",
     ].join("\n"),
   });
   wrapper.add(hint);

--- a/src/commands/tui/tabs/machines.ts
+++ b/src/commands/tui/tabs/machines.ts
@@ -1,0 +1,145 @@
+import type { CliRenderer, KeyEvent } from "@opentui/core";
+import { BoxRenderable, TextRenderable } from "@opentui/core";
+import { listMachines, performCopy } from "../../copy";
+import { resolveRuntimeContext } from "../../shared";
+import { AGENTS, type AppState, setToast } from "../state";
+import type { Store } from "../store";
+
+/**
+ * Load the machine namespaces under `vault/machines/` once per tab visit. Reuses
+ * `listMachines` from the copy command so the enumeration never forks.
+ */
+export function ensureMachinesLoaded(store: Store): void {
+  if (store.getState().machines.phase !== "idle") return;
+  store.dispatch((d) => {
+    d.machines.phase = "loading";
+    d.machines.error = null;
+  });
+  store.runOperation(
+    "machines-load",
+    "load machines",
+    async () => {
+      const runtime = await resolveRuntimeContext();
+      return listMachines(runtime.vaultDir);
+    },
+    {
+      onSuccess: (d, list) => {
+        d.machines.list = list;
+        d.machines.cursor = Math.min(d.machines.cursor, Math.max(0, list.length - 1));
+        d.machines.phase = "ready";
+      },
+      onError: (d, err) => {
+        d.machines.phase = "error";
+        d.machines.error = err.message;
+      },
+    },
+  );
+}
+
+/** Copy every agent namespace of `machine` to local disk via the shared core. */
+function copyMachine(store: Store, machine: string): void {
+  store.runOperation(
+    "copy",
+    `copy ${machine}`,
+    async () => {
+      let applied = 0;
+      for (const agent of AGENTS) {
+        const result = await performCopy({ fromMachine: machine, vaultPath: `${agent}/` });
+        if (result.status === "applied") applied += result.count;
+        else if (result.status === "reconcile-error" || result.status === "error") {
+          throw new Error(result.error);
+        }
+        // not-found (this machine has no artifacts for the agent) is expected — skip.
+      }
+      return applied;
+    },
+    {
+      activityKind: "copy",
+      toastOnStart: { text: `Copying ${machine}…` },
+      onSuccess: (d, applied) => {
+        setToast(d, `Copied ${applied} artifact(s) from ${machine}`, "success");
+        d.machines.lastCopy = { machine, ok: true, message: `applied ${applied} artifact(s)` };
+      },
+      onError: (d, err) => {
+        setToast(d, `Copy failed: ${err.message}`, "error");
+        d.machines.lastCopy = { machine, ok: false, message: err.message };
+      },
+      errorToastPrefix: "copy",
+    },
+  );
+}
+
+/** Handle Machines-tab keys. Returns true when the key was consumed. */
+export function onMachinesKey(key: KeyEvent, store: Store): boolean {
+  const m = store.getState().machines;
+  if (m.phase !== "ready" || m.list.length === 0) return false;
+
+  if (key.name === "down") {
+    store.dispatch((d) => {
+      d.machines.cursor = Math.min(d.machines.cursor + 1, d.machines.list.length - 1);
+    });
+    return true;
+  }
+  if (key.name === "up") {
+    store.dispatch((d) => {
+      d.machines.cursor = Math.max(d.machines.cursor - 1, 0);
+    });
+    return true;
+  }
+  if (key.name === "return") {
+    const machine = m.list[m.cursor];
+    if (machine) copyMachine(store, machine);
+    return true;
+  }
+  return false;
+}
+
+export function renderMachines(renderer: CliRenderer, host: BoxRenderable, state: AppState): void {
+  const m = state.machines;
+  const wrapper = new BoxRenderable(renderer, {
+    flexDirection: "column",
+    width: "100%",
+    flexGrow: 1,
+    backgroundColor: "#11151a",
+    border: false,
+  });
+  host.add(wrapper);
+
+  let body: string;
+  if (m.phase === "loading" || m.phase === "idle") {
+    body = "\n  Loading machine namespaces…";
+  } else if (m.phase === "error") {
+    body = `\n  Failed to list machines: ${m.error ?? "unknown error"}`;
+  } else if (m.list.length === 0) {
+    body = "\n  No machines in the vault yet. Run `agentsync push` on a machine first.";
+  } else {
+    body = ["", ...m.list.map((name, i) => `  ${i === m.cursor ? "›" : " "} ${name}`), ""].join(
+      "\n",
+    );
+  }
+
+  const listBox = new BoxRenderable(renderer, {
+    flexGrow: 1,
+    width: "100%",
+    border: true,
+    borderColor: "#3b4252",
+    borderStyle: "single",
+    title: " Machines (vault namespaces) ",
+    backgroundColor: "#11151a",
+  });
+  listBox.add(new TextRenderable(renderer, { content: body, fg: "#d8dee9", bg: "#11151a" }));
+  wrapper.add(listBox);
+
+  const last = m.lastCopy
+    ? `  last: ${m.lastCopy.ok ? "✓" : "✗"} ${m.lastCopy.machine} — ${m.lastCopy.message}`
+    : "  ↑↓ select • enter: copy the machine's config to this machine • copy never touches the vault";
+  wrapper.add(
+    new TextRenderable(renderer, {
+      height: 2,
+      width: "100%",
+      fg: "#6c7886",
+      bg: "#11151a",
+      content: `\n${last}`,
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

Closes #158. Adds the remaining acceptance criterion — the **TUI Machines browse view** — on top of the `copy` CLI shipped in PR #165.

- A new **Machines** tab (between Sync and Migrate) lists the vault's `machines/<name>/` namespaces, navigates with ↑/↓, and on enter copies the selected machine's config to this machine.
- Reuses the shipped core: `ensureMachinesLoaded` calls `listMachines` (now exported from `copy.ts`) and `copyMachine` loops `performCopy` over the agents — no forked business logic (per the "TUI reuses command cores" invariant). `copy` writes only to local disk, never the vault.
- Wires the tab through state (`TAB_IDS`, `MachinesSlice`, `OpKind`/`ActivityEntry`/`activityKind` gain `copy`/`machines-load`), `app.ts` (label, key delegation, render, context actions), the help overlay, and the dashboard hint.

## Review-gate fixes (caught before commit)

- Inserting a 5th tab broke the number-key switch (hardcoded `"1"–"4"`), leaving `[5] Activity` advertised but unreachable. Both number-key paths now derive the bound from `TAB_IDS.length` (`"1"–"9"`, guarded), and the help overlay (`1 – 5` + a Machines section) and action bar are updated.

## Test plan

- `machines.test.ts`: ↑/↓ navigation within bounds; keys ignored until ready/non-empty; `ensureMachinesLoaded` lists namespaces + flips to ready; idempotent reload; enter triggers `copyMachine` → records `lastCopy` (success accumulation, exercised against an empty namespace so no local-disk writes).
- Full suite: 0 `(fail)` markers. `renderMachines` (OpenTUI primitives) is uncovered like the other tab render functions.

## Out of scope

- Full README/architecture/operations docs sweep and CLAUDE.md invariants (#160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
