### PR TITLE
ci: pin e2e Docker and release Bun to 1.3.12

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.14"
+          # Pinned to match ci.yml. 1.3.14 regressed node:fs/promises interop.
+          bun-version: "1.3.12"
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -99,7 +100,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.14"
+          # Pinned to match ci.yml. 1.3.14 regressed node:fs/promises interop.
+          bun-version: "1.3.12"
 
       # Pin Node/npm via .nvmrc so the cross-target `npm install --force
       # --os --cpu` below is reproducible across runner image refreshes.

--- a/docker/e2e/Dockerfile.machine
+++ b/docker/e2e/Dockerfile.machine
@@ -24,8 +24,10 @@ ENV PATH="/home/agent/.bun/bin:/home/agent/.npm-global/bin:/home/agent/.local/bi
 RUN mkdir -p /home/agent/.npm-global \
  && npm config set prefix /home/agent/.npm-global
 
-# Bun installer pulls the current stable release at build time (unpinned).
-RUN curl -fsSL https://bun.sh/install | bash
+# Pinned: Bun 1.3.14 regressed node:fs/promises default-export interop, which
+# crashes the suite at module load. Keep in lockstep with the ci.yml pin; bump
+# only after the e2e scenarios pass on the new version.
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.12"
 
 # Claude Code + Codex pulled at @latest. Drift surfaces in CI, not in users.
 RUN npm install -g @anthropic-ai/claude-code@latest

--- a/docker/e2e/README.md
+++ b/docker/e2e/README.md
@@ -127,7 +127,7 @@ Every upstream toolchain that materially affects E2E behaviour is pulled at
 its **latest** version on every image build:
 
 - `node:24-bookworm-slim` (Node 22 EOL was 2026-03-24; Node 24 LTS through April 2028)
-- Bun via `https://bun.sh/install` (unpinned)
+- Bun via `https://bun.sh/install`, pinned to 1.3.12 (1.3.14 regressed node:fs/promises interop; keep in lockstep with ci.yml)
 - `@anthropic-ai/claude-code@latest`
 - `@openai/codex@latest`
 - `cursor-agent` via the upstream installer (unpinned by the vendor)


### PR DESCRIPTION
## What and why

Follow-up to #173. Bun **1.3.14** regressed `node:fs/promises` default-export interop, which crashes the test suite at module load. #173 pinned the four `ci.yml` `setup-bun` steps to **1.3.12**, but two more places still pull Bun unpinned and broke after #173 merged:

- `docker/e2e/Dockerfile.machine` installs Bun via `curl … bun.sh/install | bash` (latest → 1.3.14), so every e2e scenario container runs the broken Bun. `e2e.yml` runs on push to `main`, so `main`'s e2e is currently red.
- `.github/workflows/release-please.yml` was explicitly pinned to `1.3.14` (×2) — the broken version — risking a release built/smoke-tested on it.

## Changes

- `docker/e2e/Dockerfile.machine` — install `bun-v1.3.12` via the installer's version arg.
- `.github/workflows/release-please.yml` — `1.3.14` → `1.3.12` (×2).
- `docker/e2e/README.md` — note the pin.

All Bun pins across the repo are now `1.3.12` (proven good: the suite passes locally on 1.3.12). Bump only after verifying the suite on the new version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow and testing infrastructure configurations for consistency across deployment and development environments.
  * Updated relevant documentation to reflect current toolchain setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->