### PR TITLE
docs: sweep single-source/pull references to the v2 per-machine + copy model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ system model.
 src/
   cli.ts                  CLI entry — wires citty commands; bare invocation opens the TUI
   agents/                 Per-agent adapters (claude, cursor, codex, copilot, vscode)
-  commands/               User-facing commands (init, push, pull, status, daemon, key, skill, …)
+  commands/               User-facing commands (init, push, copy, status, daemon, key, skill, plugin, vault, upgrade, …)
     destroy.ts            CLI vault teardown — local rm, remote commit, or both
     tui/                  Interactive TUI: app loop, tab modules, IPC client, render panes
   config/                 Path resolution + agentsync.toml schema
@@ -63,21 +63,44 @@ bun run check:act     # run CI workflow locally via nektos/act
   go through `src/core/encryptor.ts`. `src/core/sanitizer.ts` enforces
   hard never-sync patterns and aborts the push when literal secrets are
   detected — do not loosen these without a documented reason.
+- **Per-machine vault layout (v2)**: every artifact lives under
+  `machines/<name>/<agent>/…`, composed only through `machineVaultRoot` in
+  `src/config/paths.ts` (never hardcode the `machines/` segment). Each machine
+  backs up into its own namespace and never overwrites another's. The machine
+  name is pinned at `init` (sibling of the key) so a later hostname change
+  cannot orphan the namespace.
+- **Backup is push-only; `copy` is the only vault→local path**: there is no
+  `pull`. `push` snapshots this machine into its namespace; `agentsync copy
+  <machine> <path>` is the sole way to apply vault content to local disk (it
+  reuses each agent's apply plan via `applySingleArtifact`, writing only local
+  disk, never the vault). The daemon is push-only — no pull IPC, no pull timer.
 - **Reconciliation is fast-forward-only**: `src/core/git.ts` defines the
-  shared rule used by `init`, `pull`, `push`, `key add`, `key rotate`, and
-  the daemon. Diverged history must stop the operation with recovery
-  guidance — never silently merge or print success.
+  shared rule used by `init`, `push`, `copy`, `key add`, `key rotate`, and the
+  daemon. Diverged history must stop the operation with recovery guidance —
+  never silently merge or print success.
+- **Integer version is the old-binary block**: `agentsync.toml` carries
+  `version` as an INTEGER literal (`z.literal(2)`). A v1 binary's
+  `version: z.string()` schema throws on it, so an old binary can never load a
+  v2 vault and write flat dirs beside `machines/`. `peekVaultVersion` reads the
+  raw version before Zod to route v1→`vault upgrade`, v2→load, >2→upgrade the
+  binary.
+- **Claude plugins are a manifest, not a tree**: `push` (when
+  `claudePlugins.syncPlugins = true`) distils `~/.claude/plugins/{installed_plugins,known_marketplaces}.json`
+  into one `claude/plugins.manifest.json.age` (name@marketplace, scope,
+  enabled; absolute paths dropped). It has no apply directive — never restored
+  on pull/copy — and `agentsync plugin install <machine>` reinstalls by
+  shelling to the `claude` CLI.
 - **Skill removal is explicit**: vault skills are only removed via
-  `agentsync skill remove <agent> <name>`. Snapshot, pull, and status are
+  `agentsync skill remove <agent> <name>`. Snapshot, copy, and status are
   additive by construction.
 - **Path resolution**: always resolve agent paths through `AgentPaths` in
   `src/config/paths.ts` rather than hardcoding `~/.claude`, `~/.cursor`,
   etc. — this keeps the test harness and platform overrides working.
-- **TUI reuses command logic, never duplicates it**: the TUI wizards and
-  the Migrate tab call `performInit`, `performKeyAdd`, `performKeyRotate`,
-  `performMigrate`, and `performSkillRemove` directly. Adding new TUI
-  features must not fork business logic — encryption, reconciliation,
-  sanitiser, and migration invariants live in one place.
+- **TUI reuses command logic, never duplicates it**: the TUI wizards, the
+  Machines tab, and the Migrate tab call `performInit`, `performKeyAdd`,
+  `performKeyRotate`, `performMigrate`, `performSkillRemove`, and `performCopy`
+  directly. Adding new TUI features must not fork business logic — encryption,
+  reconciliation, sanitiser, and migration invariants live in one place.
 - **`destroy` never imports `AgentPaths`**: the agent-files-never-touched
   invariant for `agentsync destroy` is enforced by construction (no
   `AgentPaths.*` reference anywhere in `src/commands/destroy.ts`) and by

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 	<img src="./docs/demo/tui.gif" alt="AgentSync TUI walkthrough" width="800"/>
 </div>
 
