### PR TITLE
fix(ci): repair Linux Unit Tests — fs/promises mock default + Bun pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Pinned: Bun 1.3.14 regressed node:fs/promises default-export interop,
-          # breaking test module loads. `latest` is a moving target — bump only
-          # after verifying the suite passes on the new version.
-          bun-version: 1.3.12
+          # Pinned for reproducibility. 1.3.14 matches release-please.yml and the
+          # e2e image. Do NOT downgrade to 1.3.12: on the Linux runner it mishandles
+          # the node:fs/promises default-export interop, so test module loads fail
+          # with "Missing 'default' export in module 'node:fs/promises'" (#176).
+          # 1.3.14 runs the full suite green on the same runner.
+          bun-version: 1.3.14
 
       - name: Cache bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -59,10 +61,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Pinned: Bun 1.3.14 regressed node:fs/promises default-export interop,
-          # breaking test module loads. `latest` is a moving target — bump only
-          # after verifying the suite passes on the new version.
-          bun-version: 1.3.12
+          # Pinned for reproducibility. 1.3.14 matches release-please.yml and the
+          # e2e image. Do NOT downgrade to 1.3.12: on the Linux runner it mishandles
+          # the node:fs/promises default-export interop, so test module loads fail
+          # with "Missing 'default' export in module 'node:fs/promises'" (#176).
+          # 1.3.14 runs the full suite green on the same runner.
+          bun-version: 1.3.14
 
       - name: Cache bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -109,10 +113,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Pinned: Bun 1.3.14 regressed node:fs/promises default-export interop,
-          # breaking test module loads. `latest` is a moving target — bump only
-          # after verifying the suite passes on the new version.
-          bun-version: 1.3.12
+          # Pinned for reproducibility. 1.3.14 matches release-please.yml and the
+          # e2e image. Do NOT downgrade to 1.3.12: on the Linux runner it mishandles
+          # the node:fs/promises default-export interop, so test module loads fail
+          # with "Missing 'default' export in module 'node:fs/promises'" (#176).
+          # 1.3.14 runs the full suite green on the same runner.
+          bun-version: 1.3.14
 
       - name: Cache bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -143,10 +149,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Pinned: Bun 1.3.14 regressed node:fs/promises default-export interop,
-          # breaking test module loads. `latest` is a moving target — bump only
-          # after verifying the suite passes on the new version.
-          bun-version: 1.3.12
+          # Pinned for reproducibility. 1.3.14 matches release-please.yml and the
+          # e2e image. Do NOT downgrade to 1.3.12: on the Linux runner it mishandles
+          # the node:fs/promises default-export interop, so test module loads fail
+          # with "Missing 'default' export in module 'node:fs/promises'" (#176).
+          # 1.3.14 runs the full suite green on the same runner.
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -119,45 +119,27 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # Cross-compiling embeds the target's @opentui/core-<os>-<cpu> native
-      # module. bun install only fetches the host's optional dep, so we
-      # explicitly install the target's variant. --force bypasses os/cpu
-      # skip filtering; --no-save keeps bun.lock untouched.
-      - name: Install target-platform OpenTUI native module
+      # Cross-compiling embeds the target's native @opentui/core module. bun's
+      # --compile resolves EVERY platform branch in OpenTUI's loader, and on
+      # Linux that means both the glibc and musl siblings (e.g.
+      # @opentui/core-linux-arm64 AND -linux-arm64-musl) since OPENTUI_LIBC is
+      # unknown at build time. Installing one variant per target left the musl
+      # sibling unresolved and failed the linux-arm64 leg (#172). Mirror
+      # scripts/build.ts: fetch every platform's native lib so no import branch
+      # is missing. Pin to the hoisted core's exact version so the native libs
+      # match the bundled core.
+      - name: Install all OpenTUI native modules for cross-compile
         if: matrix.bun_target
-        env:
-          BUN_TARGET: ${{ matrix.bun_target }}
         run: |
           set -euo pipefail
