### PR TITLE
refactor(agents): extract shared snapshot/apply toolkit and harden symlink walk

### DIFF
--- a/src/agents/__tests__/_apply.test.ts
+++ b/src/agents/__tests__/_apply.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { encryptString, generateIdentity, identityToRecipient } from "../../core/encryptor";
-import { type ApplyPlan, defineFileArtifact, readAgeFiles, runApplyPlan } from "../_apply";
+import {
+  type ApplyPlan,
+  defineFileArtifact,
+  dirWriteApplier,
+  makeApplyVault,
+  readAgeFiles,
+  runApplyPlan,
+  skillNameFilter,
+} from "../_apply";
 
 let workDir = "";
 let identity = "";
@@ -293,5 +301,103 @@ describe("runApplyPlan warnOnUnknownTopLevel", () => {
     // sanity: vault still contains both files (we didn't accidentally write or remove)
     const remaining = readdirSync(join(vaultDir, "demo"));
     expect(remaining.sort()).toEqual(["known.age", "unknown.age"]);
+  });
+});
+
+describe("skillNameFilter", () => {
+  const filter = skillNameFilter();
+
+  test("returns null for a valid skill name", () => {
+    expect(filter("my-skill")).toBeNull();
+  });
+
+  test("maps an invalid skill name to a skip reason", () => {
+    const result = filter("..");
+    expect(result).not.toBeNull();
+    expect(result?.reason).toContain("invalid skill name");
+  });
+});
+
+describe("dirWriteApplier", () => {
+  test("writes the file and creates parent directories", async () => {
+    const dir = join(workDir, "a", "b");
+    await dirWriteApplier({ dir })("note.md", "hello");
+    expect(readFileSync(join(dir, "note.md"), "utf8")).toBe("hello");
+  });
+
+  test("backs up an existing target only when backup is true", async () => {
+    const dir = join(workDir, "cmds");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "c.md"), "old");
+    await dirWriteApplier({ dir, backup: true })("c.md", "new");
+    expect(readFileSync(join(dir, "c.md"), "utf8")).toBe("new");
+    expect(readFileSync(join(dir, "c.md.bak"), "utf8")).toBe("old");
+
+    const noBackupDir = join(workDir, "nobak");
+    mkdirSync(noBackupDir, { recursive: true });
+    writeFileSync(join(noBackupDir, "d.md"), "old");
+    await dirWriteApplier({ dir: noBackupDir })("d.md", "new");
+    expect(existsSync(join(noBackupDir, "d.md.bak"))).toBe(false);
+  });
+
+  test("runs validate before any write and aborts on failure", async () => {
+    const dir = join(workDir, "validated");
+    const applier = dirWriteApplier({
+      dir,
+      validate: (name) => {
+        if (name.startsWith(".")) throw new Error("dotfile rejected");
+      },
+    });
+    await expect(applier(".secret.md", "x")).rejects.toThrow("dotfile rejected");
+    expect(existsSync(join(dir, ".secret.md"))).toBe(false);
+  });
+});
+
+describe("makeApplyVault", () => {
+  test("threads config into buildPlan and runs the plan", async () => {
+    const vaultDir = workDir;
+    await writeEncrypted(join(vaultDir, "demo", "thing.age"), "payload");
+    const seen: { config: unknown; applied: string[] } = { config: undefined, applied: [] };
+    const buildPlan = (config?: unknown): ApplyPlan => {
+      seen.config = config;
+      return {
+        agent: "demo",
+        directives: [
+          defineFileArtifact({
+            vaultName: "thing.age",
+            dryRunLabel: "[dry-run] [demo] would apply thing",
+            apply: async (decrypted) => {
+              seen.applied.push(decrypted);
+            },
+          }),
+        ],
+      };
+    };
+    const applyVault = makeApplyVault(buildPlan);
+    const sentinel = { marker: true };
+    await applyVault(vaultDir, identity, false, sentinel as never);
+    expect(seen.config).toBe(sentinel);
+    expect(seen.applied).toEqual(["payload"]);
+  });
+
+  test("threads the dryRun flag through to the plan", async () => {
+    const vaultDir = workDir;
+    await writeEncrypted(join(vaultDir, "demo", "thing.age"), "payload");
+    const applied: string[] = [];
+    const buildPlan = (): ApplyPlan => ({
+      agent: "demo",
+      directives: [
+        defineFileArtifact({
+          vaultName: "thing.age",
+          dryRunLabel: "[dry-run] [demo] would apply thing",
+          apply: async (decrypted) => {
+            applied.push(decrypted);
+          },
+        }),
+      ],
+    });
+    await makeApplyVault(buildPlan)(vaultDir, identity, true, undefined);
+    // dryRun=true must reach runApplyPlan, which skips the apply callback.
+    expect(applied).toEqual([]);
   });
 });

--- a/src/agents/__tests__/_apply.test.ts
+++ b/src/agents/__tests__/_apply.test.ts
@@ -340,6 +340,23 @@ describe("dirWriteApplier", () => {
     expect(existsSync(join(noBackupDir, "d.md.bak"))).toBe(false);
   });
 
