### PR TITLE
feat(key): add recipient revocation (key remove), key list, and crash-safe rotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The full quickstart, command reference, and architecture model live at the docum
 | `status` | Compare local files with the vault and surface drift. |
 | `doctor` | Run environment, key, vault, and daemon diagnostics. |
 | `daemon` | Install and manage the background auto-sync daemon. |
-| `key` | Add recipients or rotate the local machine key. |
+| `key` | Add, list, or remove recipients (revocation), or rotate the local machine key. |
 | `skill` | Remove a skill from the vault explicitly. |
 | `migrate` | Translate configuration between agent formats locally. |
 | `destroy` | Wipe the local vault clone (default) or the remote vault contents via a normal commit. **Local agent files (`~/.claude`, `~/.cursor`, …) are never touched.** |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -46,7 +46,7 @@ When developing from source, replace the binary call with `bun run src/cli.ts`. 
 | [`status`](#status) | Compare local snapshot to decrypted vault state. |
 | [`doctor`](#doctor) | Check the local environment before blaming sync logic. |
 | [`daemon`](#daemon) | Install, start, stop, and inspect the background daemon. |
-| [`key`](#key) | Add a recipient or rotate the current machine key. |
+| [`key`](#key) | Add, list, or remove recipients, or rotate the current machine key. |
 | [`skill`](#skill) | Remove a skill from the vault. |
 | [`plugin`](#plugin) | List or reinstall a machine's Claude plugins from its vault manifest. |
 | [`vault`](#vault) | Migrate an older vault to the current format (`vault upgrade`). |
@@ -301,22 +301,26 @@ agentsync daemon uninstall
 
 ## key
 
-**Why**: Add a new recipient or rotate the current machine's keypair without changing vault semantics.
+**Why**: Manage who can decrypt the vault — add a recipient, list recipients, deauthorize (remove) one, or rotate the current machine's keypair.
 
 **Usage**:
 
 ```bash
-agentsync key add <name> <age-public-key>
-agentsync key rotate
+agentsync key add <name> <age-public-key>   # authorize a recipient
+agentsync key list                           # audit who can decrypt the vault
+agentsync key remove <name>                  # deauthorize a recipient
+agentsync key rotate                         # new local identity, re-encrypt
 ```
 
-**Outcome**: every existing vault artefact is decrypted under the current key and re-encrypted under the updated recipient set, then the change is committed and pushed.
+**Outcome**: `add`, `remove`, and `rotate` decrypt every existing vault artefact under the current key and re-encrypt it under the updated recipient set, then commit and push. `list` is read-only — it prints each recipient alias and public key from `agentsync.toml`, marking the entry that belongs to this machine with `*`.
 
 **Caveats**:
 
-- `key add` and `key rotate` reconcile against the latest remote state before they rewrite encrypted vault content.
+- `key add`, `key remove`, and `key rotate` reconcile against the latest remote state before they rewrite encrypted vault content.
 - If the vault history has diverged, key-management commands stop until the vault is reset or recloned. See [Recover from divergence](operations.md#recover-from-divergence).
-- Rotation depends on the **old** private key still being available so existing vault files can be decrypted. Back up the old key before rotation if you intend to retire that identity entirely.
+- Rotation depends on the **old** private key still being available so existing vault files can be decrypted. Back up the old key before rotation if you intend to retire that identity entirely. Rotation is crash-safe: it re-encrypts to both the old and new key, swaps the key file atomically, then drops the old recipient, so an interrupted rotation never leaves a vault no on-disk key can read.
+- `key remove` re-encrypts forward for the remaining recipients, so the removed key can no longer read **future** pushes. It **cannot** retro-purge git history: a removed key still decrypts the vault state already on the remote. For true revocation of a lost machine, also rotate any secrets it could read. See [Deauthorize a lost machine](operations.md#deauthorize-a-lost-machine).
+- `key remove` refuses to remove the only remaining recipient (a vault must stay decryptable) and refuses to remove the key of the machine you run it on (you cannot deauthorize yourself — run it from another machine to remove a lost one).
 - Recipient names are stable config keys and are visible in the vault repository. Use names that describe the machine clearly without leaking sensitive context.
 
 ## skill

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -127,6 +127,32 @@ agentsync key add my-laptop age1...
 
 The vault is reconciled against the remote, every existing artefact is re-encrypted for the updated recipient set, and the change is pushed. The new machine can then `copy` the artefacts it needs from any machine's namespace.
 
+### List recipients
+
+To audit who can decrypt the vault:
+
+```bash
+agentsync key list
+```
+
+It prints every recipient alias and its `age1…` public key from `agentsync.toml`, marking the entry that belongs to the machine you run it on with `*`. Read-only — it never reconciles or pushes.
+
+### Deauthorize a lost machine
+
+When a machine is lost or retired, remove its recipient from **another** machine that can still decrypt the vault:
+
+```bash
+agentsync key list             # find the alias to remove
+agentsync key remove old-laptop
+```
+
+The vault is reconciled, every artefact is re-encrypted for the remaining recipients, and the change is pushed. From that commit on, the removed key cannot decrypt new pushes.
+
+Two limits to understand:
+
+- **History is not purged.** The removed key still decrypts the vault state already in the remote's git history. `key remove` is forward revocation, not a retroactive wipe. If the lost machine could read real secrets, rotate those secrets at their source — the vault cannot un-leak what was already committed.
+- **You cannot remove yourself.** `key remove` refuses the alias whose key matches the machine you run it on (it would lock that machine out of future pushes) and refuses to remove the last remaining recipient. Run it from a different, trusted machine to deauthorize a lost one.
+
 ### Rotate the current machine key
 
 Rotation re-encrypts every artefact under a fresh keypair on the current machine:
@@ -211,7 +237,7 @@ SmartScreen reputation is per-binary-hash and accrues with downloads; every new 
 
 ### Recover from divergence
 
-Reconciliation is fast-forward only. Any command that touches the vault (`init`, `push`, `copy`, `key add`, `key rotate`) fails closed when local history has diverged from `origin/<branch>`.
+Reconciliation is fast-forward only. Any command that touches the vault (`init`, `push`, `copy`, `key add`, `key remove`, `key rotate`) fails closed when local history has diverged from `origin/<branch>`.
 
 Symptoms:
 

--- a/src/commands/__tests__/key.test.ts
+++ b/src/commands/__tests__/key.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Tests for the `agentsync key` verbs: `remove`, `list`, and `rotate`
+ * crash-safety / round-trip.
+ *
+ * Like skill.test.ts, these exercise the testable cores (`performKeyRemove`,
+ * `performKeyList`, `performKeyRotate`) directly against a tmp bare-repo +
+ * working-repo pair, with no git mocking, so every documented outcome is proven
+ * end-to-end including the actual age re-encryption.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { readFile, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { loadConfig, resolveConfigPath } from "../../config/loader";
+import { machineVaultRoot } from "../../config/paths";
+import { decryptString, encryptString } from "../../core/encryptor";
+import {
+  createAgeIdentity,
+  createBareRepo,
+  createMachineFixture,
+  createTmpDir,
+  runGit,
+  seedVaultRepo,
+  type TestMachineFixture,
+} from "../../test-helpers/fixtures";
+
+{
+  const require = createRequire(import.meta.url);
+  // biome-ignore lint/style/useNodejsImportProtocol: deliberate alias to bypass mock cache
+  const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
+}
+
+mock.module("@clack/prompts", () => ({
+  intro: () => {},
+  outro: () => {},
+  log: { success: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+  note: () => {},
+  spinner: () => ({ start: () => {}, stop: () => {}, message: () => {} }),
+}));
+
+type KeyMod = typeof import("../key");
+let keyMod: KeyMod;
+
+const RUNTIME_ENV_KEYS = [
+  "AGENTSYNC_VAULT_DIR",
+  "AGENTSYNC_KEY_PATH",
+  "AGENTSYNC_MACHINE",
+  "AGENTSYNC_MACHINE_FILE",
+];
+
+beforeEach(async () => {
+  keyMod = await import("../key");
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+/** Encrypt a payload to the given recipients, write it under the machine vault, commit, push. */
+function seedEncryptedArtifact(
+  machine: TestMachineFixture,
+  relPath: string,
+  plaintext: string,
+  armored: string,
+): void {
+  const target = join(machineVaultRoot(machine.vaultDir, machine.machineName), relPath);
+  mkdirSync(join(target, ".."), { recursive: true });
+  writeFileSync(target, armored, "utf8");
+  runGit(["add", "."], machine.vaultDir);
+  runGit(["commit", "-m", `seed: ${relPath}`], machine.vaultDir);
+  runGit(["push", "origin", "main"], machine.vaultDir);
+}
+
+describe("key lifecycle", () => {
+  let tmpDir: string;
+  let machine: TestMachineFixture;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  async function setEnv(m: TestMachineFixture): Promise<void> {
+    process.env.AGENTSYNC_VAULT_DIR = m.vaultDir;
+    process.env.AGENTSYNC_KEY_PATH = m.keyPath;
+    process.env.AGENTSYNC_MACHINE = m.machineName;
+    process.env.AGENTSYNC_MACHINE_FILE = m.machineFilePath;
+  }
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    machine = await createMachineFixture(tmpDir, "key-test");
+    for (const key of RUNTIME_ENV_KEYS) savedEnv[key] = process.env[key];
+    process.exitCode = 0;
+  });
+
+  // Per-test afterEach is registered inline so each test restores env + tmp.
+  function restore(): Promise<void> {
+    for (const key of RUNTIME_ENV_KEYS) {
+      const value = savedEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return rm(tmpDir, { recursive: true, force: true });
+  }
+
+  test("performKeyList returns recipients sorted and flags this machine", async () => {
+    const bare = await createBareRepo(tmpDir);
+    const other = await createAgeIdentity();
+    seedVaultRepo({
+      machine,
+      bareRepoPath: bare,
+      recipients: { "key-test": machine.recipient, "work-laptop": other.recipient },
+    });
+    await setEnv(machine);
+
+    const entries = await keyMod.performKeyList();
+    expect(entries.map((e) => e.name)).toEqual(["key-test", "work-laptop"]);
+    expect(entries.find((e) => e.name === "key-test")?.isSelf).toBe(true);
+    expect(entries.find((e) => e.name === "work-laptop")?.isSelf).toBe(false);
+    await restore();
+  });
+
+  test("performKeyRemove revokes a recipient: remaining key decrypts, removed key cannot", async () => {
+    const bare = await createBareRepo(tmpDir);
+    const other = await createAgeIdentity();
+    seedVaultRepo({
+      machine,
+      bareRepoPath: bare,
+      recipients: { "key-test": machine.recipient, "work-laptop": other.recipient },
+    });
+    await setEnv(machine);
+
+    const plaintext = "# shared CLAUDE.md";
+    const armored = await encryptString(plaintext, [machine.recipient, other.recipient]);
+    seedEncryptedArtifact(machine, join("claude", "CLAUDE.md.age"), plaintext, armored);
+
+    const result = await keyMod.performKeyRemove({ name: "work-laptop" });
+    expect(result.status).toBe("success");
+    if (result.status === "success") expect(result.remaining).toBe(1);
+
+    // Config no longer lists the removed recipient.
+    const config = await loadConfig(resolveConfigPath(machine.vaultDir));
+    expect(config.recipients["work-laptop"]).toBeUndefined();
+    expect(config.recipients["key-test"]).toBe(machine.recipient);
+
+    // The artifact was re-encrypted: the local key still decrypts it, the
+    // removed key no longer can.
+    const reArmored = await readFile(
+      join(machineVaultRoot(machine.vaultDir, machine.machineName), "claude", "CLAUDE.md.age"),
+      "utf8",
+    );
+    expect(await decryptString(reArmored, machine.identity)).toBe(plaintext);
+    await expect(decryptString(reArmored, other.identity)).rejects.toThrow();
+    await restore();
+  });
+
+  test("performKeyRemove refuses to remove this machine's own key", async () => {
+    const bare = await createBareRepo(tmpDir);
+    const other = await createAgeIdentity();
+    seedVaultRepo({
+      machine,
+      bareRepoPath: bare,
+      recipients: { "key-test": machine.recipient, "work-laptop": other.recipient },
+    });
+    await setEnv(machine);
+
+    const result = await keyMod.performKeyRemove({ name: "key-test" });
+    expect(result.status).toBe("self");
+    await restore();
+  });
+
+  test("performKeyRemove reports not-found for an unknown alias", async () => {
+    const bare = await createBareRepo(tmpDir);
+    seedVaultRepo({ machine, bareRepoPath: bare });
+    await setEnv(machine);
+
+    const result = await keyMod.performKeyRemove({ name: "ghost" });
+    expect(result.status).toBe("not-found");
+    if (result.status === "not-found") expect(result.available).toContain("key-test");
+    await restore();
+  });
+
+  test("performKeyRemove refuses to remove the last recipient", async () => {
+    const bare = await createBareRepo(tmpDir);
+    const other = await createAgeIdentity();
+    // Single recipient that is NOT the local key, so the self-guard does not
+    // fire first and the last-recipient guard is exercised directly.
+    seedVaultRepo({
+      machine,
+      bareRepoPath: bare,
+      recipients: { "work-laptop": other.recipient },
+    });
+    await setEnv(machine);
+
+    const result = await keyMod.performKeyRemove({ name: "work-laptop" });
+    expect(result.status).toBe("last-recipient");
+    await restore();
+  });
+
+  test("performKeyRotate round-trips: new key decrypts vault, old recipient dropped", async () => {
+    const bare = await createBareRepo(tmpDir);
+    seedVaultRepo({ machine, bareRepoPath: bare });
+    await setEnv(machine);
+
+    const plaintext = "# rotate round-trip";
+    const armored = await encryptString(plaintext, [machine.recipient]);
+    seedEncryptedArtifact(machine, join("claude", "CLAUDE.md.age"), plaintext, armored);
+
+    const result = await keyMod.performKeyRotate();
+    expect(result.status).toBe("success");
+
+    const newIdentity = (await readFile(machine.keyPath, "utf8")).trim();
+    expect(newIdentity).not.toBe(machine.identity);
+
+    // New key decrypts the re-encrypted artifact; old identity cannot.
+    const reArmored = await readFile(
+      join(machineVaultRoot(machine.vaultDir, machine.machineName), "claude", "CLAUDE.md.age"),
+      "utf8",
+    );
+    expect(await decryptString(reArmored, newIdentity)).toBe(plaintext);
+    await expect(decryptString(reArmored, machine.identity)).rejects.toThrow();
+
+    // The config recipient for this machine was replaced, old recipient gone.
+    const config = await loadConfig(resolveConfigPath(machine.vaultDir));
+    expect(Object.values(config.recipients)).not.toContain(machine.recipient);
+    await restore();
+  });
+
+  test("performKeyRotate union pass keeps the vault readable when pass 2 fails mid-rotation", async () => {
+    const bare = await createBareRepo(tmpDir);
+    seedVaultRepo({ machine, bareRepoPath: bare });
+    await setEnv(machine);
+
+    const plaintext = "# rotate union safety";
+    const armored = await encryptString(plaintext, [machine.recipient]);
+    seedEncryptedArtifact(machine, join("claude", "CLAUDE.md.age"), plaintext, armored);
+
+    // Inject a failure on the SECOND write to the .age artifact — that is the
+    // new-only pass 2, which runs only after pass 1 (union ciphertext) and the
+    // atomic key swap have already completed.
+    const require = createRequire(import.meta.url);
+    const realFs = require("fs/promises") as typeof import("node:fs/promises");
+    let ageWrites = 0;
+    const failingWriteFile = ((path: unknown, ...rest: unknown[]) => {
+      if (typeof path === "string" && path.endsWith(".age")) {
+        ageWrites += 1;
+        if (ageWrites === 2) throw new Error("injected pass-2 failure");
+      }
+      return (realFs.writeFile as (...a: unknown[]) => unknown)(path, ...rest);
+    }) as typeof realFs.writeFile;
+    mock.module("node:fs/promises", () => ({
+      ...realFs,
+      writeFile: failingWriteFile,
+      default: { ...realFs, writeFile: failingWriteFile },
+    }));
+
+    const result = await keyMod.performKeyRotate();
+
+    // Restore the plain real-fs mock for the rest of the suite.
+    mock.module("node:fs/promises", () => ({ ...realFs, default: realFs }));
+
+    expect(result.status).toBe("failed");
+    // The key was already swapped (pass 1 wrote the union, then the key). The
+    // on-disk artifact is still the union ciphertext, readable by the NEW key —
+    // proving there is no crash window where no on-disk key can read the vault.
+    const newIdentity = (await readFile(machine.keyPath, "utf8")).trim();
+    expect(newIdentity).not.toBe(machine.identity);
+    const onDisk = await readFile(
+      join(machineVaultRoot(machine.vaultDir, machine.machineName), "claude", "CLAUDE.md.age"),
+      "utf8",
+    );
+    expect(await decryptString(onDisk, newIdentity)).toBe(plaintext);
+    await restore();
+  });
+
+  test("performKeyAdd rejects a pubkey already registered under another alias", async () => {
+    const bare = await createBareRepo(tmpDir);
+    const other = await createAgeIdentity();
+    seedVaultRepo({
+      machine,
+      bareRepoPath: bare,
+      recipients: { "key-test": machine.recipient, "work-laptop": other.recipient },
+    });
+    await setEnv(machine);
+
+    const result = await keyMod.performKeyAdd({ name: "second-alias", pubkey: other.recipient });
+    expect(result.status).toBe("duplicate-key");
+    if (result.status === "duplicate-key") expect(result.existingName).toBe("work-laptop");
+    await restore();
+  });
+
+  test("performKeyList degrades to not-self when the local key is unreadable", async () => {
+    const bare = await createBareRepo(tmpDir);
+    const other = await createAgeIdentity();
+    seedVaultRepo({
+      machine,
+      bareRepoPath: bare,
+      recipients: { "key-test": machine.recipient, "work-laptop": other.recipient },
+    });
+    await setEnv(machine);
+    process.env.AGENTSYNC_KEY_PATH = join(tmpDir, "absent-key.txt");
+
+    const entries = await keyMod.performKeyList();
+    expect(entries.length).toBe(2);
+    expect(entries.every((e) => !e.isSelf)).toBe(true);
+    await restore();
+  });
+});

--- a/src/commands/key.ts
+++ b/src/commands/key.ts
@@ -1,4 +1,5 @@
-import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { open, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
@@ -38,11 +39,73 @@ async function findAgeFiles(dir: string): Promise<string[]> {
   return results;
 }
 
+/**
+ * Decrypt every vault `.age` file once with the given identity.
+ *
+ * Built fully in memory BEFORE any caller writes to disk: an unreadable or
+ * corrupt artefact rejects here, so a re-encryption that aborts mid-way never
+ * leaves the key/config mutated. This preserves the `key rotate` contract that
+ * a failed re-encryption leaves `key.txt` and `agentsync.toml` untouched.
+ */
+async function decryptAllAgeFiles(files: string[], identity: string): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  for (const file of files) {
+    const armored = await readFile(file, "utf8");
+    out.set(file, await decryptString(armored, identity));
+  }
+  return out;
+}
+
+/** Re-encrypt a plaintext map to a recipient set, returning armored ciphertext per path. */
+async function encryptAll(
+  plaintexts: Map<string, string>,
+  recipients: string[],
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  for (const [file, plaintext] of plaintexts) {
+    out.set(file, await encryptString(plaintext, recipients));
+  }
+  return out;
+}
+
+/** Flush a path→ciphertext map to disk. */
+async function writeAll(ciphertexts: Map<string, string>): Promise<void> {
+  for (const [file, content] of ciphertexts) {
+    await writeFile(file, content, "utf8");
+  }
+}
+
+/**
+ * Persist an age identity with crash durability: write a sibling temp file,
+ * fsync it, then rename it over the destination. rename(2) is atomic on a single
+ * filesystem, so a crash leaves either the old key or the new key fully intact,
+ * never a truncated middle that bricks the machine's only decryption material.
+ */
+async function writeIdentityAtomic(path: string, identity: string): Promise<void> {
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  const handle = await open(tmp, "w", 0o600);
+  try {
+    try {
+      await handle.writeFile(`${identity}\n`, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(tmp, path);
+  } catch (err) {
+    // Any failure before the rename completes leaves a stray temp; drop it so a
+    // crashed write never litters the key directory with a partial identity.
+    await rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
+}
+
 /** Discriminated result of a `performKeyAdd` invocation. */
 export type KeyAddResult =
   | { status: "success"; name: string; recipientCount: number }
   | { status: "invalid-key"; error: string }
   | { status: "name-conflict"; name: string }
+  | { status: "duplicate-key"; name: string; existingName: string }
   | { status: "failed"; error: string };
 
 /** Discriminated result of a `performKeyRotate` invocation. */
@@ -55,6 +118,22 @@ export type KeyRotateResult =
     }
   | { status: "not-in-recipients"; error: string }
   | { status: "failed"; error: string };
+
+/** Discriminated result of a `performKeyRemove` invocation. */
+export type KeyRemoveResult =
+  | { status: "success"; name: string; remaining: number }
+  | { status: "not-found"; name: string; available: string[] }
+  | { status: "last-recipient"; name: string }
+  | { status: "self"; name: string }
+  | { status: "failed"; error: string };
+
+/** One recipient row for `performKeyList`. */
+export interface KeyListEntry {
+  name: string;
+  recipient: string;
+  /** True when this recipient is the key on the current machine. */
+  isSelf: boolean;
+}
 
 /**
  * Add an age recipient to the vault and re-encrypt every `.age` artefact for
@@ -96,19 +175,34 @@ export async function performKeyAdd(options: {
       return { status: "name-conflict", name: options.name };
     }
 
+    // One pubkey per alias: the `key remove` self-guard refuses removal by
+    // comparing the stored pubkey to the local identity, so a pubkey registered
+    // under two aliases would make "remove this alias" ambiguous. Reject a
+    // duplicate pubkey under a different name (the same-name path above is the
+    // idempotent re-add and is allowed).
+    const duplicateAlias = Object.entries(refreshedConfig.recipients).find(
+      ([name, pubkey]) => pubkey === options.pubkey && name !== options.name,
+    )?.[0];
+    if (duplicateAlias) {
+      return { status: "duplicate-key", name: options.name, existingName: duplicateAlias };
+    }
+
     refreshedConfig.recipients[options.name] = options.pubkey;
-    await writeConfig(configPath, refreshedConfig);
 
     const key = await loadPrivateKey(runtime.privateKeyPath);
     const allRecipients = Object.values(refreshedConfig.recipients);
     const ageFiles = await findAgeFiles(runtime.vaultDir);
 
-    for (const filePath of ageFiles) {
-      const encrypted = await readFile(filePath, "utf8");
-      const decrypted = await decryptString(encrypted, key);
-      const reEncrypted = await encryptString(decrypted, allRecipients);
-      await writeFile(filePath, reEncrypted, "utf8");
-    }
+    // Build the re-encrypted ciphertext in memory before writing anything, so a
+    // decrypt failure aborts with the vault untouched. The old key stays in
+    // `allRecipients`, so every on-disk file remains readable throughout —
+    // adding a recipient can never orphan content. Files are written before the
+    // config so a mid-write crash never leaves a config that claims a recipient
+    // the on-disk ciphertext does not yet include.
+    const plaintexts = await decryptAllAgeFiles(ageFiles, key);
+    const reEncrypted = await encryptAll(plaintexts, allRecipients);
+    await writeAll(reEncrypted);
+    await writeConfig(configPath, refreshedConfig);
 
     await git.addAll();
     const committed = await git.commit({ message: `key: add recipient ${options.name}` });
@@ -129,6 +223,17 @@ export async function performKeyAdd(options: {
 /**
  * Generate a new local age identity, re-encrypt every vault artefact for the
  * updated recipient set, persist the new key locally, and push the rotation.
+ *
+ * Crash-safe by a two-pass re-encryption around the key swap:
+ *   1. Re-encrypt every file to `union(new recipients, old recipient)` and write
+ *      it — the old key still decrypts everything on disk.
+ *   2. Persist the new identity atomically. The new recipient is a member of the
+ *      union just written, so a crash on either side of this step still leaves
+ *      every on-disk file readable by an on-disk key — no lock-out window.
+ *   3. Re-encrypt every file to the new recipient set only, dropping the old
+ *      recipient so a retired identity can no longer decrypt fresh pushes.
+ * Both ciphertext maps are built before any write, so a corrupt artefact aborts
+ * with `key.txt` and `agentsync.toml` untouched.
  */
 export async function performKeyRotate(): Promise<KeyRotateResult> {
   const runtime = await resolveRuntimeContext();
@@ -163,25 +268,24 @@ export async function performKeyRotate(): Promise<KeyRotateResult> {
 
     const nextConfig = structuredClone(config);
     nextConfig.recipients[machineName] = newRecipient;
-    const allRecipients = Object.values(nextConfig.recipients);
+    const newRecipients = Object.values(nextConfig.recipients);
+    // Dedup so the union never lists the same recipient twice (another alias
+    // could already hold the old recipient). The old recipient is gone from
+    // nextConfig, so the union is the new set plus the old.
+    const unionRecipients = Array.from(new Set([...newRecipients, oldRecipient]));
     const ageFiles = await findAgeFiles(runtime.vaultDir);
-    const rewrittenFiles = new Map<string, string>();
 
-    for (const filePath of ageFiles) {
-      const encrypted = await readFile(filePath, "utf8");
-      const decrypted = await decryptString(encrypted, oldKey);
-      const reEncrypted = await encryptString(decrypted, allRecipients);
-      rewrittenFiles.set(filePath, reEncrypted);
-    }
+    const plaintexts = await decryptAllAgeFiles(ageFiles, oldKey);
+    const unionCiphertext = await encryptAll(plaintexts, unionRecipients);
+    const newCiphertext = await encryptAll(plaintexts, newRecipients);
 
-    for (const [filePath, reEncrypted] of rewrittenFiles) {
-      await writeFile(filePath, reEncrypted, "utf8");
-    }
+    // Pass 1: union ciphertext (old key still decrypts everything on disk).
+    await writeAll(unionCiphertext);
+    // Swap the key atomically between the passes.
+    await writeIdentityAtomic(runtime.privateKeyPath, newIdentity);
+    // Pass 2: drop the old recipient (new key decrypts everything).
+    await writeAll(newCiphertext);
 
-    await writeFile(runtime.privateKeyPath, `${newIdentity}\n`, {
-      encoding: "utf8",
-      mode: 0o600,
-    });
     await writeConfig(configPath, nextConfig);
 
     await git.addAll();
@@ -203,6 +307,101 @@ export async function performKeyRotate(): Promise<KeyRotateResult> {
   } catch (err) {
     return { status: "failed", error: err instanceof Error ? err.message : String(err) };
   }
+}
+
+/**
+ * Remove a recipient from the vault and re-encrypt every artefact for the
+ * remaining set, so the removed key can no longer decrypt FUTURE pushes.
+ *
+ * Refuses to remove the last recipient (a vault must stay decryptable) and the
+ * running machine's own key (you cannot deauthorize the machine you are on —
+ * remove a lost machine from a different one). The re-encryption targets a
+ * subset that still contains the local key, so every on-disk file stays readable
+ * throughout; the ciphertext map is built before any write so a failure leaves
+ * the vault untouched.
+ */
+export async function performKeyRemove(options: { name: string }): Promise<KeyRemoveResult> {
+  const runtime = await resolveRuntimeContext();
+  const configPath = resolveConfigPath(runtime.vaultDir);
+  const config = await loadVaultConfigOrExit(runtime.vaultDir);
+
+  try {
+    // Inside the try so a missing or unreadable key returns a typed `failed`
+    // result rather than escaping as a raw rejection.
+    const key = await loadPrivateKey(runtime.privateKeyPath);
+    const git = new GitClient(runtime.vaultDir);
+    const reconciliation = await git.reconcileWithRemote({
+      remote: "origin",
+      branch: config.remote.branch,
+      allowMissingRemote: true,
+    });
+    const refreshed = await loadConfig(configPath);
+
+    if (!refreshed.recipients[options.name]) {
+      return {
+        status: "not-found",
+        name: options.name,
+        available: Object.keys(refreshed.recipients).sort(),
+      };
+    }
+
+    const localRecipient = await identityToRecipient(key);
+    if (refreshed.recipients[options.name] === localRecipient) {
+      return { status: "self", name: options.name };
+    }
+
+    const next = structuredClone(refreshed);
+    delete next.recipients[options.name];
+    const remaining = Object.values(next.recipients);
+    if (remaining.length === 0) {
+      return { status: "last-recipient", name: options.name };
+    }
+
+    const ageFiles = await findAgeFiles(runtime.vaultDir);
+    const plaintexts = await decryptAllAgeFiles(ageFiles, key);
+    const reEncrypted = await encryptAll(plaintexts, remaining);
+    // Re-encrypt the artefacts BEFORE dropping the recipient from config, so a
+    // mid-write crash fails safe: the removed key is already excluded from the
+    // on-disk ciphertext while config still lists it, never the reverse.
+    await writeAll(reEncrypted);
+    await writeConfig(configPath, next);
+
+    await git.addAll();
+    const committed = await git.commit({ message: `key: remove recipient ${options.name}` });
+    if (committed) {
+      await git.push(
+        "origin",
+        next.remote.branch,
+        reconciliation.status === "remote-missing" ? ["--set-upstream"] : [],
+      );
+    }
+
+    return { status: "success", name: options.name, remaining: remaining.length };
+  } catch (err) {
+    return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * List the recipients registered in the vault config, flagging the one that
+ * matches the local machine's key. Read-only: reads the committed local config
+ * (the same source `status` reads), never pushes. A missing local key means the
+ * self flag cannot be computed, so every row is reported as not-self.
+ */
+export async function performKeyList(): Promise<KeyListEntry[]> {
+  const runtime = await resolveRuntimeContext();
+  const config = await loadVaultConfigOrExit(runtime.vaultDir);
+
+  let localRecipient: string | null = null;
+  try {
+    localRecipient = await identityToRecipient(await loadPrivateKey(runtime.privateKeyPath));
+  } catch {
+    localRecipient = null;
+  }
+
+  return Object.entries(config.recipients)
+    .map(([name, recipient]) => ({ name, recipient, isSelf: recipient === localRecipient }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /** Manage recipients and local age key rotation for an existing vault. */
@@ -248,11 +447,86 @@ export const keyCommand = defineCommand({
             );
             process.exitCode = 1;
             return;
+          case "duplicate-key":
+            log.error(
+              `That public key is already registered as '${result.existingName}'. Reuse that alias, or remove it first.`,
+            );
+            process.exitCode = 1;
+            return;
           case "failed":
             log.error(result.error);
             process.exitCode = 1;
             return;
         }
+      },
+    }),
+
+    remove: defineCommand({
+      meta: {
+        description:
+          "Remove a recipient and re-encrypt the vault so they can no longer decrypt new pushes",
+      },
+      args: {
+        name: {
+          type: "positional",
+          description: "Recipient alias to remove (see `agentsync key list`)",
+          required: true,
+        },
+      },
+      async run({ args }) {
+        const result = await performKeyRemove({ name: String(args.name) });
+
+        switch (result.status) {
+          case "success":
+            log.success(
+              `Removed recipient '${result.name}'. Vault re-encrypted for ${result.remaining} recipient(s).`,
+            );
+            log.warn(
+              [
+                "The removed key can still decrypt PRIOR vault history already on the remote.",
+                "For true revocation of a lost machine, rotate any secrets it could read.",
+              ].join("\n"),
+            );
+            return;
+          case "not-found":
+            log.error(
+              `No recipient named '${result.name}'. Known: ${result.available.join(", ") || "(none)"}`,
+            );
+            process.exitCode = 1;
+            return;
+          case "last-recipient":
+            log.error(
+              `Refusing to remove '${result.name}': it is the only recipient. A vault must keep at least one.`,
+            );
+            process.exitCode = 1;
+            return;
+          case "self":
+            log.error(
+              `Refusing to remove '${result.name}': it is THIS machine's own key. Run \`agentsync key remove ${result.name}\` from another machine to deauthorize this one.`,
+            );
+            process.exitCode = 1;
+            return;
+          case "failed":
+            log.error(result.error);
+            process.exitCode = 1;
+            return;
+        }
+      },
+    }),
+
+    list: defineCommand({
+      meta: { description: "List the recipients who can decrypt the vault" },
+      async run() {
+        const entries = await performKeyList();
+        if (entries.length === 0) {
+          log.warn("No recipients registered. Run `agentsync init` first.");
+          return;
+        }
+        log.info("Recipients ('*' = this machine):");
+        for (const entry of entries) {
+          log.info(`  ${entry.isSelf ? "*" : " "} ${entry.name}  ${entry.recipient}`);
+        }
+        log.info(`${entries.length} recipient(s) can decrypt the vault.`);
       },
     }),
 


### PR DESCRIPTION
## Why

`agentsync` could authorize recipients (`key add`) but had **no way to deauthorize one**. If a laptop was lost, its age identity stayed a valid recipient on every future push forever — the only "fix" was destroying the whole vault. There was also no way to audit who can decrypt the vault, and `key rotate` had a crash window that could leave freshly re-encrypted files unreadable by any on-disk key.

This is the first PR in a series addressing key-lifecycle, discovery, daemon-reliability, and configurability gaps.

## What

- **`agentsync key remove <name>`** — recipient revocation. Reconciles fast-forward, re-encrypts every vault artefact for the *remaining* recipients (so the removed key can no longer read future pushes), commits, and pushes. Refuses to remove the last recipient or this machine's own key (you deauthorize a lost machine from a *different* one). Re-encrypts files before dropping the recipient from config, so a mid-write crash fails safe.
- **`agentsync key list`** — read-only audit of recipients, marking this machine's entry with `*`.
- **Crash-safe `key rotate`** — two-pass re-encryption around the key swap: write ciphertext for `union(new, old)` → atomically swap `key.txt` → re-encrypt to the new set only. The new recipient is always a member of the union written first, so **no crash point leaves an on-disk file unreadable by an on-disk key**. Both ciphertext maps are built in memory before any write, preserving the existing "key unchanged on re-encryption failure" contract.
- **Hardening** — `key add` now rejects a pubkey already registered under another alias (the `remove` self-guard relies on one-pubkey-per-alias); `writeIdentityAtomic` cleans up its temp on any failure.

## Honest limitation (documented)

`key remove` is **forward** revocation. It cannot retro-purge git history — a removed key still decrypts the vault state already on the remote. For true revocation of a lost machine, rotate any secrets it could read. This is spelled out in `docs/operations.md#deauthorize-a-lost-machine`.

## Tests

New `src/commands/__tests__/key.test.ts` (9 tests) against real git fixtures: forward-revocation (removed key's decrypt fails), self/last-recipient/not-found guards, list self-flagging + missing-key degradation, duplicate-pubkey rejection, rotate round-trip, and a **failure-injection test that proves the union safety property** (pass-2 write fails → vault still readable by the new key). Full suite: 907 pass / 0 fail.

## CI note

`bun test` exits non-zero on the per-file coverage floor, but CI treats 0-fail as success (`.github/workflows/ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