-          case "$BUN_TARGET" in
-            bun-windows-x64)    PKG=@opentui/core-win32-x64;    OS=win32;  CPU=x64 ;;
-            bun-windows-arm64)  PKG=@opentui/core-win32-arm64;  OS=win32;  CPU=arm64 ;;
-            bun-linux-x64)      PKG=@opentui/core-linux-x64;    OS=linux;  CPU=x64 ;;
-            bun-linux-arm64)    PKG=@opentui/core-linux-arm64;  OS=linux;  CPU=arm64 ;;
-            bun-darwin-x64)     PKG=@opentui/core-darwin-x64;   OS=darwin; CPU=x64 ;;
-            bun-darwin-arm64)   PKG=@opentui/core-darwin-arm64; OS=darwin; CPU=arm64 ;;
-            *) echo "Unknown bun_target: $BUN_TARGET" >&2; exit 1 ;;
-          esac
           CORE_PKG=node_modules/@opentui/core/package.json
           if [ ! -f "$CORE_PKG" ]; then
             echo "Expected @opentui/core hoisted at $CORE_PKG; install layout changed" >&2
             exit 1
           fi
           VERSION=$(jq -r .version "$CORE_PKG")
-          echo "Installing $PKG@$VERSION for $OS/$CPU"
-          npm install --no-save --force --os="$OS" --cpu="$CPU" "${PKG}@${VERSION}"
-          # Loud failure if the registry returned a different version, instead of
-          # the later "Could not resolve" error from bun build at compile time.
-          INSTALLED="node_modules/${PKG}/package.json"
-          if [ ! -f "$INSTALLED" ]; then
-            echo "Expected $INSTALLED after install; native package missing" >&2
-            exit 1
-          fi
-          INSTALLED_VERSION=$(jq -r .version "$INSTALLED")
-          if [ "$INSTALLED_VERSION" != "$VERSION" ]; then
-            echo "Version mismatch: host @opentui/core=$VERSION, target $PKG=$INSTALLED_VERSION" >&2
-            exit 1
-          fi
+          echo "Installing all @opentui/core native variants @ $VERSION"
+          bun install --os="*" --cpu="*" "@opentui/core@${VERSION}"
 
       - name: Build binary
         run: bun build --compile ${{ matrix.bun_target && format('--target {0}', matrix.bun_target) || '' }} src/cli.ts --outfile dist/${{ matrix.target }}