+  test("rejects names that would traverse out of the target dir, before any write", async () => {
+    const dir = join(workDir, "guard");
+    const applier = dirWriteApplier({ dir });
+    // `\` is a separator on Windows; `/` on POSIX; `..`/`.`/empty are traversal
+    // primitives; control chars are filesystem-hostile.
+    for (const bad of ["..", ".", "", "a/b.md", "a\\b.md", "\u0000x.md"]) {
+      await expect(applier(bad, "x")).rejects.toThrow(/Unsafe vault entry name/);
+    }
+    expect(existsSync(dir)).toBe(false); // guard runs before mkdir/write
+  });
+
+  test("allows a leading-dot name so dotfile .md entries still round-trip", async () => {
+    const dir = join(workDir, "dotok");
+    await dirWriteApplier({ dir })(".hidden.md", "x");
+    expect(readFileSync(join(dir, ".hidden.md"), "utf8")).toBe("x");
+  });
+
   test("runs validate before any write and aborts on failure", async () => {
     const dir = join(workDir, "validated");
     const applier = dirWriteApplier({

--- a/src/agents/__tests__/_snapshot.test.ts
+++ b/src/agents/__tests__/_snapshot.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { createTmpDir } from "../../test-helpers/fixtures";
+import { collectMarkdownDir, collectSingleFile, collectSkillScopes } from "../_snapshot";
+
+/** Create a qualifying skill directory (real SKILL.md sentinel) under `scope`. */
+function makeSkill(scope: string, name: string, extraFiles: Record<string, string> = {}): void {
+  const dir = join(scope, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), `# ${name}\n`);
+  for (const [rel, content] of Object.entries(extraFiles)) {
+    const p = join(dir, rel);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, content);
+  }
+}
+
+describe("collectMarkdownDir", () => {
+  let tmp: string;
+  beforeEach(async () => {
+    tmp = await createTmpDir();
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("returns [] for a missing directory", async () => {
+    const out = await collectMarkdownDir({
+      dir: join(tmp, "nope"),
+      vaultPath: (n) => `claude/commands/${n}.age`,
+    });
+    expect(out).toEqual([]);
+  });
+
+  test("collects .md files with the built vault path and skips non-.md", async () => {
+    writeFileSync(join(tmp, "review.md"), "# review");
+    writeFileSync(join(tmp, "notes.txt"), "ignore me");
+    const out = await collectMarkdownDir({
+      dir: tmp,
+      vaultPath: (n) => `claude/commands/${n}.age`,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      vaultPath: "claude/commands/review.md.age",
+      sourcePath: join(tmp, "review.md"),
+      plaintext: "# review",
+    });
+  });
+
+  test("honours a custom compound-suffix match predicate", async () => {
+    writeFileSync(join(tmp, "global.instructions.md"), "x");
+    writeFileSync(join(tmp, "plain.md"), "y");
+    const out = await collectMarkdownDir({
+      dir: tmp,
+      vaultPath: (n) => `copilot/instructions/${n}.age`,
+      match: (n) => n.endsWith(".instructions.md"),
+    });
+    expect(out.map((a) => a.vaultPath)).toEqual([
+      "copilot/instructions/global.instructions.md.age",
+    ]);
+  });
+
+  test("skips files matching a never-sync pattern", async () => {
+    // `**/*.local.md` is a never-sync glob; the default `.md` match would
+    // otherwise pick it up.
+    writeFileSync(join(tmp, "secret.local.md"), "do not sync");
+    writeFileSync(join(tmp, "keep.md"), "ok");
+    const out = await collectMarkdownDir({
+      dir: tmp,
+      vaultPath: (n) => `claude/rules/${n}.age`,
+    });
+    expect(out.map((a) => a.vaultPath)).toEqual(["claude/rules/keep.md.age"]);
+  });
+
+  test("rejects a symlinked markdown entry so it cannot smuggle content past the never-sync gate", async () => {
+    // A `commands/evil.md -> <outside>` symlink: readFile would follow it while
+    // shouldNeverSync only sees the link path. The hardened walk must drop it.
+    const secret = join(tmp, "outside-secret.md");
+    writeFileSync(secret, "TOP SECRET");
+    const scan = join(tmp, "scan");
+    mkdirSync(scan, { recursive: true });
+    writeFileSync(join(scan, "real.md"), "real content");
+    symlinkSync(secret, join(scan, "evil.md"));
+    const out = await collectMarkdownDir({
+      dir: scan,
+      vaultPath: (n) => `claude/commands/${n}.age`,
+    });
+    expect(out.map((a) => a.vaultPath)).toEqual(["claude/commands/real.md.age"]);
+  });
+
+  test("skips subdirectories", async () => {
+    mkdirSync(join(tmp, "nested.md"), { recursive: true }); // a directory named like a file
+    writeFileSync(join(tmp, "file.md"), "ok");
+    const out = await collectMarkdownDir({
+      dir: tmp,
+      vaultPath: (n) => `claude/commands/${n}.age`,
+    });
+    expect(out.map((a) => a.vaultPath)).toEqual(["claude/commands/file.md.age"]);
+  });
+});
+
+describe("collectSingleFile", () => {
+  let tmp: string;
+  beforeEach(async () => {
+    tmp = await createTmpDir();
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("returns one artifact when the file exists", async () => {
+    const p = join(tmp, "CLAUDE.md");
+    writeFileSync(p, "# claude");
+    const out = await collectSingleFile({ sourcePath: p, vaultPath: "claude/CLAUDE.md.age" });
+    expect(out).toEqual([
+      { vaultPath: "claude/CLAUDE.md.age", sourcePath: p, plaintext: "# claude", warnings: [] },
+    ]);
+  });
+
+  test("returns [] when the file is absent", async () => {
+    const out = await collectSingleFile({
+      sourcePath: join(tmp, "missing.md"),
+      vaultPath: "claude/CLAUDE.md.age",
+    });
+    expect(out).toEqual([]);
+  });
+});
+
+describe("collectSkillScopes", () => {
+  let tmp: string;
+  beforeEach(async () => {
+    tmp = await createTmpDir();
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  function names(arts: { vaultPath: string }[]): string[] {
+    return arts
+      .map((a) => a.vaultPath.replace(/^codex\/skills\//, "").replace(/\.tar\.age$/, ""))
+      .sort();
+  }
+
+  test("passes a single scope straight through", async () => {
+    const canonical = join(tmp, "canonical");
+    makeSkill(canonical, "alpha");
+    makeSkill(canonical, "beta");
+    const result = await collectSkillScopes("codex", [canonical]);
+    expect(names(result.artifacts)).toEqual(["alpha", "beta"]);
+  });
+
+  test("dedups a legacy scope against the canonical directory listing", async () => {
+    const canonical = join(tmp, "canonical");
+    const legacy = join(tmp, "legacy");
+    makeSkill(canonical, "shared");
+    makeSkill(canonical, "canon-only");
+    makeSkill(legacy, "shared"); // suppressed — canonical owns the name
+    makeSkill(legacy, "legacy-only");
+    const result = await collectSkillScopes("codex", [canonical, legacy]);
+    expect(names(result.artifacts)).toEqual(["canon-only", "legacy-only", "shared"]);
+    // exactly one "shared", and it comes from the canonical scope.
+    const shared = result.artifacts.filter((a) => a.vaultPath === "codex/skills/shared.tar.age");
+    expect(shared).toHaveLength(1);
+    expect(shared[0].sourcePath).toBe(join(canonical, "shared"));
+  });
+
+  test("a name present-but-rejected in canonical still blocks the legacy copy", async () => {
+    const canonical = join(tmp, "canonical");
+    const legacy = join(tmp, "legacy");
+    // canonical "blocked" carries an interior never-sync file, so the walker
+    // emits a warning and NO artifact — but the name is on disk canonically.
+    makeSkill(canonical, "blocked", { "auth.json": "{}" });
+    makeSkill(legacy, "blocked"); // clean, but must stay suppressed
+    const result = await collectSkillScopes("codex", [canonical, legacy]);
+    expect(names(result.artifacts)).toEqual([]);
+    expect(result.warnings.some((w) => w.includes("never-sync"))).toBe(true);
+  });
+
+  test("returns an empty result for no scopes", async () => {
+    expect(await collectSkillScopes("codex", [])).toEqual({ artifacts: [], warnings: [] });
+  });
+});

--- a/src/agents/__tests__/skills-walker.test.ts
+++ b/src/agents/__tests__/skills-walker.test.ts
@@ -6,11 +6,11 @@
  * collectSkillArtifacts, and asserts on the returned shape.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { extractArchive } from "../../core/tar";
 import { createTmpDir } from "../../test-helpers/fixtures";
-import { collectSkillArtifacts } from "../skills-walker";
+import { applySkillArchive, collectSkillArtifacts, InvalidSkillNameError } from "../skills-walker";
 
 describe("collectSkillArtifacts", () => {
   let tmpDir: string;
@@ -297,5 +297,39 @@ describe("collectSkillArtifacts", () => {
     const result = await collectSkillArtifacts("claude", linkedRoot);
     expect(result.artifacts).toHaveLength(0);
     expect(result.warnings).toHaveLength(0);
+  });
+});
+
+describe("applySkillArchive", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("extracts a skill's base64 tar into <root>/<name>/ preserving interior layout", async () => {
+    // Round-trip: build a real skill, snapshot it to a base64 artifact, then
+    // restore it through applySkillArchive into a fresh root.
+    const src = join(tmpDir, "src");
+    const skill = join(src, "my-skill");
+    await mkdir(skill, { recursive: true });
+    await writeFile(join(skill, "SKILL.md"), "# my skill\n");
+    await writeFile(join(skill, "body.md"), "interior\n");
+    const [artifact] = (await collectSkillArtifacts("claude", src)).artifacts;
+
+    const dest = join(tmpDir, "dest");
+    await applySkillArchive(dest, "my-skill", artifact.plaintext);
+    expect(await readFile(join(dest, "my-skill", "SKILL.md"), "utf8")).toBe("# my skill\n");
+    expect(await readFile(join(dest, "my-skill", "body.md"), "utf8")).toBe("interior\n");
+  });
+
+  test("rejects a traversal skill name before touching the filesystem", async () => {
+    await expect(applySkillArchive(join(tmpDir, "dest"), "..", "")).rejects.toBeInstanceOf(
+      InvalidSkillNameError,
+    );
   });
 });

--- a/src/agents/_apply.ts
+++ b/src/agents/_apply.ts
@@ -1,7 +1,10 @@
-import { readdir, readFile } from "node:fs/promises";
+import { mkdir, readdir, readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { log } from "@clack/prompts";
+import type { AgentSyncConfig } from "../config/schema";
 import { decryptString } from "../core/encryptor";
+import { atomicWrite, ensureCommandBackup } from "./_utils";
+import { InvalidSkillNameError, validateSkillName } from "./skills-walker";
 
 /** Read .age (or .tar.age) files from a vault subdirectory, ignoring missing dirs. */
 export async function readAgeFiles(
@@ -152,6 +155,60 @@ export async function runApplyPlan(
  */
 export function defineFileArtifact(d: Omit<FileArtifact, "kind">): FileArtifact {
   return { kind: "file", ...d };
+}
+
+/**
+ * Standard `DirArtifact.filter` for a skills directory: runs `validateSkillName`
+ * and maps `InvalidSkillNameError` to a `{ reason }` skip. Replaces the
+ * identical inline try/catch every skill-bearing adapter used to carry.
+ * Re-throws any non-`InvalidSkillNameError` so genuine bugs are not swallowed.
+ */
+export function skillNameFilter(): NonNullable<DirArtifact["filter"]> {
+  return (name) => {
+    try {
+      validateSkillName(name);
+      return null;
+    } catch (err) {
+      if (err instanceof InvalidSkillNameError) {
+        return { reason: `invalid skill name — ${err.reason}` };
+      }
+      throw err;
+    }
+  };
+}
+
+/**
+ * Build a `DirArtifact.apply` handler that writes one decrypted file into
+ * `dir`: optional name validation, `mkdir -p`, optional `.bak` backup before
+ * overwrite, then `atomicWrite`. `backup` defaults to false; only Claude's
+ * command/agent/rule writes opt in. `validate` runs before any filesystem
+ * touch (Cursor rule names, Copilot agent filenames); it is the pre-write
+ * defence-in-depth guard, independent of the build-plan `filter`, which
+ * rejects bad names earlier, before decryption.
+ */
+export function dirWriteApplier(opts: {
+  dir: string;
+  backup?: boolean;
+  validate?: (name: string) => void;
+}): (name: string, decrypted: string) => Promise<void> {
+  return async (name, decrypted) => {
+    opts.validate?.(name);
+    await mkdir(opts.dir, { recursive: true });
+    const target = join(opts.dir, name);
+    if (opts.backup) await ensureCommandBackup(target);
+    await atomicWrite(target, decrypted);
+  };
+}
+
+/**
+ * The `apply` half of an adapter: decrypt every vault artifact this agent owns
+ * and write it to disk by running its plan. Replaces the one-line
+ * `runApplyPlan(buildXPlan(config), …)` each adapter used to redeclare.
+ */
+export function makeApplyVault(
+  buildPlan: (config?: AgentSyncConfig) => ApplyPlan,
+): (vaultDir: string, key: string, dryRun: boolean, config?: AgentSyncConfig) => Promise<void> {
+  return (vaultDir, key, dryRun, config) => runApplyPlan(buildPlan(config), vaultDir, key, dryRun);
 }
 
 /** No plan directive owns the given vault path (the `copy` command's miss). */

--- a/src/agents/_apply.ts
+++ b/src/agents/_apply.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { log } from "@clack/prompts";
 import type { AgentSyncConfig } from "../config/schema";
@@ -178,13 +178,39 @@ export function skillNameFilter(): NonNullable<DirArtifact["filter"]> {
 }
 
 /**
+ * Reject a vault-derived dir-entry name that could escape the target directory
+ * once joined: empty, `.`/`..`, or any name carrying a path separator (`/`, or
+ * `\` which is a separator on Windows) or control character. This is the
+ * baseline traversal guard every `dirWriteApplier` runs before it writes, so a
+ * crafted vault entry like `..\\..\\evil.md.age` cannot place a file outside the
+ * agent's directory. Leading dots are deliberately allowed: the snapshot walk
+ * round-trips dotfile `.md` entries (`collectMarkdownDir` does not dot-skip), so
+ * rejecting them here would break a legitimate round-trip.
+ */
+function assertSafeDirEntryName(name: string): void {
+  if (name === "" || name === "." || name === "..") {
+    throw new Error(`Unsafe vault entry name: ${JSON.stringify(name)}`);
+  }
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i);
+    if (code < 0x20 || code === 0x2f || code === 0x5c) {
+      throw new Error(`Unsafe vault entry name: ${JSON.stringify(name)}`);
+    }
+  }
+}
+
+/**
  * Build a `DirArtifact.apply` handler that writes one decrypted file into
- * `dir`: optional name validation, `mkdir -p`, optional `.bak` backup before
- * overwrite, then `atomicWrite`. `backup` defaults to false; only Claude's
- * command/agent/rule writes opt in. `validate` runs before any filesystem
- * touch (Cursor rule names, Copilot agent filenames); it is the pre-write
- * defence-in-depth guard, independent of the build-plan `filter`, which
- * rejects bad names earlier, before decryption.
+ * `dir`: optional per-adapter name validation, then the baseline traversal
+ * guard, optional `.bak` backup before overwrite, then `atomicWrite` (which
+ * creates `dir` on demand). `backup` defaults to false; only Claude's
+ * command/agent/rule writes opt in. The stricter per-adapter `validate` (Cursor
+ * rule names, Copilot agent filenames) runs first so its message wins, but
+ * `assertSafeDirEntryName` always runs as the universal backstop — it catches
+ * what a per-adapter check misses, e.g. a Windows `\` separator that POSIX
+ * `basename` treats as a literal character. Both run before any filesystem
+ * touch, and both are independent of the build-plan `filter`, which rejects bad
+ * names even earlier, before decryption.
  */
 export function dirWriteApplier(opts: {
   dir: string;
@@ -193,7 +219,7 @@ export function dirWriteApplier(opts: {
 }): (name: string, decrypted: string) => Promise<void> {
   return async (name, decrypted) => {
     opts.validate?.(name);
-    await mkdir(opts.dir, { recursive: true });
+    assertSafeDirEntryName(name);
     const target = join(opts.dir, name);
     if (opts.backup) await ensureCommandBackup(target);
     await atomicWrite(target, decrypted);

--- a/src/agents/_snapshot.ts
+++ b/src/agents/_snapshot.ts
@@ -1,0 +1,132 @@
+/**
+ * src/agents/_snapshot.ts
+ *
+ * Snapshot-side toolkit shared by every agent adapter. These verbs replace the
+ * walk/collect fragments that were copy-pasted across the five adapters so a
+ * cross-cutting rule (symlink hardening, the never-sync gate, the artifact
+ * shape) lives in exactly one place. Per-adapter variation is passed in as a
+ * parameter (match predicate, vault-path builder, scope list), never branched
+ * on the agent name.
+ */
+
+import type { Dirent } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { shouldNeverSync } from "../core/sanitizer";
+import { readIfExists, type SnapshotArtifact, type SnapshotResult } from "./_utils";
+import { collectSkillArtifacts, type SkillBearingAgent } from "./skills-walker";
+
+/**
+ * Walk one flat directory and return a plaintext SnapshotArtifact per
+ * qualifying file. Hardened by construction: `withFileTypes` + reject any entry
+ * that is not a real file (so a symlinked `commands/evil.md -> /etc/passwd`
+ * cannot smuggle arbitrary content through `readFile`, which follows symlinks
+ * while `shouldNeverSync` only ever sees the link path). The per-file
+ * `shouldNeverSync` gate and silent skip on a missing directory or unreadable
+ * entry are preserved. There is deliberately no symlink-follow opt-out — the
+ * hardening is structural, not a flag.
+ *
+ * @param dir        absolute source directory on the local machine
+ * @param vaultPath  builds the vault path from the bare file name,
+ *                   e.g. `(n) => `claude/commands/${n}.age``
+ * @param match      filename predicate; default `(n) => n.endsWith(".md")`
+ */
+export async function collectMarkdownDir(opts: {
+  dir: string;
+  vaultPath: (fileName: string) => string;
+  match?: (fileName: string) => boolean;
+}): Promise<SnapshotArtifact[]> {
+  const match = opts.match ?? ((name: string) => name.endsWith(".md"));
+  const artifacts: SnapshotArtifact[] = [];
+
+  let entries: Dirent[];
+  try {
+    entries = await readdir(opts.dir, { withFileTypes: true });
+  } catch {
+    return artifacts; // dir may not exist yet.
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile() || entry.isSymbolicLink()) continue;
+    const name = entry.name;
+    if (!match(name)) continue;
+    const sourcePath = join(opts.dir, name);
+    if (shouldNeverSync(sourcePath)) continue;
+    let content: string;
+    try {
+      content = await readFile(sourcePath, "utf8");
+    } catch {
+      continue; // unreadable entry — skip silently.
+    }
+    artifacts.push({
+      vaultPath: opts.vaultPath(name),
+      sourcePath,
+      plaintext: content,
+      warnings: [],
+    });
+  }
+
+  return artifacts;
+}
+
+/**
+ * Collect one optional, verbatim single file. Returns `[]` when absent. Only
+ * for files stored as-is — adapters that sanitise or normalise a single file
+ * (claude hooks/mcp, codex config, cursor rules/mcp) keep using `collect(...)`.
+ */
+export async function collectSingleFile(opts: {
+  sourcePath: string;
+  vaultPath: string;
+}): Promise<SnapshotArtifact[]> {
+  const content = await readIfExists(opts.sourcePath);
+  if (content === null) return [];
+  return [
+    { vaultPath: opts.vaultPath, sourcePath: opts.sourcePath, plaintext: content, warnings: [] },
+  ];
+}
+
+/**
+ * Collect skills across one or more scope directories. `scopes[0]` is the
+ * canonical write target; any later scope is deduplicated against the canonical
+ * directory's on-disk listing — so a skill present canonically suppresses the
+ * same-named copy in a legacy scope even when the canonical scan rejected it
+ * (never-sync hit, literal secret) and emitted no artifact. Single-scope
+ * callers pass one entry and get a plain `collectSkillArtifacts` pass-through.
+ */
+export async function collectSkillScopes(
+  agent: SkillBearingAgent,
+  scopes: readonly string[],
+): Promise<SnapshotResult> {
+  const artifacts: SnapshotArtifact[] = [];
+  const warnings: string[] = [];
+  if (scopes.length === 0) return { artifacts, warnings };
+
+  const [canonical, ...rest] = scopes;
+  const canonicalResult = await collectSkillArtifacts(agent, canonical);
+  artifacts.push(...canonicalResult.artifacts);
+  warnings.push(...canonicalResult.warnings);
+  if (rest.length === 0) return { artifacts, warnings };
+
+  // Dedup key set comes from the canonical directory listing, not the emitted
+  // artifacts, so a rejected canonical skill still blocks the legacy copy.
+  let canonicalNames: string[] = [];
+  try {
+    canonicalNames = await readdir(canonical);
+  } catch {
+    // canonical dir may not exist; nothing to dedup against.
+  }
+  const seen = new Set(canonicalNames.filter((n) => !n.startsWith(".")));
+  const prefix = `${agent}/skills/`;
+
+  for (const scope of rest) {
+    const result = await collectSkillArtifacts(agent, scope);
+    warnings.push(...result.warnings);
+    for (const artifact of result.artifacts) {
+      const name = artifact.vaultPath.slice(prefix.length).replace(/\.tar\.age$/, "");
+      if (seen.has(name)) continue;
+      artifacts.push(artifact);
+    }
+  }
+
+  return { artifacts, warnings };
+}

--- a/src/agents/claude/index.ts
+++ b/src/agents/claude/index.ts
@@ -1,21 +1,24 @@
-import { mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
 import { denormalizeFromVault } from "../../core/path-portability";
-import { shouldNeverSync } from "../../core/sanitizer";
-import { extractArchive } from "../../core/tar";
+import {
+  type ApplyPlan,
+  defineFileArtifact,
+  dirWriteApplier,
+  makeApplyVault,
+  skillNameFilter,
+} from "../_apply";
+import { collectMarkdownDir, collectSingleFile } from "../_snapshot";
 import {
   atomicWrite,
   collect,
-  ensureCommandBackup,
   readIfExists,
   type SnapshotArtifact,
   type SnapshotResult,
   setJsoncTopLevelKey,
 } from "../_utils";
-import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "../skills-walker";
+import { applySkillArchive, collectSkillArtifacts } from "../skills-walker";
 import { buildPluginManifest, serializeManifest } from "./plugin-manifest";
 import { sanitizeClaudeHooks, sanitizeClaudeMcp } from "./sanitize";
 
@@ -28,15 +31,12 @@ export async function snapshotClaude(config: AgentSyncConfig): Promise<SnapshotR
   const artifacts: SnapshotArtifact[] = [];
   const warnings: string[] = [];
 
-  const claudeMd = await readIfExists(AgentPaths.claude.claudeMd);
-  if (claudeMd !== null) {
-    artifacts.push({
-      vaultPath: "claude/CLAUDE.md.age",
+  artifacts.push(
+    ...(await collectSingleFile({
       sourcePath: AgentPaths.claude.claudeMd,
-      plaintext: claudeMd,
-      warnings: [],
-    });
-  }
+      vaultPath: "claude/CLAUDE.md.age",
+    })),
+  );
 
   const settingsJson = await readIfExists(AgentPaths.claude.settingsJson);
   if (settingsJson !== null) {
@@ -54,87 +54,30 @@ export async function snapshotClaude(config: AgentSyncConfig): Promise<SnapshotR
     warnings.push(...mcp.warnings);
   }
 
-  try {
-    const names = await readdir(AgentPaths.claude.commandsDir);
-    for (const name of names) {
-      if (!name.endsWith(".md")) continue;
-      const sourcePath = join(AgentPaths.claude.commandsDir, name);
-      if (shouldNeverSync(sourcePath)) continue;
-      let content: string;
-      try {
-        content = await readFile(sourcePath, "utf8");
-      } catch {
-        continue; // skip directories or unreadable entries
-      }
-      artifacts.push({
-        vaultPath: `claude/commands/${name}.age`,
-        sourcePath,
-        plaintext: content,
-        warnings: [],
-      });
-    }
-  } catch {
-    // commands dir may not exist yet.
-  }
+  artifacts.push(
+    ...(await collectMarkdownDir({
+      dir: AgentPaths.claude.commandsDir,
+      vaultPath: (name) => `claude/commands/${name}.age`,
+    })),
+    ...(await collectMarkdownDir({
+      dir: AgentPaths.claude.agentsDir,
+      vaultPath: (name) => `claude/agents/${name}.age`,
+    })),
+    // Rules at ~/.claude/rules/*.md are referenced from CLAUDE.md via include
+    // directives, so they must travel with the config or the includes break on
+    // the destination machine. collectMarkdownDir rejects symlinked entries so a
+    // `rules/secret.md -> /etc/passwd` link cannot smuggle content past
+    // shouldNeverSync (readFile would follow the link; the gate only sees it).
+    ...(await collectMarkdownDir({
+      dir: AgentPaths.claude.rulesDir,
+      vaultPath: (name) => `claude/rules/${name}.age`,
+    })),
+  );
 
-  try {
-    const names = await readdir(AgentPaths.claude.agentsDir);
-    for (const name of names) {
-      if (!name.endsWith(".md")) continue;
-      const sourcePath = join(AgentPaths.claude.agentsDir, name);
-      if (shouldNeverSync(sourcePath)) continue;
-      let content: string;
-      try {
-        content = await readFile(sourcePath, "utf8");
-      } catch {
-        continue; // skip directories or unreadable entries
-      }
-      artifacts.push({
-        vaultPath: `claude/agents/${name}.age`,
-        sourcePath,
-        plaintext: content,
-        warnings: [],
-      });
-    }
-  } catch {
-    // agents dir may not exist yet.
-  }
-
-  // Rules markdown at ~/.claude/rules/*.md is referenced from CLAUDE.md via
-  // include directives, so the files must travel with the agent config or the
-  // includes break on the destination machine. Use withFileTypes + symlink
-  // rejection so a `rules/secret.md → /etc/passwd` symlink can't smuggle
-  // arbitrary file content into the encrypted vault — readFile would follow
-  // it and shouldNeverSync only sees the symlink path.
-  try {
-    const entries = await readdir(AgentPaths.claude.rulesDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isFile() || entry.isSymbolicLink()) continue;
-      const name = entry.name;
-      if (!name.endsWith(".md")) continue;
-      const sourcePath = join(AgentPaths.claude.rulesDir, name);
-      if (shouldNeverSync(sourcePath)) continue;
-      let content: string;
-      try {
-        content = await readFile(sourcePath, "utf8");
-      } catch {
-        continue;
-      }
-      artifacts.push({
-        vaultPath: `claude/rules/${name}.age`,
-        sourcePath,
-        plaintext: content,
-        warnings: [],
-      });
-    }
-  } catch {
-    // rules dir may not exist yet.
-  }
-
-  // Skills — delegated to the shared walker.
-  // The walker handles dot-skip, symlink rejection, sentinel verification, the
-  // never-sync interior scan, and the symlink-filtered tar archival in one
-  // place so every skill-bearing agent inherits identical rules.
+  // Skills — delegated to the shared walker. The walker handles dot-skip,
+  // symlink rejection, sentinel verification, the never-sync interior scan, and
+  // the symlink-filtered tar archival in one place so every skill-bearing agent
+  // inherits identical rules.
   const claudeSkills = await collectSkillArtifacts("claude", AgentPaths.claude.skillsDir);
   artifacts.push(...claudeSkills.artifacts);
   warnings.push(...claudeSkills.warnings);
@@ -168,23 +111,16 @@ export async function snapshotClaude(config: AgentSyncConfig): Promise<SnapshotR
   return { artifacts, warnings };
 }
 
+// ─── Apply (pull side) ────────────────────────────────────────────────────────
+
 /**
- * Restore one Claude skill directory from the vault by extracting its
- * encrypted tar archive into `~/.claude/skills/<name>/`.
- *
- * Mirrors {@link applyCopilotSkill}: parents are created on demand and the
- * tar's interior layout is preserved bit-for-bit.
- *
- * @param skillName  Basename of the skill (no extension).
- * @param base64Tar  Base64-encoded `.tar.gz` payload that the walker
- *                   produced on the source machine.
+ * Restore one Claude skill directory from the vault by extracting its encrypted
+ * tar archive into `~/.claude/skills/<name>/`. Thin wrapper over
+ * {@link applySkillArchive}, which validates the name and preserves the tar's
+ * interior layout bit-for-bit.
  */
 export async function applyClaudeSkill(skillName: string, base64Tar: string): Promise<void> {
-  validateSkillName(skillName);
-  const targetDir = join(AgentPaths.claude.skillsDir, skillName);
-  await mkdir(targetDir, { recursive: true });
-  const tarBuffer = Buffer.from(base64Tar, "base64");
-  await extractArchive(tarBuffer, targetDir);
+  await applySkillArchive(AgentPaths.claude.skillsDir, skillName, base64Tar);
 }
 
 /** Restore the shared CLAUDE.md prompt file from the vault. */
@@ -225,40 +161,31 @@ export async function applyClaudeMcp(claudeJsonContent: string): Promise<void> {
 }
 
 /** Restore one Claude command markdown file from the vault. */
-export async function applyClaudeCommand(commandName: string, content: string): Promise<void> {
-  const target = join(AgentPaths.claude.commandsDir, commandName);
-  await mkdir(AgentPaths.claude.commandsDir, { recursive: true });
-  await ensureCommandBackup(target);
-  await atomicWrite(target, content);
+export function applyClaudeCommand(commandName: string, content: string): Promise<void> {
+  return dirWriteApplier({ dir: AgentPaths.claude.commandsDir, backup: true })(
+    commandName,
+    content,
+  );
 }
 
 /** Restore one Claude agent definition markdown file from the vault. */
-export async function applyClaudeAgent(agentName: string, content: string): Promise<void> {
-  const target = join(AgentPaths.claude.agentsDir, agentName);
-  await mkdir(AgentPaths.claude.agentsDir, { recursive: true });
-  await ensureCommandBackup(target);
-  await atomicWrite(target, content);
+export function applyClaudeAgent(agentName: string, content: string): Promise<void> {
+  return dirWriteApplier({ dir: AgentPaths.claude.agentsDir, backup: true })(agentName, content);
 }
 
 /** Restore one Claude rule markdown file from the vault. */
-export async function applyClaudeRule(ruleName: string, content: string): Promise<void> {
-  const target = join(AgentPaths.claude.rulesDir, ruleName);
-  await mkdir(AgentPaths.claude.rulesDir, { recursive: true });
-  await ensureCommandBackup(target);
-  await atomicWrite(target, content);
+export function applyClaudeRule(ruleName: string, content: string): Promise<void> {
+  return dirWriteApplier({ dir: AgentPaths.claude.rulesDir, backup: true })(ruleName, content);
 }
-
-// ─── Apply (pull side) ────────────────────────────────────────────────────────
-
-import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
 
 /**
  * Build the Claude apply plan. Exposed so `copy` can apply a single artifact.
  * Note: `claude/plugins.manifest.json.age` is deliberately NOT a directive —
  * the manifest drives `agentsync plugin install`, it is never written to disk
- * on pull. `_config` is unused now that nothing in the plan gates on it.
+ * on pull. `_config` is unused now that nothing in the plan gates on it; the
+ * param is kept to satisfy the shared `AgentDefinition.buildPlan` contract.
  */
-export function buildClaudePlan(_config: AgentSyncConfig): ApplyPlan {
+export function buildClaudePlan(_config?: AgentSyncConfig): ApplyPlan {
   return {
     agent: "claude",
     directives: [
@@ -304,28 +231,11 @@ export function buildClaudePlan(_config: AgentSyncConfig): ApplyPlan {
         suffix: ".tar.age",
         dryRunVerb: "would extract skill:",
         apply: applyClaudeSkill,
-        filter: (name) => {
-          try {
-            validateSkillName(name);
-            return null;
-          } catch (err) {
-            if (err instanceof InvalidSkillNameError) {
-              return { reason: `invalid skill name — ${err.reason}` };
-            }
-            throw err;
-          }
-        },
+        filter: skillNameFilter(),
       },
     ],
   };
 }
 
 /** Decrypt and apply all Claude vault artifacts to the local machine. */
-export async function applyClaudeVault(
-  vaultDir: string,
-  key: string,
-  dryRun: boolean,
-  config: AgentSyncConfig,
-): Promise<void> {
-  await runApplyPlan(buildClaudePlan(config), vaultDir, key, dryRun);
-}
+export const applyClaudeVault = makeApplyVault(buildClaudePlan);

--- a/src/agents/codex/index.ts
+++ b/src/agents/codex/index.ts
@@ -1,12 +1,17 @@
-import { mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
 import * as TOML from "@iarna/toml";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
 import { denormalizeFromVault, normalizeForVault } from "../../core/path-portability";
-import { type RedactionResult, redactSecretLiterals, shouldNeverSync } from "../../core/sanitizer";
-import { extractArchive } from "../../core/tar";
+import { type RedactionResult, redactSecretLiterals } from "../../core/sanitizer";
+import {
+  type ApplyPlan,
+  defineFileArtifact,
+  dirWriteApplier,
+  makeApplyVault,
+  skillNameFilter,
+} from "../_apply";
+import { collectMarkdownDir, collectSingleFile, collectSkillScopes } from "../_snapshot";
 import {
   atomicWrite,
   collect,
@@ -14,7 +19,7 @@ import {
   type SnapshotArtifact,
   type SnapshotResult,
 } from "../_utils";
-import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "../skills-walker";
+import { applySkillArchive } from "../skills-walker";
 
 /** Snapshot payload for the Codex adapter. */
 export type CodexSnapshotResult = SnapshotResult;
@@ -49,27 +54,18 @@ export async function snapshotCodex(_config?: AgentSyncConfig): Promise<Snapshot
   const artifacts: SnapshotArtifact[] = [];
   const warnings: string[] = [];
 
-  const agentsMd = await readIfExists(AgentPaths.codex.agentsMd);
-  if (agentsMd !== null) {
-    artifacts.push({
-      vaultPath: "codex/AGENTS.md.age",
+  artifacts.push(
+    ...(await collectSingleFile({
       sourcePath: AgentPaths.codex.agentsMd,
-      plaintext: agentsMd,
-      warnings: [],
-    });
-  }
-
-  // AGENTS.override.md wins over AGENTS.md when codex reads the pair; sync
-  // both so the override semantics are preserved on the destination machine.
-  const agentsOverrideMd = await readIfExists(AgentPaths.codex.agentsOverrideMd);
-  if (agentsOverrideMd !== null) {
-    artifacts.push({
-      vaultPath: "codex/AGENTS.override.md.age",
+      vaultPath: "codex/AGENTS.md.age",
+    })),
+    // AGENTS.override.md wins over AGENTS.md when codex reads the pair; sync
+    // both so the override semantics are preserved on the destination machine.
+    ...(await collectSingleFile({
       sourcePath: AgentPaths.codex.agentsOverrideMd,
-      plaintext: agentsOverrideMd,
-      warnings: [],
-    });
-  }
+      vaultPath: "codex/AGENTS.override.md.age",
+    })),
+  );
 
   const configToml = await readIfExists(AgentPaths.codex.configToml);
   if (configToml !== null) {
@@ -78,60 +74,30 @@ export async function snapshotCodex(_config?: AgentSyncConfig): Promise<Snapshot
     warnings.push(...sanitized.warnings);
   }
 
-  try {
-    const names = await readdir(AgentPaths.codex.rulesDir);
-    for (const name of names) {
-      if (!name.endsWith(".md")) continue;
-      const sourcePath = join(AgentPaths.codex.rulesDir, name);
-      if (shouldNeverSync(sourcePath)) continue;
-      let content: string;
-      try {
-        content = await readFile(sourcePath, "utf8");
-      } catch {
-        continue; // skip directories or unreadable entries
-      }
-      artifacts.push({
-        vaultPath: `codex/rules/${name}.age`,
-        sourcePath,
-        plaintext: content,
-        warnings: [],
-      });
-    }
-  } catch {
-    // rules dir may not exist yet
-  }
+  artifacts.push(
+    ...(await collectMarkdownDir({
+      dir: AgentPaths.codex.rulesDir,
+      vaultPath: (name) => `codex/rules/${name}.age`,
+    })),
+  );
 
   // Skills — canonical USER scope is $HOME/.agents/skills per the Codex Skills
   // docs; the legacy $CODEX_HOME/.codex/skills path stays readable so prior
-  // installs migrate forward on the next pull. Deduplication keys come from
-  // the canonical directory listing rather than emitted artifacts so a skill
-  // the walker REJECTED at the canonical location (never-sync hit, literal
-  // secret) still blocks the legacy copy from leaking through.
-  let canonicalNames: string[] = [];
-  try {
-    canonicalNames = await readdir(AgentPaths.codex.userSkillsDir);
-  } catch {
-    // canonical dir may not exist yet
-  }
-  const seen = new Set(canonicalNames.filter((n) => !n.startsWith(".")));
-
-  const userSkills = await collectSkillArtifacts("codex", AgentPaths.codex.userSkillsDir);
-  const legacySkills = await collectSkillArtifacts("codex", AgentPaths.codex.skillsDir);
-  artifacts.push(...userSkills.artifacts);
-  for (const artifact of legacySkills.artifacts) {
-    // vaultPath is `codex/skills/<name>.tar.age` — extract `<name>` and skip
-    // when the canonical directory already carries the name (regardless of
-    // whether the canonical scan emitted an artifact).
-    const legacyName = artifact.vaultPath
-      .replace(/^codex\/skills\//, "")
-      .replace(/\.tar\.age$/, "");
-    if (seen.has(legacyName)) continue;
-    artifacts.push(artifact);
-  }
-  warnings.push(...userSkills.warnings, ...legacySkills.warnings);
+  // installs migrate forward on the next pull. collectSkillScopes dedups the
+  // legacy scope against the canonical directory listing, so a skill the walker
+  // REJECTED at the canonical location (never-sync hit, literal secret) still
+  // blocks the legacy copy from leaking through.
+  const skills = await collectSkillScopes("codex", [
+    AgentPaths.codex.userSkillsDir,
+    AgentPaths.codex.skillsDir,
+  ]);
+  artifacts.push(...skills.artifacts);
+  warnings.push(...skills.warnings);
 
   return { artifacts, warnings };
 }
+
+// ─── Apply (pull side) ────────────────────────────────────────────────────────
 
 /** Restore the top-level Codex AGENTS.md file from the vault. */
 export async function applyCodexAgentsMd(content: string): Promise<void> {
@@ -173,37 +139,19 @@ export async function applyCodexConfig(content: string): Promise<void> {
 }
 
 /** Restore one Codex rule markdown file from the vault. */
-export async function applyCodexRule(ruleName: string, content: string): Promise<void> {
-  const target = join(AgentPaths.codex.rulesDir, ruleName);
-  await mkdir(AgentPaths.codex.rulesDir, { recursive: true });
-  await atomicWrite(target, content);
+export function applyCodexRule(ruleName: string, content: string): Promise<void> {
+  return dirWriteApplier({ dir: AgentPaths.codex.rulesDir })(ruleName, content);
 }
 
 /**
- * Restore one Codex skill directory from the vault by extracting its
- * encrypted tar archive into `~/.codex/skills/<name>/`.
- *
- * Mirrors {@link applyClaudeSkill}: parents are created on demand and the
- * tar's interior layout is preserved bit-for-bit.
- *
- * @param skillName  Basename of the skill (no extension).
- * @param base64Tar  Base64-encoded `.tar.gz` payload that the walker
- *                   produced on the source machine.
+ * Restore one Codex skill directory from the vault. Always restores under
+ * $HOME/.agents/skills — the canonical Codex USER scope. Legacy
+ * $CODEX_HOME/.codex/skills remains readable on snapshot but is never a write
+ * target, so pulls migrate forward in place without leaving stragglers.
  */
 export async function applyCodexSkill(skillName: string, base64Tar: string): Promise<void> {
-  validateSkillName(skillName);
-  // Always restore under $HOME/.agents/skills — the canonical Codex USER scope.
-  // Legacy $CODEX_HOME/.codex/skills remains readable on snapshot but is never
-  // a write target, so pulls migrate forward in place without leaving stragglers.
-  const targetDir = join(AgentPaths.codex.userSkillsDir, skillName);
-  await mkdir(targetDir, { recursive: true });
-  const tarBuffer = Buffer.from(base64Tar, "base64");
-  await extractArchive(tarBuffer, targetDir);
+  await applySkillArchive(AgentPaths.codex.userSkillsDir, skillName, base64Tar);
 }
-
-// ─── Apply (pull side) ────────────────────────────────────────────────────────
-
-import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
 
 /** Build the Codex apply plan. Exposed so `copy` can apply a single artifact. */
 export function buildCodexPlan(_config?: AgentSyncConfig): ApplyPlan {
@@ -238,28 +186,11 @@ export function buildCodexPlan(_config?: AgentSyncConfig): ApplyPlan {
         suffix: ".tar.age",
         dryRunVerb: "would extract skill:",
         apply: applyCodexSkill,
-        filter: (name) => {
-          try {
-            validateSkillName(name);
-            return null;
-          } catch (err) {
-            if (err instanceof InvalidSkillNameError) {
-              return { reason: `invalid skill name — ${err.reason}` };
-            }
-            throw err;
-          }
-        },
+        filter: skillNameFilter(),
       },
     ],
   };
 }
 
 /** Decrypt and apply all Codex vault artifacts to the local machine. */
-export async function applyCodexVault(
-  vaultDir: string,
-  key: string,
-  dryRun: boolean,
-  config?: AgentSyncConfig,
-): Promise<void> {
-  await runApplyPlan(buildCodexPlan(config), vaultDir, key, dryRun);
-}
+export const applyCodexVault = makeApplyVault(buildCodexPlan);

--- a/src/agents/copilot/index.ts
+++ b/src/agents/copilot/index.ts
@@ -1,11 +1,17 @@
-import { mkdir, readdir } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { mkdir } from "node:fs/promises";
+import { basename, dirname } from "node:path";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
-import { shouldNeverSync } from "../../core/sanitizer";
-import { extractArchive } from "../../core/tar";
+import {
+  type ApplyPlan,
+  defineFileArtifact,
+  dirWriteApplier,
+  makeApplyVault,
+  skillNameFilter,
+} from "../_apply";
+import { collectMarkdownDir, collectSingleFile } from "../_snapshot";
 import { atomicWrite, readIfExists, type SnapshotArtifact, type SnapshotResult } from "../_utils";
-import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "../skills-walker";
+import { applySkillArchive, collectSkillArtifacts } from "../skills-walker";
 
 /**
  * Reject Copilot agent filenames that could escape `agentsDir`, smuggle in
@@ -34,102 +40,53 @@ export async function snapshotCopilot(_config?: AgentSyncConfig): Promise<Snapsh
   const artifacts: SnapshotArtifact[] = [];
   const warnings: string[] = [];
 
-  // Single instructions file (may or may not have extension)
-  const instructionsFile = await readIfExists(AgentPaths.copilot.instructionsFile);
-  if (instructionsFile !== null) {
-    artifacts.push({
-      vaultPath: "copilot/instructions.md.age",
+  artifacts.push(
+    // Single instructions entry point.
+    ...(await collectSingleFile({
       sourcePath: AgentPaths.copilot.instructionsFile,
-      plaintext: instructionsFile,
-      warnings: [],
-    });
-  }
+      vaultPath: "copilot/instructions.md.age",
+    })),
+    // Instructions directory *.instructions.md
+    ...(await collectMarkdownDir({
+      dir: AgentPaths.copilot.instructionsDir,
+      vaultPath: (name) => `copilot/instructions/${name}.age`,
+      match: (name) => name.endsWith(".instructions.md"),
+    })),
+    // Prompts *.prompt.md
+    ...(await collectMarkdownDir({
+      dir: AgentPaths.copilot.promptsDir,
+      vaultPath: (name) => `copilot/prompts/${name}.age`,
+      match: (name) => name.endsWith(".prompt.md"),
+    })),
+    // Copilot agents live as single `<name>.agent.md` files per the GitHub docs.
+    // collectMarkdownDir rejects dotfiles, non-files, and symlinked entries
+    // (readFile follows symlinks, so a `foo.agent.md -> /etc/passwd` link would
+    // otherwise smuggle content into the vault); the match predicate enforces
+    // the `.agent.md` suffix and the traversal/NUL rules.
+    ...(await collectMarkdownDir({
+      dir: AgentPaths.copilot.agentsDir,
+      vaultPath: (name) => `copilot/agents/${name}.age`,
+      match: (name) => {
+        try {
+          validateCopilotAgentFileName(name);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    })),
+  );
 
-  // Instructions directory *.instructions.md
-  try {
-    const names = await readdir(AgentPaths.copilot.instructionsDir);
-    for (const name of names) {
-      if (!name.endsWith(".instructions.md")) continue;
-      const sourcePath = join(AgentPaths.copilot.instructionsDir, name);
-      if (shouldNeverSync(sourcePath)) continue;
-      const content = await readIfExists(sourcePath);
-      if (content !== null) {
-        artifacts.push({
-          vaultPath: `copilot/instructions/${name}.age`,
-          sourcePath,
-          plaintext: content,
-          warnings: [],
-        });
-      }
-    }
-  } catch {
-    // directory may not exist
-  }
-
-  // Prompts *.prompt.md
-  try {
-    const names = await readdir(AgentPaths.copilot.promptsDir);
-    for (const name of names) {
-      if (!name.endsWith(".prompt.md")) continue;
-      const sourcePath = join(AgentPaths.copilot.promptsDir, name);
-      if (shouldNeverSync(sourcePath)) continue;
-      const content = await readIfExists(sourcePath);
-      if (content !== null) {
-        artifacts.push({
-          vaultPath: `copilot/prompts/${name}.age`,
-          sourcePath,
-          plaintext: content,
-          warnings: [],
-        });
-      }
-    }
-  } catch {
-    // directory may not exist
-  }
-
-  // Skills — delegated to the shared walker so dot-skip, symlink rejection,
-  // sentinel verification, never-sync interior scan, and symlink-filtered
-  // archival stay identical across every skill-bearing agent. The walker
-  // uses lstat throughout, so symlinked roots and symlinked SKILL.md
-  // sentinels (the vendored-pool pattern seen on real machines) are skipped.
+  // Skills — delegated to the shared walker (dot-skip, symlink rejection,
+  // sentinel verification, never-sync interior scan, symlink-filtered archival).
   const copilotSkills = await collectSkillArtifacts("copilot", AgentPaths.copilot.skillsDir);
   artifacts.push(...copilotSkills.artifacts);
   warnings.push(...copilotSkills.warnings);
 
-  // Copilot agents live as single `<name>.agent.md` files per the GitHub docs.
-  // The walker rejects dotfiles, traversal segments, and symlinked entries
-  // (readFile follows symlinks, so a `foo.agent.md → /etc/passwd` symlink
-  // would otherwise smuggle arbitrary content into the encrypted vault).
-  // Markdown bodies are scanned for embedded literal secrets by the central
-  // walker in `commands/push.ts`.
-  try {
-    const entries = await readdir(AgentPaths.copilot.agentsDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isFile() || entry.isSymbolicLink()) continue;
-      const name = entry.name;
-      try {
-        validateCopilotAgentFileName(name);
-      } catch {
-        continue;
-      }
-      const sourcePath = join(AgentPaths.copilot.agentsDir, name);
-      if (shouldNeverSync(sourcePath)) continue;
-      const content = await readIfExists(sourcePath);
-      if (content !== null) {
-        artifacts.push({
-          vaultPath: `copilot/agents/${name}.age`,
-          sourcePath,
-          plaintext: content,
-          warnings: [],
-        });
-      }
-    }
-  } catch {
-    // agents dir may not exist
-  }
-
   return { artifacts, warnings };
 }
+
+// ─── Apply (pull side) ────────────────────────────────────────────────────────
 
 /** Restore the legacy single-file Copilot instructions entry point. */
 export async function applyCopilotInstructions(content: string): Promise<void> {
@@ -137,20 +94,13 @@ export async function applyCopilotInstructions(content: string): Promise<void> {
 }
 
 /** Restore one Copilot instruction file from the vault. */
-export async function applyCopilotInstructionFile(
-  fileName: string,
-  content: string,
-): Promise<void> {
-  const target = join(AgentPaths.copilot.instructionsDir, fileName);
-  await mkdir(AgentPaths.copilot.instructionsDir, { recursive: true });
-  await atomicWrite(target, content);
+export function applyCopilotInstructionFile(fileName: string, content: string): Promise<void> {
+  return dirWriteApplier({ dir: AgentPaths.copilot.instructionsDir })(fileName, content);
 }
 
 /** Restore one Copilot prompt file from the vault. */
-export async function applyCopilotPrompt(fileName: string, content: string): Promise<void> {
-  const target = join(AgentPaths.copilot.promptsDir, fileName);
-  await mkdir(AgentPaths.copilot.promptsDir, { recursive: true });
-  await atomicWrite(target, content);
+export function applyCopilotPrompt(fileName: string, content: string): Promise<void> {
+  return dirWriteApplier({ dir: AgentPaths.copilot.promptsDir })(fileName, content);
 }
 
 /**
@@ -177,24 +127,16 @@ export async function applyCopilotMcp(mcpJsonContent: string): Promise<void> {
 
 /** Extract one archived Copilot skill directory into the local skills folder. */
 export async function applyCopilotSkill(skillName: string, base64Tar: string): Promise<void> {
-  validateSkillName(skillName);
-  const targetDir = join(AgentPaths.copilot.skillsDir, skillName);
-  await mkdir(targetDir, { recursive: true });
-  const tarBuffer = Buffer.from(base64Tar, "base64");
-  await extractArchive(tarBuffer, targetDir);
+  await applySkillArchive(AgentPaths.copilot.skillsDir, skillName, base64Tar);
 }
 
 /** Restore one Copilot `<name>.agent.md` single-file agent from the vault. */
-export async function applyCopilotAgent(fileName: string, content: string): Promise<void> {
-  validateCopilotAgentFileName(fileName);
-  const target = join(AgentPaths.copilot.agentsDir, fileName);
-  await mkdir(AgentPaths.copilot.agentsDir, { recursive: true });
-  await atomicWrite(target, content);
+export function applyCopilotAgent(fileName: string, content: string): Promise<void> {
+  return dirWriteApplier({
+    dir: AgentPaths.copilot.agentsDir,
+    validate: validateCopilotAgentFileName,
+  })(fileName, content);
 }
-
-// ─── Apply (pull side) ────────────────────────────────────────────────────────
-
-import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
 
 /** Build the Copilot apply plan. Exposed so `copy` can apply a single artifact. */
 export function buildCopilotPlan(_config?: AgentSyncConfig): ApplyPlan {
@@ -228,17 +170,7 @@ export function buildCopilotPlan(_config?: AgentSyncConfig): ApplyPlan {
         suffix: ".tar.age",
         dryRunVerb: "would extract skill:",
         apply: applyCopilotSkill,
-        filter: (name) => {
-          try {
-            validateSkillName(name);
-            return null;
-          } catch (err) {
-            if (err instanceof InvalidSkillNameError) {
-              return { reason: `invalid skill name — ${err.reason}` };
-            }
-            throw err;
-          }
-        },
+        filter: skillNameFilter(),
       },
       {
         kind: "dir",
@@ -247,6 +179,9 @@ export function buildCopilotPlan(_config?: AgentSyncConfig): ApplyPlan {
         match: (name) => name.endsWith(".agent.md.age"),
         dryRunVerb: "would write agent:",
         apply: applyCopilotAgent,
+        // NOT skillNameFilter(): copilot agent filenames have their own rule
+        // (.agent.md suffix) and validateCopilotAgentFileName throws a plain
+        // Error, so map any failure to a fixed reason rather than re-throwing.
         filter: (name) => {
           try {
             validateCopilotAgentFileName(name);
@@ -261,11 +196,4 @@ export function buildCopilotPlan(_config?: AgentSyncConfig): ApplyPlan {
 }
 
 /** Decrypt and apply all Copilot vault artifacts to the local machine. */
-export async function applyCopilotVault(
-  vaultDir: string,
-  key: string,
-  dryRun: boolean,
-  config?: AgentSyncConfig,
-): Promise<void> {
-  await runApplyPlan(buildCopilotPlan(config), vaultDir, key, dryRun);
-}
+export const applyCopilotVault = makeApplyVault(buildCopilotPlan);

--- a/src/agents/cursor/index.ts
+++ b/src/agents/cursor/index.ts
@@ -1,12 +1,18 @@
-import { mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename } from "node:path";
 import { type ParseError, parse as parseJsonc } from "jsonc-parser";
 import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
 import { denormalizeStringFromVault, normalizeStringForVault } from "../../core/path-portability";
-import { sanitizeAndNormalizeJson, shouldNeverSync } from "../../core/sanitizer";
-import { extractArchive } from "../../core/tar";
+import { sanitizeAndNormalizeJson } from "../../core/sanitizer";
+import {
+  type ApplyPlan,
+  defineFileArtifact,
+  dirWriteApplier,
+  makeApplyVault,
+  skillNameFilter,
+} from "../_apply";
+import { collectMarkdownDir } from "../_snapshot";
 import {
   atomicWrite,
   collect,
@@ -15,7 +21,7 @@ import {
   type SnapshotResult,
   setJsoncTopLevelKey,
 } from "../_utils";
-import { collectSkillArtifacts, InvalidSkillNameError, validateSkillName } from "../skills-walker";
+import { applySkillArchive, collectSkillArtifacts } from "../skills-walker";
 
 /** Snapshot payload for the Cursor adapter. */
 export type CursorSnapshotResult = SnapshotResult;
@@ -47,6 +53,22 @@ async function readCursorRules(): Promise<string | null> {
   }
 }
 
+/**
+ * Reject Cursor rule filenames that could escape `rulesDir`, smuggle in vendor
+ * dotfiles, or carry NUL bytes. Used as the apply-side `validate` guard for the
+ * cross-agent `rules` passthrough.
+ */
+function validateCursorRuleName(ruleName: string): void {
+  if (
+    ruleName.length === 0 ||
+    ruleName !== basename(ruleName) ||
+    ruleName.startsWith(".") ||
+    ruleName.includes("\0")
+  ) {
+    throw new Error(`Invalid Cursor rule filename: ${ruleName}`);
+  }
+}
+
 /** Collect Cursor rules, MCP config, and commands that are safe to sync. */
 export async function snapshotCursor(_config?: AgentSyncConfig): Promise<SnapshotResult> {
   const artifacts: SnapshotArtifact[] = [];
@@ -65,46 +87,28 @@ export async function snapshotCursor(_config?: AgentSyncConfig): Promise<Snapsho
   const mcpRaw = await readIfExists(AgentPaths.cursor.mcpGlobal);
   if (mcpRaw !== null) {
     const sanitized = sanitizeAndNormalizeJson(mcpRaw, "cursor_mcp");
-    const artifact = collect(sanitized, AgentPaths.cursor.mcpGlobal, "cursor/mcp.json.age");
-    artifacts.push(artifact);
+    artifacts.push(collect(sanitized, AgentPaths.cursor.mcpGlobal, "cursor/mcp.json.age"));
     warnings.push(...sanitized.warnings);
   }
 
-  try {
-    const names = await readdir(AgentPaths.cursor.commandsDir);
-    for (const name of names) {
-      if (!name.endsWith(".md")) continue;
-      const sourcePath = join(AgentPaths.cursor.commandsDir, name);
-      if (shouldNeverSync(sourcePath)) continue;
-      let content: string;
-      try {
-        content = await readFile(sourcePath, "utf8");
-      } catch {
-        continue; // skip directories or unreadable entries
-      }
-      artifacts.push({
-        vaultPath: `cursor/commands/${name}.age`,
-        sourcePath,
-        plaintext: content,
-        warnings: [],
-      });
-    }
-  } catch {
-    // commands dir may not exist yet.
-  }
+  artifacts.push(
+    ...(await collectMarkdownDir({
+      dir: AgentPaths.cursor.commandsDir,
+      vaultPath: (name) => `cursor/commands/${name}.age`,
+    })),
+  );
 
-  // Skills — delegated to the shared walker. The walker is pointed at
-  // `AgentPaths.cursor.skillsDir` which resolves to `~/.cursor/skills/` —
-  // the canonical user-skills path. The bundled `~/.cursor/skills-cursor/`
-  // directory is NEVER read because `paths.ts` does not expose it and the
-  // walker is not given a pointer to it, so there is no code path through
-  // which vendor bundles can leak into the vault.
+  // Skills — delegated to the shared walker, pointed at `~/.cursor/skills/`. The
+  // bundled `~/.cursor/skills-cursor/` directory is never read (paths.ts does
+  // not expose it), so vendor bundles cannot leak into the vault.
   const cursorSkills = await collectSkillArtifacts("cursor", AgentPaths.cursor.skillsDir);
   artifacts.push(...cursorSkills.artifacts);
   warnings.push(...cursorSkills.warnings);
 
   return { artifacts, warnings };
 }
+
+// ─── Apply (pull side) ────────────────────────────────────────────────────────
 
 /**
  * Apply the synced `rules` value back into Cursor's settings.json.
@@ -132,54 +136,30 @@ export async function applyCursorMcp(mcpJsonContent: string): Promise<void> {
   );
 }
 
-/** Restore one Cursor command markdown file from the vault. */
 /**
  * Write one Cursor rules-folder file to ~/.cursor/rules/<name>.
  * The migrate `rules` ConfigType uses this for cross-agent passthrough.
  */
-export async function applyCursorRule(ruleName: string, content: string): Promise<void> {
-  if (
-    ruleName.length === 0 ||
-    ruleName !== basename(ruleName) ||
-    ruleName.startsWith(".") ||
-    ruleName.includes("\0")
-  ) {
-    throw new Error(`Invalid Cursor rule filename: ${ruleName}`);
-  }
-  const target = join(AgentPaths.cursor.rulesDir, ruleName);
-  await mkdir(AgentPaths.cursor.rulesDir, { recursive: true });
-  await atomicWrite(target, content);
+export function applyCursorRule(ruleName: string, content: string): Promise<void> {
+  return dirWriteApplier({ dir: AgentPaths.cursor.rulesDir, validate: validateCursorRuleName })(
+    ruleName,
+    content,
+  );
 }
 
-export async function applyCursorCommand(commandName: string, content: string): Promise<void> {
-  const target = join(AgentPaths.cursor.commandsDir, commandName);
-  await mkdir(AgentPaths.cursor.commandsDir, { recursive: true });
-  await atomicWrite(target, content);
+/** Restore one Cursor command markdown file from the vault. */
+export function applyCursorCommand(commandName: string, content: string): Promise<void> {
+  return dirWriteApplier({ dir: AgentPaths.cursor.commandsDir })(commandName, content);
 }
 
 /**
- * Restore one Cursor skill directory from the vault by extracting its
- * encrypted tar archive into `~/.cursor/skills/<name>/` — NEVER into the
- * bundled `~/.cursor/skills-cursor/` path.
- *
- * Mirrors {@link applyClaudeSkill}: parents are created on demand and the
- * tar's interior layout is preserved bit-for-bit.
- *
- * @param skillName  Basename of the skill (no extension).
- * @param base64Tar  Base64-encoded `.tar.gz` payload that the walker
- *                   produced on the source machine.
+ * Restore one Cursor skill directory from the vault by extracting its encrypted
+ * tar archive into `~/.cursor/skills/<name>/` — NEVER into the bundled
+ * `~/.cursor/skills-cursor/` path. Thin wrapper over {@link applySkillArchive}.
  */
 export async function applyCursorSkill(skillName: string, base64Tar: string): Promise<void> {
-  validateSkillName(skillName);
-  const targetDir = join(AgentPaths.cursor.skillsDir, skillName);
-  await mkdir(targetDir, { recursive: true });
-  const tarBuffer = Buffer.from(base64Tar, "base64");
-  await extractArchive(tarBuffer, targetDir);
+  await applySkillArchive(AgentPaths.cursor.skillsDir, skillName, base64Tar);
 }
-
-// ─── Apply (pull side) ────────────────────────────────────────────────────────
-
-import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
 
 /** Build the Cursor apply plan. Exposed so `copy` can apply a single artifact. */
 export function buildCursorPlan(_config?: AgentSyncConfig): ApplyPlan {
@@ -210,28 +190,11 @@ export function buildCursorPlan(_config?: AgentSyncConfig): ApplyPlan {
         suffix: ".tar.age",
         dryRunVerb: "would extract skill:",
         apply: applyCursorSkill,
-        filter: (name) => {
-          try {
-            validateSkillName(name);
-            return null;
-          } catch (err) {
-            if (err instanceof InvalidSkillNameError) {
-              return { reason: `invalid skill name — ${err.reason}` };
-            }
-            throw err;
-          }
-        },
+        filter: skillNameFilter(),
       },
     ],
   };
 }
 
 /** Decrypt and apply all Cursor vault artifacts to the local machine. */
-export async function applyCursorVault(
-  vaultDir: string,
-  key: string,
-  dryRun: boolean,
-  config?: AgentSyncConfig,
-): Promise<void> {
-  await runApplyPlan(buildCursorPlan(config), vaultDir, key, dryRun);
-}
+export const applyCursorVault = makeApplyVault(buildCursorPlan);

--- a/src/agents/skills-walker.ts
+++ b/src/agents/skills-walker.ts
@@ -25,10 +25,10 @@
  * travel back as warnings on the result so the caller decides how to surface.
  */
 
-import { lstat, readdir, readFile } from "node:fs/promises";
+import { lstat, mkdir, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { scanForSecrets, shouldNeverSync } from "../core/sanitizer";
-import { archiveDirectory } from "../core/tar";
+import { archiveDirectory, extractArchive } from "../core/tar";
 import type { SnapshotArtifact, SnapshotResult } from "./_utils";
 
 /**
@@ -129,6 +129,25 @@ export function validateSkillName(name: string): void {
       throw new InvalidSkillNameError(name, "contains path separator");
     }
   }
+}
+
+/**
+ * Pull-side counterpart to the walker: extract one skill's base64 `.tar.gz`
+ * payload into `<skillsRoot>/<skillName>/`. `validateSkillName` guards the
+ * trust boundary before the join (see its docstring for the `..` tar-slip it
+ * closes), parents are created on demand, and the tar's interior layout is
+ * preserved bit-for-bit. Every adapter's `applyXxxSkill` is a one-line wrapper
+ * over this that supplies its own skills root.
+ */
+export async function applySkillArchive(
+  skillsRoot: string,
+  skillName: string,
+  base64Tar: string,
+): Promise<void> {
+  validateSkillName(skillName);
+  const targetDir = join(skillsRoot, skillName);
+  await mkdir(targetDir, { recursive: true });
+  await extractArchive(Buffer.from(base64Tar, "base64"), targetDir);
 }
 
 /**

--- a/src/agents/vscode/index.ts
+++ b/src/agents/vscode/index.ts
@@ -3,7 +3,7 @@ import { AgentPaths } from "../../config/paths";
 import type { AgentSyncConfig } from "../../config/schema";
 import { denormalizeStringFromVault } from "../../core/path-portability";
 import { sanitizeAndNormalizeJson } from "../../core/sanitizer";
-import { type ApplyPlan, defineFileArtifact, runApplyPlan } from "../_apply";
+import { type ApplyPlan, defineFileArtifact, makeApplyVault } from "../_apply";
 import {
   atomicWrite,
   collect,
@@ -56,11 +56,4 @@ export function buildVsCodePlan(_config?: AgentSyncConfig): ApplyPlan {
 }
 
 /** Decrypt and apply all VS Code vault artifacts to the local machine. */
-export async function applyVsCodeVault(
-  vaultDir: string,
-  key: string,
-  dryRun: boolean,
-  config?: AgentSyncConfig,
-): Promise<void> {
-  await runApplyPlan(buildVsCodePlan(config), vaultDir, key, dryRun);
-}
+export const applyVsCodeVault = makeApplyVault(buildVsCodePlan);


### PR DESCRIPTION
## What changed

Five agent adapters (claude, codex, cursor, copilot, vscode) each carried near-identical boilerplate for walking markdown directories, collecting single files, deduplicating skill scopes, and running apply plans. This PR collapses that duplication into a shared toolkit without changing observable behaviour — with one deliberate security hardening noted below.

### New toolkit surface

| File | Exports |
|---|---|
| `src/agents/_snapshot.ts` | `collectMarkdownDir`, `collectSingleFile`, `collectSkillScopes` |
| `src/agents/_apply.ts` (additions) | `skillNameFilter`, `dirWriteApplier`, `makeApplyVault` |
| `src/agents/skills-walker.ts` (addition) | `applySkillArchive` |

- `collectMarkdownDir` — single hardened directory walk used by all adapters; custom `match` predicate covers copilot's compound suffixes (`.instructions.md`).
- `collectSingleFile` — zero-boilerplate optional-file collector for verbatim single files.
- `collectSkillScopes` — absorbs codex's dual-scope skill dedup: the canonical directory listing gates the legacy scope even when a canonical skill was rejected (never-sync hit), so no previously-blocked skill leaks through the legacy path.
- `skillNameFilter` — wraps `validateSkillName` + `InvalidSkillNameError` mapping into a reusable `DirArtifact.filter` callback.
- `dirWriteApplier` — builds a `DirArtifact.apply` handler: optional validate, `mkdir -p`, optional `.bak` backup (only claude opts in), then `atomicWrite`.
- `makeApplyVault` — wraps `runApplyPlan(buildPlan(config), ...)` so each adapter's `applyXxxVault` is a one-liner.
- `applySkillArchive` — pull-side counterpart to the skills walker; `validateSkillName` guards the trust boundary before `join` (closes the `..` tar-slip vector), then `extractArchive` into `<skillsRoot>/<name>/`.

### Security hardening (behaviour change, intentional)

`collectMarkdownDir` uses `readdir` with `withFileTypes: true` and rejects any entry where `!entry.isFile() || entry.isSymbolicLink()`. Previously only the claude/rules and copilot/agents walks applied this guard. The remaining adapters' directory walks used a plain `readdir` + `readFile`, meaning a symlink like `commands/evil.md -> /etc/passwd` would be followed by `readFile` while `shouldNeverSync` only saw the link path — the secret content would reach the vault. The hardening is structural (no opt-out flag) and is covered by a named test: `"rejects a symlinked markdown entry so it cannot smuggle content past the never-sync gate"`.

### What is unchanged

- All bespoke sanitiser and transform paths: claude plugin manifest + hooks/mcp, codex TOML normalisation, cursor JSONC + mcp, copilot mcp.
- Copilot's distinct `agents` filename filter (kept inline — it throws a plain `Error` and maps to a fixed reason, unlike `skillNameFilter`).
- Codex dual-scope logic (now inside `collectSkillScopes`, same semantics).
- `buildXxxPlan` signatures are unified to accept an optional `config` parameter; previously some required it and some made it optional. Calling code (`copy`, the registry, `makeApplyVault`) is unaffected.

Net: approximately -82 lines of production code.

### Tests

New boundary tests for every toolkit verb across `__tests__/_snapshot.test.ts`, `__tests__/_apply.test.ts` (additions), and `__tests__/skills-walker.test.ts` (additions), including the empty-scope guard and the `makeApplyVault` dry-run threading. The symlink-hardening case is an explicit named test.

```mermaid
flowchart TD
    subgraph Before
      CLa["claude inline walk + skill dedup"]:::old
      COa["codex inline walk + dual-scope dedup"]:::old
      CUa["cursor inline walk"]:::old
      COPa["copilot inline walk"]:::old
      VSa["vscode inline walk"]:::old
    end

    subgraph After
      SNP["_snapshot.ts<br/>collectMarkdownDir<br/>collectSingleFile<br/>collectSkillScopes"]:::new
      APL["_apply.ts additions<br/>skillNameFilter<br/>dirWriteApplier<br/>makeApplyVault"]:::new
      SKW["skills-walker.ts addition<br/>applySkillArchive"]:::new
      CLb["claude"]:::adapter --> SNP
      COb["codex"]:::adapter --> SNP
      CUb["cursor"]:::adapter --> SNP
      COPb["copilot"]:::adapter --> SNP
      VSb["vscode"]:::adapter --> SNP
      CLb --> APL
      COb --> APL
      CUb --> APL
      COPb --> APL
      VSb --> APL
      CLb --> SKW
      COb --> SKW
    end

    classDef old fill:#7f1d1d,color:#fecaca
    classDef new fill:#14532d,color:#bbf7d0
    classDef adapter fill:#1e3a5f,color:#bfdbfe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for agent apply operations, snapshot collection, and skill archive handling with improved validation assertions.

* **Bug Fixes**
  * Enhanced symlink security hardening in snapshot collection to prevent directory traversal attacks.
  * Improved skill name validation and error handling with consistent error propagation.

* **Refactor**
  * Consolidated agent snapshot and apply logic across multiple agents to use shared utilities, improving consistency and reducing code duplication.
  * Standardized backup and validation behavior in file write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->