### PR TITLE
fix(ci): pin Bun 1.3.14 and install all OpenTUI native variants for cross-compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Pinned: Bun 1.3.14 regressed node:fs/promises default-export interop,
-          # breaking test module loads. `latest` is a moving target — bump only
-          # after verifying the suite passes on the new version.
-          bun-version: 1.3.12
+          # Pinned for reproducibility. 1.3.14 matches release-please.yml and the
+          # e2e image. Do NOT downgrade to 1.3.12: on the Linux runner it mishandles
+          # the node:fs/promises default-export interop, so test module loads fail
+          # with "Missing 'default' export in module 'node:fs/promises'" (#176).
+          # 1.3.14 runs the full suite green on the same runner.
+          bun-version: 1.3.14
 
       - name: Cache bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -59,10 +61,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Pinned: Bun 1.3.14 regressed node:fs/promises default-export interop,
-          # breaking test module loads. `latest` is a moving target — bump only
-          # after verifying the suite passes on the new version.
-          bun-version: 1.3.12
+          # Pinned for reproducibility. 1.3.14 matches release-please.yml and the
+          # e2e image. Do NOT downgrade to 1.3.12: on the Linux runner it mishandles
+          # the node:fs/promises default-export interop, so test module loads fail
+          # with "Missing 'default' export in module 'node:fs/promises'" (#176).
+          # 1.3.14 runs the full suite green on the same runner.
+          bun-version: 1.3.14
 
       - name: Cache bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -109,10 +113,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Pinned: Bun 1.3.14 regressed node:fs/promises default-export interop,
-          # breaking test module loads. `latest` is a moving target — bump only
-          # after verifying the suite passes on the new version.
-          bun-version: 1.3.12
+          # Pinned for reproducibility. 1.3.14 matches release-please.yml and the
+          # e2e image. Do NOT downgrade to 1.3.12: on the Linux runner it mishandles
+          # the node:fs/promises default-export interop, so test module loads fail
+          # with "Missing 'default' export in module 'node:fs/promises'" (#176).
+          # 1.3.14 runs the full suite green on the same runner.
+          bun-version: 1.3.14
 
       - name: Cache bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -143,10 +149,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Pinned: Bun 1.3.14 regressed node:fs/promises default-export interop,
-          # breaking test module loads. `latest` is a moving target — bump only
-          # after verifying the suite passes on the new version.
-          bun-version: 1.3.12
+          # Pinned for reproducibility. 1.3.14 matches release-please.yml and the
+          # e2e image. Do NOT downgrade to 1.3.12: on the Linux runner it mishandles
+          # the node:fs/promises default-export interop, so test module loads fail
+          # with "Missing 'default' export in module 'node:fs/promises'" (#176).
+          # 1.3.14 runs the full suite green on the same runner.
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -119,45 +119,27 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # Cross-compiling embeds the target's @opentui/core-<os>-<cpu> native
-      # module. bun install only fetches the host's optional dep, so we
-      # explicitly install the target's variant. --force bypasses os/cpu
-      # skip filtering; --no-save keeps bun.lock untouched.
-      - name: Install target-platform OpenTUI native module
+      # Cross-compiling embeds the target's native @opentui/core module. bun's
+      # --compile resolves EVERY platform branch in OpenTUI's loader, and on
+      # Linux that means both the glibc and musl siblings (e.g.
+      # @opentui/core-linux-arm64 AND -linux-arm64-musl) since OPENTUI_LIBC is
+      # unknown at build time. Installing one variant per target left the musl
+      # sibling unresolved and failed the linux-arm64 leg (#172). Mirror
+      # scripts/build.ts: fetch every platform's native lib so no import branch
+      # is missing. Pin to the hoisted core's exact version so the native libs
+      # match the bundled core.
+      - name: Install all OpenTUI native modules for cross-compile
         if: matrix.bun_target
-        env:
-          BUN_TARGET: ${{ matrix.bun_target }}
         run: |
           set -euo pipefail
