### PR TITLE
chore(renovate): disable the Dependency Dashboard issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":semanticCommits", "helpers:pinGitHubActionDigests"],
+  "dependencyDashboard": false,
   "timezone": "Australia/Melbourne",
   "schedule": ["before 4am on Monday"],
   "labels": ["dependencies"],


### PR DESCRIPTION
## Summary

Closes #121. Adds `"dependencyDashboard": false` to `renovate.json`.

The Dependency Dashboard (#121) is authored by `app/renovate` and auto-created by the inherited `config:recommended` preset. It is bot-owned and Renovate recreates it on every run, so it cannot be durably closed while the dashboard is enabled. With this toggle, Renovate closes the dashboard issue and does not reopen it.

## Rationale

- The repo already runs aggressive Renovate automation — grouped PRs (github-actions / npm / base-images / docs), automerge for minor/patch/digest with `platformAutomerge`, `prConcurrentLimit` 4, and `minimumReleaseAge` holds. The dashboard is informational on top of that.
- One-line, fully reversible: set back to `true` (or remove the line) to restore it.
- The open Renovate dependency PRs (#153, #154) are unaffected — they merge on their own schedule under the existing rules.

## Verification

`renovate.json` remains valid JSON (verified locally). `dependencyDashboard` is a documented boolean option; `false` closes the existing dashboard issue and prevents recreation ([Renovate docs](https://docs.renovatebot.com/key-concepts/dashboard/)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)