--- a/src/agents/claude/__tests__/index.test.ts
+++ b/src/agents/claude/__tests__/index.test.ts
@@ -16,7 +16,7 @@ const TEST_CONFIG_WITH_PLUGINS = createTestAgentSyncConfig({
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 type MutableClaudePaths = {

--- a/src/agents/codex/__tests__/index.test.ts
+++ b/src/agents/codex/__tests__/index.test.ts
@@ -11,7 +11,7 @@ import { createTmpDir } from "../../../test-helpers/fixtures";
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 type MutableCodexPaths = {

--- a/src/agents/copilot/__tests__/index.test.ts
+++ b/src/agents/copilot/__tests__/index.test.ts
@@ -10,7 +10,7 @@ import { createTmpDir } from "../../../test-helpers/fixtures";
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 type MutableCopilotPaths = {

--- a/src/agents/cursor/__tests__/index.test.ts
+++ b/src/agents/cursor/__tests__/index.test.ts
@@ -10,7 +10,7 @@ import { createAgeIdentity, createTmpDir } from "../../../test-helpers/fixtures"
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 type MutableCursorPaths = {

--- a/src/agents/vscode/__tests__/index.test.ts
+++ b/src/agents/vscode/__tests__/index.test.ts
@@ -8,7 +8,7 @@ import { createAgeIdentity, createTmpDir } from "../../../test-helpers/fixtures"
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 type MutableVsCodePaths = {

--- a/src/commands/__tests__/integration.test.ts
+++ b/src/commands/__tests__/integration.test.ts
@@ -38,7 +38,7 @@ const fakeLogs = {
   const require = createRequire(import.meta.url);
   // biome-ignore lint/style/useNodejsImportProtocol: The fs/promises alias bypasses Bun's shared node:fs/promises mock cache between test files.
   const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 const { readFile, rm } = createRequire(import.meta.url)(

--- a/src/commands/__tests__/packaging.test.ts
+++ b/src/commands/__tests__/packaging.test.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
   const require = createRequire(import.meta.url);
   // biome-ignore lint/style/useNodejsImportProtocol: The fs/promises alias bypasses Bun's shared node:fs/promises mock cache between test files.
   const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 const { readFile } = createRequire(import.meta.url)(

--- a/src/commands/__tests__/push.test.ts
+++ b/src/commands/__tests__/push.test.ts
@@ -28,7 +28,7 @@ import {
   const require = createRequire(import.meta.url);
   // biome-ignore lint/style/useNodejsImportProtocol: deliberate alias to bypass mock cache
   const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 // Mute @clack/prompts so log output doesn't pollute the test runner.

--- a/src/commands/__tests__/release-workflow.test.ts
+++ b/src/commands/__tests__/release-workflow.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
   const require = createRequire(import.meta.url);
   // biome-ignore lint/style/useNodejsImportProtocol: The fs/promises alias bypasses Bun's shared node:fs/promises mock cache between test files.
   const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 const { readFile } = createRequire(import.meta.url)(

--- a/src/commands/__tests__/skill.test.ts
+++ b/src/commands/__tests__/skill.test.ts
@@ -26,7 +26,7 @@ import {
   const require = createRequire(import.meta.url);
   // biome-ignore lint/style/useNodejsImportProtocol: deliberate alias to bypass mock cache
   const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 // Mute @clack/prompts so log output doesn't pollute the test runner.

--- a/src/commands/__tests__/status.test.ts
+++ b/src/commands/__tests__/status.test.ts
@@ -69,7 +69,7 @@ describe("status colour mapping", () => {
   const require = createRequire(import.meta.url);
   // biome-ignore lint/style/useNodejsImportProtocol: deliberate alias to bypass mock cache
   const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 const fakeLogs = {

--- a/src/commands/__tests__/upgrade.test.ts
+++ b/src/commands/__tests__/upgrade.test.ts
@@ -14,6 +14,9 @@ const realFsPromises = createRequire(import.meta.url)(
 let cacheJson: string | null = null;
 mock.module("node:fs/promises", () => ({
   ...realFsPromises,
+  // require() omits the synthesized default export; Linux Bun links named
+  // imports through CJS-interop default, so it must be present.
+  default: realFsPromises,
   readFile: async () => {
     if (cacheJson === null) throw new Error("ENOENT");
     return cacheJson;
@@ -33,7 +36,9 @@ afterEach(() => {
   cacheJson = null;
   process.exitCode = 0;
 });
-afterAll(() => mock.module("node:fs/promises", () => realFsPromises));
+afterAll(() =>
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises })),
+);
 
 function fetchReturning(tag: string): void {
   globalThis.fetch = mock(

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -19,7 +19,7 @@ import { AgentSyncConfigSchema, CURRENT_VAULT_VERSION } from "../schema";
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 const MINIMAL_TOML = `

--- a/src/core/__tests__/encryptor.test.ts
+++ b/src/core/__tests__/encryptor.test.ts
@@ -17,7 +17,7 @@ import {
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 describe("encryptor", () => {

--- a/src/core/__tests__/git.test.ts
+++ b/src/core/__tests__/git.test.ts
@@ -15,7 +15,7 @@ import { GitClient, type GitReconciliationError } from "../git";
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 // GitClient clone, init, commit, push, pull, currentBranch

--- a/src/core/__tests__/tar.test.ts
+++ b/src/core/__tests__/tar.test.ts
@@ -10,7 +10,7 @@ import { archiveDirectory, extractArchive, listArchiveEntries } from "../tar";
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 describe("tar", () => {

--- a/src/core/__tests__/version-check.test.ts
+++ b/src/core/__tests__/version-check.test.ts
@@ -12,6 +12,9 @@ const realFsPromises = createRequire(import.meta.url)(
 let cacheJson: string | null = null;
 mock.module("node:fs/promises", () => ({
   ...realFsPromises,
+  // require() omits the synthesized default export; Linux Bun links named
+  // imports through CJS-interop default, so it must be present.
+  default: realFsPromises,
   readFile: async () => {
     if (cacheJson === null) throw new Error("ENOENT");
     return cacheJson;
@@ -32,7 +35,9 @@ afterEach(() => {
   globalThis.fetch = realFetch;
   cacheJson = null;
 });
-afterAll(() => mock.module("node:fs/promises", () => realFsPromises));
+afterAll(() =>
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises })),
+);
 
 function fetchReturning(tag: string): void {
   globalThis.fetch = mock(

--- a/src/core/__tests__/watcher.test.ts
+++ b/src/core/__tests__/watcher.test.ts
@@ -10,7 +10,7 @@ import { Watcher } from "../watcher";
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 // Poll for an event-driven condition instead of a fixed sleep — fs.watch on

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -21,7 +21,7 @@ import { createAgeIdentity, createTmpDir, runGit } from "../../test-helpers/fixt
   const require = createRequire(import.meta.url);
   // biome-ignore lint/style/useNodejsImportProtocol: The fs/promises alias bypasses Bun's shared node:fs/promises mock cache between test files.
   const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 const { mkdir, rm, writeFile } = createRequire(import.meta.url)(

--- a/src/migrate/__tests__/migrate.test.ts
+++ b/src/migrate/__tests__/migrate.test.ts
@@ -24,7 +24,7 @@ import { applyMigrated, performMigrate, readSourceArtefacts } from "../migrate";
 {
   const require = createRequire(import.meta.url);
   const realFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
-  mock.module("node:fs/promises", () => realFsPromises);
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
 }
 
 // ── Mutable path references for testing ──────────────────────────────────────


### PR DESCRIPTION
## What

Two changes targeting the red **Unit Tests** job on `ubuntu-latest` (#176):

1. **`test: add default export to node:fs/promises mocks`** (this PR's new work). Every test that does `mock.module("node:fs/promises", () => real)` used `require("node:fs/promises")`, which returns the bare exports object with **no `default` key**. Bun's CJS interop links a consumer's *named* imports through that `default`; when absent, the Linux runner throws `SyntaxError: Missing 'default' export in module 'node:fs/promises'`. macOS Bun synthesizes a `default`, so the suite stays green locally. `mock.module` is process-global and never auto-reset, so a default-less mock poisons later files in the same run. Fix: make every fs/promises mock a faithful ESM namespace (`{ ...real, default: real }`), including the two cache-faker files and their `afterAll` restores.
2. Pre-existing `fix(ci): pin Bun 1.3.14 and install all OpenTUI native variants for cross-compile` (already on the branch).

## Honest status

- ✅ Local: `tsc` clean, `biome ci` clean, full `bun test` 0 failures; non-regressing on a `linux/amd64` Bun 1.3.14 container.
- ⚠️ I could **not** reproduce the runner-only failure locally in any container/order, so this is a **hypothesis-driven** fix verified for non-regression, not a locally-proven cure. This PR is the decisive test: watch the Unit Tests job.
- If it stays red, the fallback is the structural angle in #176 — isolate the TUI/`@opentui/core` tests into a separate `bun test` invocation (opentui's heavy native graph sharing Bun's single-process registry is the change that temporally coincides with the break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Bun runtime to version 1.3.14 across CI/CD pipelines.
  * Updated native module installation process in cross-compilation workflow for improved artifact builds.

* **Tests**
  * Improved test infrastructure module mocking for enhanced CommonJS/ESM interoperability compatibility across all agent and command test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->