-          case "$BUN_TARGET" in
-            bun-windows-x64)    PKG=@opentui/core-win32-x64;    OS=win32;  CPU=x64 ;;
-            bun-windows-arm64)  PKG=@opentui/core-win32-arm64;  OS=win32;  CPU=arm64 ;;
-            bun-linux-x64)      PKG=@opentui/core-linux-x64;    OS=linux;  CPU=x64 ;;
-            bun-linux-arm64)    PKG=@opentui/core-linux-arm64;  OS=linux;  CPU=arm64 ;;
-            bun-darwin-x64)     PKG=@opentui/core-darwin-x64;   OS=darwin; CPU=x64 ;;
-            bun-darwin-arm64)   PKG=@opentui/core-darwin-arm64; OS=darwin; CPU=arm64 ;;
-            *) echo "Unknown bun_target: $BUN_TARGET" >&2; exit 1 ;;
-          esac
           CORE_PKG=node_modules/@opentui/core/package.json
           if [ ! -f "$CORE_PKG" ]; then
             echo "Expected @opentui/core hoisted at $CORE_PKG; install layout changed" >&2
             exit 1
           fi
           VERSION=$(jq -r .version "$CORE_PKG")
-          echo "Installing $PKG@$VERSION for $OS/$CPU"
-          npm install --no-save --force --os="$OS" --cpu="$CPU" "${PKG}@${VERSION}"
-          # Loud failure if the registry returned a different version, instead of
-          # the later "Could not resolve" error from bun build at compile time.
-          INSTALLED="node_modules/${PKG}/package.json"
-          if [ ! -f "$INSTALLED" ]; then
-            echo "Expected $INSTALLED after install; native package missing" >&2
-            exit 1
-          fi
-          INSTALLED_VERSION=$(jq -r .version "$INSTALLED")
-          if [ "$INSTALLED_VERSION" != "$VERSION" ]; then
-            echo "Version mismatch: host @opentui/core=$VERSION, target $PKG=$INSTALLED_VERSION" >&2
-            exit 1
-          fi
+          echo "Installing all @opentui/core native variants @ $VERSION"
+          bun install --os="*" --cpu="*" "@opentui/core@${VERSION}"
 
       - name: Build binary
         run: bun build --compile ${{ matrix.bun_target && format('--target {0}', matrix.bun_target) || '' }} src/cli.ts --outfile dist/${{ matrix.target }}


### PR DESCRIPTION
## Summary

Fixes two independent CI/release failures on `main`, both verified against live CI history rather than assumed.

### Fixes #176 — Unit Tests red on Linux (`node:fs/promises`)
`ci.yml` pinned Bun **1.3.12**, which mishandles the `node:fs/promises` default-export interop on the ubuntu-latest runner. Test module loads fail with `SyntaxError: Missing 'default' export in module 'node:fs/promises'`.

**Evidence (same runner, `@opentui/core@0.3.4` present in all three):**

| Commit | Bun | Unit Tests |
|--------|-----|-----------|
| `491906d` (#153, the 0.3.4 bump) | 1.3.14 | ✅ pass |
| `eeee1b6` (release) | 1.3.14 | ✅ pass |
| `1937482` (#173 merge) | **1.3.12** | ❌ fail |

The pin to 1.3.12 landed *inside* #173 and is the only variable that flipped green→red. The prior `ci.yml` comment ("Bun 1.3.14 regressed fs/promises") was backwards. This bumps all four `setup-bun` pins to **1.3.14** (matching `release-please.yml` and the e2e image) and corrects the comment.

> Supersedes the root-cause theory in #176, which blamed `@opentui/core 0.3.4` — disproven because 0.3.4 is present in the green runs too.

### Fixes #172 — release `linux-arm64` leg cannot resolve `@opentui/core-linux-arm64-musl`
`bun build --compile --target bun-linux-arm64` resolves *every* platform branch in OpenTUI's native loader, including both the glibc and musl Linux siblings (`OPENTUI_LIBC` is unknown at build time). The per-target install fetched only the glibc variant, so the musl `import()` failed:

```
error: Could not resolve: "@opentui/core-linux-arm64-musl"
```

This mirrors the proven pattern in `scripts/build.ts:17` — install every platform's native lib via `bun install --os="*" --cpu="*"`, pinned to the hoisted core's exact version. Also drops ~30 lines of brittle per-target `case` mapping.

**Verified:** `bun install --os="*" --cpu="*" @opentui/core@0.3.4` pulls all 8 native variants including `core-linux-arm64-musl`.

## Verification
- Both workflow YAMLs parse cleanly; all jobs intact.
- The wildcard install was run in isolation and confirmed to fetch the previously-missing musl variant.
- This PR's own CI run on 1.3.14 is the green proof for #176.

## Out of scope (follow-ups)
- The Unit Tests step's exit-code grep workaround in `ci.yml` is left as-is (permissive, won't false-fail); worth revisiting once 1.3.14 confirms a clean exit.

Closes #176
Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)