-AgentSync is a Bun-based CLI and background daemon that snapshots AI agent configuration from your machine, encrypts it with [age](https://age-encryption.org/) recipients, and stores it in a Git-backed vault so you can pull the same setup onto another machine.
+AgentSync is a Bun-based CLI and background daemon that snapshots AI agent configuration from your machine, encrypts it with [age](https://age-encryption.org/) recipients, and backs it up into a Git-backed vault under a per-machine namespace, so you can copy any machine's setup onto another.
 
-It is for people who keep global agent configuration in tools like Claude, Cursor, Codex, Copilot, and VS Code and want one encrypted source of truth instead of manually copying files between laptops.
+It is for people who keep global agent configuration in tools like Claude, Cursor, Codex, Copilot, and VS Code and want one encrypted backup per machine instead of manually copying files between laptops. Each machine pushes into its own `machines/<name>/` namespace; bringing config to a new machine is an explicit `copy`, never a silent overwrite.
 
 ## Install
 
@@ -42,8 +42,8 @@ bunx --package @chrisleekr/agentsync agentsync --version
 
 The fastest way in is the interactive TUI. Running `agentsync` with no
 arguments opens a tabbed dashboard that lets you browse the vault, inspect
-local agent content per agent, trigger push/pull, and migrate configuration
-between agents:
+local agent content per agent, trigger a push, browse other machines and copy
+from them, and migrate configuration between agents:
 
 ```bash
 # Open the TUI (or use the explicit alias `agentsync tui`)
@@ -73,7 +73,7 @@ The full quickstart, command reference, and architecture model live at the docum
 
 | Command | Why you run it |
 |---|---|
-| *(bare)* / `tui` | Open the interactive TUI: vault browser, per-agent local view, push/pull, and migrate. |
+| *(bare)* / `tui` | Open the interactive TUI: vault browser, per-agent local view, push, browse machines and copy, and migrate. |
 | `init` | Create the local vault workspace, machine key, config, and initial remote state. |
 | `push` | Snapshot local agent configs, sanitise secrets, encrypt artefacts, and push to Git. |
 | `copy` | Restore an artefact (or subdir) from a machine's vault namespace to local disk (`copy self …` for your own). |
@@ -91,7 +91,7 @@ Full flag tables and caveats: [Commands](https://chrisleekr.github.io/agentsync/
 
 The full documentation is hosted at <https://chrisleekr.github.io/agentsync/> and lives in [`docs/`](./docs):
 
-- **[Architecture](./docs/architecture.md)** — system model, push and pull pipelines, daemon model, security boundaries.
+- **[Architecture](./docs/architecture.md)** — system model, push and copy pipelines, daemon model, security boundaries.
 - **[Commands](./docs/commands.md)** — every subcommand, flag, outcome, and caveat.
 - **[Migrate](./docs/migrate.md)** — translate config between Claude, Cursor, Codex, Copilot, and VS Code.
 - **[Operations](./docs/operations.md)** — daemon install per OS, key rotation, troubleshooting catalogue.

--- a/docker/e2e/README.md
+++ b/docker/e2e/README.md
@@ -76,7 +76,7 @@ the canary path so the never-sync contract is exercised, not bypassed:
 For every JSON/TOML file the **synced fields** column travels through the
 encrypted vault. Every other key remains local. The HOME-rewrite column flags
 the values that pass through `${AGENTSYNC_HOME}` normalization on push and
-back to the local `homedir()` on pull (B24).
+back to the local `homedir()` on `copy` (B24).
 
 | Adapter | File | Synced fields | HOME-rewrite | Ignored (stays local) |
 | --- | --- | --- | --- | --- |
@@ -113,7 +113,7 @@ back to the local `homedir()` on pull (B24).
 | 6 | `06-skill-additive.sh` | Disk removal of a skill leaves vault copy intact; explicit `skill remove` drops it |
 | 9 | `09-key-add.sh` | Add a second recipient; every blob decrypts under either key; idempotent re-run |
 | 10 | `10-migrate.sh` | Every supported `(--from, --to, --type)` combo; `--dry-run` no-op; idempotent |
-| 11 | `11-daemon-ipc.sh` | Daemon `status`, `push`, `pull` verbs work; clean shutdown |
+| 11 | `11-daemon-ipc.sh` | Daemon `status` and `push` verbs work; `pull` is rejected (push-only daemon); clean shutdown |
 | 13 | `13-doctor.sh` | Every `agentsync doctor` check fires; negative breaks surface the correct failure line |
 | 14 | `14-dry-run.sh` | `push --dry-run` lists intended changes but produces no commit |
 | 16 | `16-vscode-non-mcp.sh` | Pin (B6): VS Code adapter syncs **only** `mcp.json.mcpServers`; settings/keybindings/snippets stay local |
@@ -140,7 +140,7 @@ affected line if a critical regression strikes.
 
 JSON and TOML values whose strings start with the current machine's
 `homedir()` + path-separator are rewritten to `${AGENTSYNC_HOME}` on push.
-On pull, the placeholder is rewritten back to the destination machine's
+On `copy`, the placeholder is rewritten back to the destination machine's
 `homedir()`.
 
 - Markdown bodies are **not** rewritten — they are user content. Sanitizer
@@ -148,7 +148,8 @@ On pull, the placeholder is rewritten back to the destination machine's
 - Strings that don't match `homedir() + sep` (e.g. `/etc/hosts`, `/opt/foo`)
   pass through unchanged.
 
-Scenario 20 verifies both directions plus the negative-control cases.
+Unit tests verify both directions plus the negative-control cases (the former
+home-portability e2e scenario was retired with the down-sync removal).
 
 ## Hermetic isolation contract
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 ---
-description: How AgentSync works: the encrypted vault format, push and pull pipelines, the background daemon, and fail-closed reconciliation.
+description: How AgentSync works: the encrypted vault format, push and copy pipelines, the background daemon, and fail-closed reconciliation.
 ---
 
 # Architecture
@@ -8,7 +8,7 @@ How AgentSync moves bytes from your machine to a Git remote and back, encrypted 
 
 ## What this page owns
 
-This page owns the system model, the push and pull pipelines, the daemon model, the vault layout, the security boundaries, and the reconciliation rule. Command flags live in [Commands](commands.md); day-2 operational concerns live in [Operations](operations.md).
+This page owns the system model, the push and copy pipelines, the daemon model, the vault layout, the security boundaries, and the reconciliation rule. Command flags live in [Commands](commands.md); day-2 operational concerns live in [Operations](operations.md).
 
 ## System context
 
@@ -88,9 +88,11 @@ Gate-by-gate:
 - **Encryptor**: every artefact is encrypted to the current recipient set using age. Plaintext exists only in process memory and is never serialised to disk after this point.
 - **Reconciliation**: fast-forward only. If the local vault has diverged from the remote branch, the push stops and prints a recovery path. AgentSync never merges silently.
 
-## The pull pipeline
+## The copy pipeline
 
-Pull is **additive by construction**. It can add files and update existing ones; it never deletes a local file the vault does not contain. Skill removal is explicit (`agentsync skill remove`) precisely so a misconfigured pull on a fresh machine cannot wipe local work.
+There is no automatic down-sync. `push` only ever writes this machine's own `machines/<name>/` namespace; the **only** way to bring vault content onto local disk is an explicit `agentsync copy <machine> <path>`. You name the source machine and the artefact (or a directory prefix), and AgentSync decrypts just that and applies it to local disk through the same per-agent apply plan a snapshot uses.
+
+Copy is **additive by construction**. It can add files and update existing ones; it never deletes a local file the vault does not contain. Skill removal is explicit (`agentsync skill remove`) precisely so a misconfigured copy on a fresh machine cannot wipe local work. Copy writes only local disk — it never touches the vault, so the next `push` captures the result normally.
 
 <div class="agentsync-darknodes" markdown>
 
@@ -98,14 +100,16 @@ Pull is **additive by construction**. It can add files and update existing ones;
 flowchart LR
     Fetch["git fetch<br/>vault"]:::step
     FF["Fast-forward<br/>or abort"]:::gate
+    Pick["Resolve machine<br/>+ artefact path"]:::step
     Decrypt["Decryptor<br/>age identity"]:::step
-    Apply["Apply additively"]:::step
+    Apply["Apply additively<br/>to local disk"]:::step
     Local[("Local agent<br/>configs")]:::remote
-    Abort["pull fails<br/>guidance printed"]:::abort
+    Abort["copy fails<br/>guidance printed"]:::abort
 
     Fetch --> FF
     FF -->|diverged| Abort
-    FF --> Decrypt
+    FF --> Pick
+    Pick --> Decrypt
     Decrypt --> Apply
     Apply --> Local
 
@@ -121,11 +125,11 @@ flowchart LR
 
 ## Reconciliation rule
 
-Reconciliation is fast-forward only and is the **same rule** used by `init`, `push`, `pull`, `key add`, `key rotate`, and the daemon. The contract:
+Reconciliation is fast-forward only and is the **same rule** used by `init`, `push`, `copy`, `key add`, `key rotate`, and the daemon. The contract:
 
 - If the local branch is identical to the remote branch, the operation continues.
 - If the local branch is behind the remote, the operation fast-forwards the local before continuing.
-- If the local branch is ahead of the remote, `push` fast-forwards the remote; `pull` continues without writing (pull never pushes).
+- If the local branch is ahead of the remote, `push` fast-forwards the remote; `copy` continues reading without writing the remote (copy never pushes).
 - If the local branch has diverged from the remote, the operation stops with a printed recovery path. AgentSync never merges or rebases automatically.
 
 The reasoning: a configuration vault is a flat record of intent. Three-way merge on encrypted blobs would either produce nonsense or require trust in a merge driver that has no way to inspect the plaintext. Failing closed forces the human to decide which branch is canonical.
@@ -179,7 +183,7 @@ Once admitted, each artefact is sanitised through the relevant rule set, encrypt
 
 ## Daemon model
 
-The daemon is a long-running process under platform supervision (launchd on macOS, systemd-user on Linux, Task Scheduler on Windows). It exposes `status`, `push`, and `pull` over a newline-delimited IPC protocol on a per-user socket.
+The daemon is a long-running process under platform supervision (launchd on macOS, systemd-user on Linux, Task Scheduler on Windows). It is **push-only**: it exposes `status` and `push` over a newline-delimited IPC protocol on a per-user socket. There is no pull IPC command and no periodic pull timer — the vault is a backup, and bringing content down is always an explicit, interactive `copy`.
 
 <div class="agentsync-darknodes" markdown>
 
@@ -189,19 +193,15 @@ flowchart LR
     Debounce["Debounce<br/>quiet window"]:::step
     Queue["Sync queue<br/>serialised"]:::gate
     Push["push"]:::step
-    Pull["pull"]:::step
-    Timer["Periodic pull timer"]:::step
     Ipc["IPC server"]:::step
     Cli["agentsync CLI"]:::local
     Tui["agentsync TUI"]:::local
 
     Watcher --> Debounce --> Queue
-    Timer --> Queue
-    Cli -->|status / push / pull| Ipc
-    Tui -->|status poll 1.5s, push, pull| Ipc
+    Cli -->|status / push| Ipc
+    Tui -->|status poll 1.5s, push| Ipc
     Ipc --> Queue
     Queue --> Push
-    Queue --> Pull
 
     classDef local fill:#2c3e50,color:#ffffff,stroke:#1a252f
     classDef step fill:#2c3e50,color:#ffffff,stroke:#1a252f
@@ -217,7 +217,7 @@ because every request goes through the same sync queue.
 Key invariants:
 
 - **Only one daemon per user.** Second-instance detection runs at startup and exits cleanly if a daemon is already up. A stale socket from an ungraceful prior exit is unlinked automatically.
-- **One sync at a time.** Every push and pull, whether file-watcher-driven, timer-driven, or IPC-driven, passes through the sync queue. Two operations can never race.
+- **One sync at a time.** Every push, whether file-watcher-driven or IPC-driven, passes through the sync queue. Two operations can never race.
 - **One automatic retry.** A transient sync failure triggers one retry. If both attempts fail, the error is recorded and the daemon stays alive so the next change can trigger a fresh push. The daemon never silently gives up.
 - **Hard shutdown timeout.** On shutdown the queue is drained with a ten-second hard timeout. The IPC socket and watchers are released cleanly.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,5 +1,5 @@
 ---
-description: Complete AgentSync CLI reference: every command, flag, default, and caveat for init, push, pull, status, daemon, key, skill, and the TUI.
+description: Complete AgentSync CLI reference: every command, flag, default, and caveat for init, push, copy, status, daemon, key, skill, plugin, vault, and the TUI.
 ---
 
 # Commands
@@ -41,14 +41,15 @@ When developing from source, replace the binary call with `bun run src/cli.ts`. 
 |---|---|
 | [*(bare)* / `tui`](#tui) | Open the interactive tab-based TUI. |
 | [`init`](#init) | Bootstrap the vault, machine key, and config. |
-| [`push`](#push) | Snapshot, sanitise, encrypt, and fast-forward to the vault. |
-| [`pull`](#pull) | Fetch the vault, decrypt, and apply locally. |
+| [`push`](#push) | Snapshot, sanitise, encrypt, and fast-forward this machine's namespace to the vault. |
+| [`copy`](#copy) | Apply an artefact (or subdir) from a machine's vault namespace to local disk (`copy self …` for your own). |
 | [`status`](#status) | Compare local snapshot to decrypted vault state. |
 | [`doctor`](#doctor) | Check the local environment before blaming sync logic. |
 | [`daemon`](#daemon) | Install, start, stop, and inspect the background daemon. |
 | [`key`](#key) | Add a recipient or rotate the current machine key. |
 | [`skill`](#skill) | Remove a skill from the vault. |
 | [`plugin`](#plugin) | List or reinstall a machine's Claude plugins from its vault manifest. |
+| [`vault`](#vault) | Migrate an older vault to the current format (`vault upgrade`). |
 | [`migrate`](#migrate) | Translate configuration between agent formats. |
 | [`destroy`](#destroy) | Wipe the local vault clone or the remote vault contents (via commit). |
 | [`upgrade`](#upgrade) | Check GitHub for a newer release and install it when possible. |
@@ -56,7 +57,8 @@ When developing from source, replace the binary call with `bun run src/cli.ts`. 
 ## tui
 
 **Why**: Browse the vault, inspect what each local agent has on disk, trigger
-push / pull, and run cross-agent migrations from a single interactive screen.
+a push, browse other machines and copy their config to this one, and run
+cross-agent migrations from a single interactive screen.
 
 **Usage**:
 
@@ -71,26 +73,27 @@ agentsync tui       # explicit alias, same behaviour
 |---|---|
 | 1 Dashboard | Daemon health (pid, uptime, last error), vault state, agent summary, init / key-rotate launchers. |
 | 2 Sync | Per-artifact rows grouped by sync status (`local-changed`, `local-only`, `vault-only`, `unknown`, `synced`). Multi-select with `space`; push selected with `p`; bulk-remove skills with `x` (y/n confirm). Enter on a skill drills into its files with per-file diff. |
-| 3 Migrate | From / To / Type form (To and Type are multi-select with sub-cursor). Preview is mandatory before Apply enables. |
-| 4 Activity | Session-only ring buffer of TUI actions. |
+| 3 Machines | The vault's `machines/<name>/` namespaces. Move with `↑`/`↓`; `enter` copies the selected machine's config to this machine (the same `performCopy` core as the CLI; never touches the vault). |
+| 4 Migrate | From / To / Type form (To and Type are multi-select with sub-cursor). Preview is mandatory before Apply enables. |
+| 5 Activity | Session-only ring buffer of TUI actions. |
 
 **Global keys** (any tab):
 
 | Key | Action |
 |---|---|
-| `1` – `4` | Jump to tab |
+| `1` – `5` | Jump to tab |
 | `Tab` / `Shift-Tab` | Cycle tabs |
 | `p` | Push vault (honours selection in the Sync tab as a per-file allowlist) |
-| `l` | Pull vault |
 | `r` | Refresh current tab |
 | `?` | Toggle the keymap overlay |
 | `q` / `Ctrl-C` | Quit, restoring the terminal |
 
 **Outcome**: every state change is additive on the same data the CLI
-subcommands operate on. Push / pull go through the same daemon IPC the
-`status` and `daemon` subcommands use; migrate calls the same planner as
-`agentsync migrate`; bulk skill removal calls the same `performSkillRemove`
-that `agentsync skill remove` does, once per selected skill.
+subcommands operate on. Push goes through the same daemon IPC the `status` and
+`daemon` subcommands use; the Machines tab calls the same `performCopy` core as
+`agentsync copy`; migrate calls the same planner as `agentsync migrate`; bulk
+skill removal calls the same `performSkillRemove` that `agentsync skill remove`
+does, once per selected skill.
 
 **Caveats**:
 
@@ -98,9 +101,10 @@ that `agentsync skill remove` does, once per selected skill.
   `nohup`, CI runners) bare `agentsync` deliberately falls back to text
   `status` output so existing scripts continue to work.
 - The activity log is session-scoped — closing the TUI discards history.
-- Push / pull require the daemon to be running. If the daemon is offline,
-  the footer shows `daemon ● offline` and `p` / `l` surface an inline
-  notice rather than queueing a request that cannot be served.
+- Push requires the daemon to be running. If the daemon is offline, the footer
+  shows `daemon ● offline` and `p` surfaces an inline notice rather than
+  queueing a request that cannot be served. (Copy runs in-process and does not
+  need the daemon.)
 
 ## Conventions
 
@@ -213,9 +217,9 @@ agentsync status --verbose
 **Outcome**: a per-agent report covering every enabled agent. Each row carries one of the following status strings, printed verbatim:
 
 - `synced` — local content matches the vault.
-- `local-changed` — both sides have the file but the content differs. Run `push` to publish the local copy, or `pull` after backing up the local copy.
+- `local-changed` — both sides have the file but the content differs. Run `push` to publish the local copy, or `copy self <path>` to restore the vault copy after backing up the local one.
 - `local-only` — the machine has content the vault does not. Run `push`.
-- `vault-only` — the vault has content this machine does not. Run `pull`.
+- `vault-only` — this machine's namespace has content the local disk does not. Run `copy self <path>` to bring it down.
 - `error` — snapshot or decryption failed for that row. The error detail is printed in the same row; address it before trusting the rest of the report.
 
 **Caveats**:
@@ -323,15 +327,22 @@ agentsync key rotate
 
 ```bash
 agentsync skill remove <agent> <name>
+agentsync skill remove <agent> <name> --machine <namespace>
 ```
+
+**Flags**:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--machine` | this machine | Remove from another machine's `machines/<name>/` namespace. Validated against the same path-traversal rules as the resolved machine name. |
 
 **Outcome**: the vault artefact for that skill is deleted, the change is committed and pushed under the fast-forward reconciliation rule. The local skill directory on the current machine is left untouched.
 
 **Caveats**:
 
 - `skill remove` is the **only** non-additive operation in AgentSync. It deletes the vault artefact but does not remove the local skill directory on the current or other machines.
-- After `skill remove`, every machine that pulled the skill previously still has the local directory until you delete it manually there. See [A skill I deleted reappears after pull on another machine](operations.md#a-skill-i-deleted-reappears-after-pull-on-another-machine).
-- To snapshot or apply a single skill, use the bulk `push` and `pull` commands with `--agent`. There is no targeted `skill push` or `skill pull`; the snapshot for an agent always includes every skill that survives the walker contract.
+- After `skill remove`, every machine that copied the skill previously still has the local directory until you delete it manually there. See [A skill I deleted reappears after copy on another machine](operations.md#a-skill-i-deleted-reappears-after-copy-on-another-machine).
+- To snapshot a single agent's skills, use `push --agent <agent>`; to bring one machine's skills onto this one, use `copy <machine> <agent>/skills/`. There is no targeted `skill push`/`skill copy`; the snapshot for an agent always includes every skill that survives the walker contract.
 
 ## plugin
 
@@ -353,6 +364,23 @@ Use `self` as `<machine>` to act on this machine's own manifest.
 - Requires the `claude` CLI on `PATH`; a missing binary fails loudly rather than skipping silently.
 - Reinstall fetches the **latest** version — there is no version pin.
 - Local edits to plugin files are not preserved; only the manifest (marketplace + name + scope + enabled) round-trips.
+
+## vault
+
+**Why**: Migrate an older flat (v1) vault to the per-machine layout (v2), where every artefact lives under `machines/<name>/`. This is the vault-**format** migration — distinct from [`migrate`](#migrate), which translates config between agents, and from [`upgrade`](#upgrade), which updates the AgentSync binary.
+
+**Usage**:
+
+```bash
+agentsync vault upgrade
+```
+
+**Outcome**: the existing flat content is assumed to belong to this machine and is `git mv`'d under `machines/<this-machine>/`, the config `version` is bumped to the integer `2`, and the change is committed and fast-forwarded to the remote. It reconciles first, so a vault another machine already upgraded is detected and the command is a no-op. Idempotent — running it on a v2 vault prints "already at format v2".
+
+**Caveats**:
+
+- If the vault format is **newer** than this binary understands, the upgrade refuses and tells you to run `agentsync upgrade` to update AgentSync first.
+- Old (v1) binaries cannot read a v2 vault at all: `version` is an integer literal, and their string-typed schema rejects it. This is deliberate — it stops an old binary writing flat directories beside `machines/`.
 
 ## migrate
 
@@ -434,8 +462,8 @@ agentsync destroy --scope=all           # both
 **Caveats**:
 
 - Other recipients are affected by `--scope=remote` / `--scope=all`. Their
-  next `agentsync pull` will see an empty vault and lose their
-  `agentsync.toml` config — they will need to re-init.
+  next `agentsync push` or `copy` will reconcile against an empty vault and
+  they lose their `agentsync.toml` config — they will need to re-init.
 - The daemon stays running after a local destroy. Its next sync attempt
   will fail until re-init. Run `agentsync daemon stop` if you want it
   quiet in the meantime.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,8 @@ Five steps from zero to a working sync.
 
 > Tip: once you have run `init` once, running `agentsync` with no arguments
 > opens an interactive TUI that covers vault browsing, per-agent local view,
-> push/pull, and migrate. See [Commands → tui](commands.md#tui).
+> push, browsing other machines and copying from them, and migrate. See
+> [Commands → tui](commands.md#tui).
 
 1. **Create an empty Git repo** to act as the vault. A private GitHub or GitLab repo works. Nothing in it will ever contain plaintext.
 2. **Initialise on the first machine.** `agentsync init` generates an age keypair, registers it as a recipient, writes `agentsync.toml`, and clones the empty vault.
@@ -55,7 +56,7 @@ Five steps from zero to a working sync.
     agentsync push
     ```
 
-4. **Join from another machine.** On the second machine, `init` generates a fresh age keypair; on a machine that already has the vault, register the new public key as a recipient (`agentsync key add <name> <pubkey>` and push), then `pull` here.
+4. **Join from another machine.** On the second machine, `init` generates a fresh age keypair; on a machine that already has the vault, register the new public key as a recipient (`agentsync key add <name> <pubkey>` and push). Then, back on the new machine, `copy` the config you want from any machine's namespace (use `copy self …` once it has its own backup).
 
     ```bash
     # on the new machine
@@ -63,8 +64,8 @@ Five steps from zero to a working sync.
     # then on a machine that already has the vault, add the new recipient and push:
     #   agentsync key add <name> <pubkey-printed-by-init>
     #   agentsync push
-    # back on the new machine
-    agentsync pull
+    # back on the new machine, bring down another machine's config:
+    agentsync copy <other-machine> claude/
     ```
 
 5. **Run the daemon (optional).** The daemon watches your agent paths and pushes on change, with debounce and a sync queue.
@@ -81,14 +82,14 @@ Detailed flag, outcome, and caveat tables live in [Commands](commands.md).
 - **Plaintext never crosses the network.** Every artefact in the vault is encrypted to one or more age recipients before any Git operation runs.
 - **Fast-forward only.** Reconciliation never merges silently. If two machines diverge, AgentSync stops and prints a recovery path.
 - **Sanitiser is a hard gate.** Literal secrets and never-sync paths abort the push before any bytes leave the machine.
-- **Skill removal is explicit.** `pull` is additive by design so an in-progress local edit cannot be wiped by a remote that omits it. `agentsync skill remove` is the only command that deletes vault entries.
-- **Interactive TUI.** Running `agentsync` with no subcommand opens a tabbed UI to browse the vault, inspect per-agent local content, trigger push/pull, and migrate config — without memorising flags.
+- **Skill removal is explicit.** `copy` is additive by design so an in-progress local edit cannot be wiped by a remote that omits it. `agentsync skill remove` is the only command that deletes vault entries.
+- **Interactive TUI.** Running `agentsync` with no subcommand opens a tabbed UI to browse the vault, inspect per-agent local content, trigger a push, browse machines and copy from them, and migrate config — without memorising flags.
 
 ## Where to go next
 
 <div class="grid cards" markdown>
 
-- :material-sitemap: **[Architecture](architecture.md)** — system model, vault format, push and pull pipelines, daemon model, security boundaries.
+- :material-sitemap: **[Architecture](architecture.md)** — system model, vault format, push and copy pipelines, daemon model, security boundaries.
 - :material-console: **[Commands](commands.md)** — every subcommand, flag, outcome, and caveat in one reference.
 - :material-swap-horizontal: **[Migrate](migrate.md)** — translate config between Claude, Cursor, Codex, Copilot, and VS Code.
 - :material-cog: **[Operations](operations.md)** — daemon install per OS, key rotation, troubleshooting catalogue.

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -10,6 +10,11 @@ Translate configuration from one AI agent's format to another. The migrator read
 
 No vault initialisation is required — migration operates on local files only.
 
+> **Not the vault-format migration.** `agentsync migrate` translates config
+> between *agents* (Claude → Cursor, etc.). Upgrading an older vault to the
+> current per-machine *format* is a separate command, [`agentsync vault
+> upgrade`](commands.md#vault). The two never overlap.
+
 ## Two ways to run a migration
 
 - **Interactive (TUI)**: run `agentsync`, press `4` for the Migrate tab,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -66,7 +66,7 @@ The daemon moves through a small number of phases. Each phase has a well-defined
 | Validating | Verifies the vault directory, the config file, and the encryption key are reachable. Exits immediately on failure. |
 | Second-instance check | Sends an IPC `status` ping. If a daemon is already running, exits. Unlinks a stale socket if the prior daemon died ungracefully. |
 | Running | IPC server is listening and file watchers are active (push-only; no pull timer). `status` returns the current pid, consecutive-failure counter, and last error. |
-| Syncing | A push or pull is executing inside the sync queue. Only one sync runs at a time. |
+| Syncing | A push is executing inside the sync queue. Only one sync runs at a time. |
 | Retry once | Automatic single retry after a transient failure. If both attempts fail, the error is recorded but the daemon stays alive so the next change can still trigger a push. |
 | Shutting down | Drains the sync queue with a hard ten-second timeout, closes IPC, stops watchers, unlinks the socket, exits cleanly. |
 
@@ -125,7 +125,7 @@ When a new machine joins the vault, run `init` on it, copy the public key it pri
 agentsync key add my-laptop age1...
 ```
 
-The vault is reconciled against the remote, every existing artefact is re-encrypted for the updated recipient set, and the change is pushed. The new machine can then `pull`.
+The vault is reconciled against the remote, every existing artefact is re-encrypted for the updated recipient set, and the change is pushed. The new machine can then `copy` the artefacts it needs from any machine's namespace.
 
 ### Rotate the current machine key
 
@@ -211,13 +211,13 @@ SmartScreen reputation is per-binary-hash and accrues with downloads; every new 
 
 ### Recover from divergence
 
-Reconciliation is fast-forward only. Any command that touches the vault (`init`, `push`, `pull`, `key add`, `key rotate`) fails closed when local history has diverged from `origin/<branch>`.
+Reconciliation is fast-forward only. Any command that touches the vault (`init`, `push`, `copy`, `key add`, `key rotate`) fails closed when local history has diverged from `origin/<branch>`.
 
 Symptoms:
 
 - The command reports that AgentSync only supports fast-forward sync.
 - It prints a recovery hint telling you to reset or reclone the vault.
-- `pull` stops without printing `Pull completed: ...`.
+- `push` or `copy` stops with the divergence error instead of completing.
 
 Steps:
 
@@ -230,13 +230,13 @@ Do not resolve this with `git merge` or `git rebase`. AgentSync intentionally fa
 
 ### Recover a missing private key
 
-If `pull` cannot decrypt or `doctor` reports a missing key:
+If `copy` cannot decrypt or `doctor` reports a missing key:
 
 1. Confirm the expected key path with `agentsync doctor`.
 2. Restore the backed-up private key file.
 3. Ensure permissions are restrictive: on Unix, `chmod 600 ~/.config/agentsync/key.txt`.
 
-If the key is gone and was never backed up, the vault cannot be recovered for that machine. Generate a new identity with `init`, have the new public key added by an existing machine, then `pull`.
+If the key is gone and was never backed up, that machine's namespace cannot be decrypted any more. Generate a new identity with `init`, have the new public key added by an existing machine, then `copy` what you need from another machine's namespace.
 
 ### Reset a vault
 
@@ -280,7 +280,7 @@ and behaviour reference.
 ### `status` shows local-only or vault-only entries
 
 - `local-only` means the machine has config that is not in the vault yet. Run `push` after reviewing the content.
-- `vault-only` means the vault has artefacts this machine did not snapshot locally. Run `pull` if the content should exist on this machine.
+- `vault-only` means this machine's namespace has artefacts the local disk does not. Run `copy self <path>` if the content should exist on this machine.
 
 ### Push aborts because secrets were detected
 
@@ -304,9 +304,9 @@ Check, in order:
 
 If the service is installed but `daemon status` cannot reach it, inspect the platform logs listed above.
 
-### A skill I deleted reappears after pull on another machine
+### A skill I deleted reappears after copy on another machine
 
-Working as designed. `pull` is additive: it never removes a local skill directory, even when the matching vault file is gone. The safety reasoning is that a concurrent edit on machine B should not silently vanish after machine A removes a skill.
+Working as designed. `copy` is additive: it never removes a local skill directory, even when the matching vault file is gone. The safety reasoning is that a concurrent edit on machine B should not silently vanish after machine A removes a skill.
 
 Two cases:
 
@@ -316,9 +316,9 @@ Two cases:
     rm -rf ~/.claude/skills/<name>     # or ~/.cursor/skills, ~/.codex/skills, ~/.copilot/skills
     ```
 
-- **Single file inside a skill**: pull never propagates deletions, so a removed `helper.md` survives on machines that previously had it. Delete the stale file manually on each machine, then `status` to confirm.
+- **Single file inside a skill**: copy never propagates deletions, so a removed `helper.md` survives on machines that previously had it. Delete the stale file manually on each machine, then `status` to confirm.
 
-A future release may offer `pull --replace-skills` for users who want vault-as-source-of-truth overwrite semantics, but the default will remain additive.
+A future release may offer `copy --replace-skills` for users who want vault-as-source-of-truth overwrite semantics, but the default will remain additive.
 
 ### Private key missing or unreadable
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -53,7 +53,7 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 /**
- * Start the IPC server, file watchers, and periodic pull loop for background sync.
+ * Start the IPC server and file watchers for push-only background sync.
  * @returns A promise that resolves once the daemon has bound its IPC socket and registered watchers.
  */
 export async function startDaemon(): Promise<void> {
@@ -177,9 +177,10 @@ export async function startDaemon(): Promise<void> {
     });
   }
 
-  // No periodic pull: the vault is push-only backup. Each machine's local
-  // config is its own source of truth, so the daemon only auto-pushes on change.
-  // A manual pull remains available over IPC.
+  // No periodic pull and no pull IPC handler: the vault is push-only backup.
+  // Each machine's local config is its own source of truth, so the daemon only
+  // auto-pushes on change. Bringing vault content down is an explicit, manual
+  // `agentsync copy`, never a daemon action.
 
   // ── Graceful shutdown ──────────────────────────────────────────────
   const shutdown = async () => {


### PR DESCRIPTION
## Summary

Closes #160. The v2 documentation + invariants consistency backstop: sweeps every stale single-source-mirror / `agentsync pull` reference across the docs and `CLAUDE.md`, replacing it with the shipped per-machine model (push-only backup, `copy` as the only vault→local path, `vault upgrade`, push-only daemon, plugin manifest).

## Changes

- **CLAUDE.md** — dropped `pull` from the reconciliation invariant + structure list; added four v2 invariants: per-machine layout (`machines/<name>/<agent>/` via `machineVaultRoot`), push-only / `copy`-only down-path (daemon has no pull IPC or timer), integer-version old-binary block (`z.literal(2)` + `peekVaultVersion`), and the Claude plugin manifest model. Added `performCopy` to the TUI-reuse invariant.
- **README.md** — per-machine namespaces + explicit `copy` instead of the mirror framing; fixed the residual `push/pull` phrasings.
- **docs/architecture.md** — "pull pipeline" → "copy pipeline"; reconciliation lists `copy`; daemon section rewritten to push-only (status+push IPC, no pull, no timer) including the Mermaid.
- **docs/commands.md** — removed the dangling `pull` index link; rewrote the TUI section to the real 5-tab layout + `1`–`5` keys (no `l`/Pull); added a `copy` index row, a `## vault` section, and `--machine` on `skill remove`; status guidance uses `copy self`.
- **docs/operations.md** — daemon states, recovery runbooks, and the skill-reappears section use `copy` (section retitled).
- **docs/index.md / docs/migrate.md** — quickstart uses `copy`; migrate gains a `vault upgrade` (format) vs `migrate` (cross-agent) disambiguation note.
- **docker/e2e/README.md** — down-path is `copy`; scenario 11 documented push-only; retired the deleted scenario-20 reference.
- **src/daemon/index.ts** — corrected two stale comments that claimed a "periodic pull loop" and "manual pull over IPC" (the daemon has neither; a test asserts no pull handler). Comment-only.

## Accuracy

Every claim was verified against source, not the issue wishlist:
- Daemon IPC = `status` + `push` only (test asserts no pull handler); no pull timer.
- TUI = 5 tabs, help "1 – 5"; the only `l` is vim right-nav in the sync diff, not a global pull key.
- `status` has **no** `--machine` flag — it is this-machine-scoped — so it is documented as such (not invented).
- `vault upgrade` reconciles-first and is idempotent.

## Verification

- Reproduction grep red→green: `agentsync pull` / single-source-mirror over README/docs/CLAUDE.md was matching → now returns nothing. Remaining `pull` mentions only describe its absence.
- Gates: typecheck 0 errors, biome 0 errors, `check:docs` ownership passed (6 files), `check:spec-refs` passed (146 files), full suite 0 `(fail)` markers.
- Senior-review panel (correctness + tests-docs lenses) returned zero findings: cross-links resolve, claims match code, Mermaid valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
