### PR TITLE
feat(daemon): durable health state, divergence escalation, staleness checks, watcher pre-filter

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -314,7 +314,7 @@ agentsync upgrade --check  # report only, install nothing
 ```bash
 agentsync daemon install     # write the OS service descriptor
 agentsync daemon start       # idempotent
-agentsync daemon status      # IPC ping
+agentsync daemon status      # last-sync health (last success, failures, stuck)
 agentsync daemon stop
 agentsync daemon uninstall
 ```
@@ -325,7 +325,8 @@ agentsync daemon uninstall
 
 - Only one daemon runs per user. A second-instance check exits cleanly if a daemon is already up.
 - A transient sync failure triggers one automatic retry. If the retry also fails, the error is recorded but the daemon stays alive so the next change can trigger a fresh push.
-- See [Daemon](operations.md#daemon) for install paths per OS, lifecycle, and log locations.
+- `daemon status` reports the last successful sync time, consecutive failures, and a **stuck** flag (vault diverged). When the daemon is **not** running it falls back to the durable `daemon-state.json`, so you still see when sync last succeeded. `doctor` surfaces a stale or stuck last-sync as a dedicated health row — a silent backup failure is loud, not invisible.
+- See [Daemon](operations.md#daemon) for install paths per OS, lifecycle, health/durable-state, and log locations.
 
 ## key
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -65,10 +65,20 @@ The daemon moves through a small number of phases. Each phase has a well-defined
 |---|---|
 | Validating | Verifies the vault directory, the config file, and the encryption key are reachable. Exits immediately on failure. |
 | Second-instance check | Sends an IPC `status` ping. If a daemon is already running, exits. Unlinks a stale socket if the prior daemon died ungracefully. |
-| Running | IPC server is listening and file watchers are active (push-only; no pull timer). `status` returns the current pid, consecutive-failure counter, and last error. |
+| Running | IPC server is listening and file watchers are active (push-only; no pull timer). `status` returns pid, last successful sync time, consecutive-failure counter, last error, and whether the daemon is stuck. |
 | Syncing | A push is executing inside the sync queue. Only one sync runs at a time. |
 | Retry once | Automatic single retry after a transient failure. If both attempts fail, the error is recorded but the daemon stays alive so the next change can still trigger a push. |
+| Stuck | The vault diverged (`DIVERGED_HISTORY`). A divergence cannot heal on its own, so the daemon latches a `stuck` flag, fires one desktop notification, and backs off watcher-driven retries to once every 5 minutes instead of hammering a doomed push. A manual `agentsync push` is never throttled. The next success (after you reset the vault) clears it. |
 | Shutting down | Drains the sync queue with a hard ten-second timeout, closes IPC, stops watchers, unlinks the socket, exits cleanly. |
+
+### Health and durable state
+
+The daemon persists its health to `<AGENTSYNC_DIR>/daemon-state.json` (last successful sync, last error, consecutive failures, and the stuck flag) and updates it on every success and failure. Because it is on disk, the state survives a crash or restart:
+
+- `agentsync daemon status` reports the live state when the daemon is up, and **falls back to the durable file when it is down** — so you can still see when sync last succeeded and whether it died stuck.
+- `agentsync doctor` reads the same file and adds a **Daemon sync health** row: it **fails** when stuck, **warns** when the daemon is installed but the last success is older than 24 hours (or has never succeeded), and **passes** on a recent success. This is the loud signal that a *silent* backup failure has been happening — the worst failure mode for a backup tool. (The installed-but-stale/never warning is derived from the service file, which doctor only detects on macOS and Linux today; on Windows the row still **fails** on a stuck vault but does not yet warn on staleness.)
+
+The file watcher pre-filters never-sync paths (`sessions/`, `history.jsonl`, `*.local.md`, …) at the watch layer, so a high-churn agent directory no longer wakes a push that would snapshot nothing.
 
 ### Configuration
 

--- a/src/commands/__tests__/daemon.test.ts
+++ b/src/commands/__tests__/daemon.test.ts
@@ -4,11 +4,14 @@
  * Covers getExecutableArgs() and the daemon subcommands (install, start, stop, status, uninstall).
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { rm } from "node:fs/promises";
 import { log } from "@clack/prompts";
 import { IpcClient } from "../../core/ipc";
 import { __setInstallerLinuxOverridesForTests } from "../../daemon/installer-linux";
 import { __setInstallerMacOsOverridesForTests } from "../../daemon/installer-macos";
 import { __setInstallerWindowsOverridesForTests } from "../../daemon/installer-windows";
+import { writeDaemonState } from "../../daemon/state";
+import { createTmpDir } from "../../test-helpers/fixtures";
 
 // ── getExecutableArgs tests ────────────────────────────────────────────────────
 
@@ -112,10 +115,12 @@ __setInstallerWindowsOverridesForTests({
 const successLogs: string[] = [];
 const errorLogs: string[] = [];
 const warnLogs: string[] = [];
+const infoLogs: string[] = [];
 
 let successSpy: ReturnType<typeof spyOn>;
 let errorSpy: ReturnType<typeof spyOn>;
 let warnSpy: ReturnType<typeof spyOn>;
+let infoSpy: ReturnType<typeof spyOn>;
 let ipcClientSendSpy: ReturnType<typeof spyOn>;
 
 beforeAll(() => {
@@ -128,6 +133,9 @@ beforeAll(() => {
   warnSpy = spyOn(log, "warn").mockImplementation((msg: string) => {
     warnLogs.push(msg);
   });
+  infoSpy = spyOn(log, "info").mockImplementation((msg: string) => {
+    infoLogs.push(msg);
+  });
   ipcClientSendSpy = spyOn(IpcClient.prototype, "send");
 });
 
@@ -135,6 +143,7 @@ afterAll(() => {
   successSpy.mockRestore();
   errorSpy.mockRestore();
   warnSpy.mockRestore();
+  infoSpy.mockRestore();
   ipcClientSendSpy.mockRestore();
   // Clear the globalThis-backed override slots so any later test file that
   // exercises the real installer functions sees clean defaults.
@@ -147,6 +156,7 @@ afterAll(() => {
 beforeEach(() => {
   successLogs.length = 0;
   errorLogs.length = 0;
+  infoLogs.length = 0;
   warnLogs.length = 0;
   mockInstall.mockClear();
   mockUninstall.mockClear();
@@ -244,6 +254,73 @@ describe("daemonCommand subcommands", () => {
 
     expect(errorLogs.some((m) => m.includes("not running"))).toBe(true);
     expect(process.exitCode).toBe(1);
+  });
+
+  test("status falls back to the durable state file when the daemon is down", async () => {
+    const tmp = await createTmpDir();
+    const saved = process.env.AGENTSYNC_DIR;
+    process.env.AGENTSYNC_DIR = tmp;
+    try {
+      await writeDaemonState({
+        pid: null,
+        startedAt: null,
+        lastSuccessAt: new Date().toISOString(),
+        lastErrorAt: new Date().toISOString(),
+        lastError: "[push] Vault history diverged",
+        consecutiveFailures: 3,
+        stuck: true,
+      });
+      ipcClientSendSpy.mockRejectedValueOnce(new Error("ENOENT"));
+      const cmd = await getSubCmd("status");
+      await cmd.run();
+
+      expect(errorLogs.some((m) => m.includes("not running"))).toBe(true);
+      expect(errorLogs.some((m) => m.includes("STUCK"))).toBe(true);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      if (saved === undefined) delete process.env.AGENTSYNC_DIR;
+      else process.env.AGENTSYNC_DIR = saved;
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("status subcommand escalates a stuck daemon and exits 1", async () => {
+    ipcClientSendSpy.mockResolvedValueOnce({
+      id: "test",
+      ok: true,
+      data: {
+        pid: 12345,
+        consecutiveFailures: 7,
+        lastError: "[push] Vault history diverged",
+        lastSuccessAt: null,
+        startedAt: new Date().toISOString(),
+        stuck: true,
+      },
+    });
+    const cmd = await getSubCmd("status");
+    await cmd.run();
+
+    expect(errorLogs.some((m) => m.includes("STUCK"))).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("status subcommand reports the last successful sync age", async () => {
+    ipcClientSendSpy.mockResolvedValueOnce({
+      id: "test",
+      ok: true,
+      data: {
+        pid: 12345,
+        consecutiveFailures: 0,
+        lastError: null,
+        lastSuccessAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+        startedAt: new Date().toISOString(),
+        stuck: false,
+      },
+    });
+    const cmd = await getSubCmd("status");
+    await cmd.run();
+
+    expect(infoLogs.some((m) => m.includes("Last successful sync"))).toBe(true);
   });
 
   test("status subcommand handles error response from daemon", async () => {

--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -10,8 +10,9 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { rm, symlink } from "node:fs/promises";
 import { join } from "node:path";
 import { AgentPaths } from "../../config/paths";
+import { type DaemonState, writeDaemonState } from "../../daemon/state";
 import { createTmpDir } from "../../test-helpers/fixtures";
-import { buildSkillsDirChecks } from "../doctor";
+import { buildDaemonHealthCheck, buildSkillsDirChecks } from "../doctor";
 
 type MutablePaths = {
   claude: { skillsDir: string };
@@ -127,5 +128,65 @@ describe("buildSkillsDirChecks", () => {
     const claudeRow = rows.find((r) => r.name === "Claude skills directory");
     expect(claudeRow?.status).toBe("warn");
     expect(claudeRow?.detail).toContain("Symlinked skills root");
+  });
+});
+
+describe("buildDaemonHealthCheck", () => {
+  let tmpDir: string;
+  let savedDir: string | undefined;
+
+  const base: DaemonState = {
+    pid: null,
+    startedAt: null,
+    lastSuccessAt: null,
+    lastErrorAt: null,
+    lastError: null,
+    consecutiveFailures: 0,
+    stuck: false,
+  };
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    savedDir = process.env.AGENTSYNC_DIR;
+    process.env.AGENTSYNC_DIR = tmpDir;
+  });
+
+  afterEach(async () => {
+    if (savedDir === undefined) delete process.env.AGENTSYNC_DIR;
+    else process.env.AGENTSYNC_DIR = savedDir;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("fails when the daemon is stuck on a divergence", async () => {
+    await writeDaemonState({ ...base, stuck: true, lastError: "[push] diverged" });
+    const row = await buildDaemonHealthCheck(true);
+    expect(row.status).toBe("fail");
+    expect(row.detail).toContain("STUCK");
+  });
+
+  test("warns when installed but no sync has ever succeeded", async () => {
+    await writeDaemonState(base);
+    const row = await buildDaemonHealthCheck(true);
+    expect(row.status).toBe("warn");
+  });
+
+  test("passes when not installed and no sync has run", async () => {
+    await writeDaemonState(base);
+    const row = await buildDaemonHealthCheck(false);
+    expect(row.status).toBe("pass");
+  });
+
+  test("warns when the last success is stale", async () => {
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    await writeDaemonState({ ...base, lastSuccessAt: old });
+    const row = await buildDaemonHealthCheck(true);
+    expect(row.status).toBe("warn");
+    expect(row.detail).toContain("stale");
+  });
+
+  test("passes on a recent successful sync", async () => {
+    await writeDaemonState({ ...base, lastSuccessAt: new Date().toISOString() });
+    const row = await buildDaemonHealthCheck(true);
+    expect(row.status).toBe("pass");
   });
 });

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -5,6 +5,13 @@ import { defineCommand } from "citty";
 import { resolveDaemonSocketPath } from "../config/paths";
 import { DaemonStatusSchema } from "../config/schema";
 import { IpcClient } from "../core/ipc";
+import { type DaemonState, formatAge, readDaemonState } from "../daemon/state";
+
+/** Render the "last successful sync" line shared by the live and offline paths. */
+function lastSyncLine(lastSuccessAt: string | null): string {
+  if (!lastSuccessAt) return "Last successful sync: never";
+  return `Last successful sync: ${formatAge(Date.now() - Date.parse(lastSuccessAt))} ago`;
+}
 
 /**
  * Detect whether a file path resolves into a session-scoped temporary directory
@@ -144,26 +151,50 @@ export const daemonCommand = defineCommand({
     }),
 
     status: defineCommand({
-      meta: { description: "Show daemon status via IPC" },
+      meta: { description: "Show daemon status and last-sync health" },
       async run() {
         const client = new IpcClient();
         try {
           const response = await client.send("status", {}, resolveDaemonSocketPath());
-          if (response.ok) {
-            const parsed = DaemonStatusSchema.safeParse(response.data);
-            const pid = parsed.success ? parsed.data.pid : (response.data as { pid: number }).pid;
-            const failures = parsed.success ? parsed.data.consecutiveFailures : 0;
-            const lastErr = parsed.success ? parsed.data.lastError : null;
-            log.success(`Daemon is running (pid: ${pid})`);
-            if (failures > 0) {
-              log.warn(`Consecutive failures: ${failures}. Last error: ${lastErr ?? "unknown"}`);
-            }
-          } else {
+          if (!response.ok) {
             log.error(`Daemon error: ${response.error}`);
             process.exitCode = 1;
+            return;
+          }
+          const parsed = DaemonStatusSchema.safeParse(response.data);
+          if (!parsed.success) {
+            const pid = (response.data as { pid?: number }).pid ?? "unknown";
+            log.success(`Daemon is running (pid: ${pid}).`);
+            return;
+          }
+          const s = parsed.data;
+          log.success(`Daemon is running (pid: ${s.pid}).`);
+          log.info(lastSyncLine(s.lastSuccessAt));
+          if (s.stuck) {
+            log.error(
+              "STUCK: vault history diverged — auto-sync is paused until you reset the vault. See `agentsync doctor`.",
+            );
+            process.exitCode = 1;
+          } else if (s.consecutiveFailures > 0) {
+            log.warn(
+              `Consecutive failures: ${s.consecutiveFailures}. Last error: ${s.lastError ?? "unknown"}`,
+            );
           }
         } catch {
+          // Daemon is down — fall back to the durable state file so the user
+          // still sees when sync last succeeded and whether it died stuck.
+          const s: DaemonState = await readDaemonState();
           log.error("Daemon is not running.");
+          if (s.lastSuccessAt || s.lastErrorAt) {
+            log.info(lastSyncLine(s.lastSuccessAt));
+            if (s.stuck) {
+              log.error(
+                "Last run was STUCK (vault diverged). Reset the vault, then start the daemon.",
+              );
+            } else if (s.lastError) {
+              log.warn(`Last error: ${s.lastError}`);
+            }
+          }
           process.exitCode = 1;
         }
       },

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -8,6 +8,7 @@ import { log } from "@clack/prompts";
 import { defineCommand } from "citty";
 import { formatConfigError, loadConfig, resolveConfigPath } from "../config/loader";
 import { AgentPaths } from "../config/paths";
+import { type DaemonState, formatAge, readDaemonState } from "../daemon/state";
 import { resolveRuntimeContext } from "./shared";
 
 /** Single diagnostic check row rendered by the doctor command. */
@@ -15,6 +16,50 @@ export interface Check {
   name: string;
   status: "pass" | "warn" | "fail";
   detail: string;
+}
+
+/** A successful sync older than this is reported as stale by `doctor`. */
+const STALE_SYNC_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Build the daemon sync-health row from the durable state file. A divergence
+ * (`stuck`) fails; a stale or never-succeeded last-sync warns ONLY when the
+ * daemon is installed (otherwise the user is not relying on auto-sync); a
+ * recent success passes. Extracted so the rule is unit-testable.
+ */
+export async function buildDaemonHealthCheck(daemonInstalled: boolean): Promise<Check> {
+  const state: DaemonState = await readDaemonState();
+  const name = "Daemon sync health";
+
+  if (state.stuck) {
+    return {
+      name,
+      status: "fail",
+      detail: `Auto-sync STUCK (vault diverged). Reset the vault, then it resumes. Last error: ${state.lastError ?? "unknown"}`,
+    };
+  }
+
+  if (state.lastSuccessAt === null) {
+    if (!daemonInstalled) {
+      return { name, status: "pass", detail: "Daemon not installed; no auto-sync expected." };
+    }
+    return {
+      name,
+      status: "warn",
+      detail:
+        "Daemon installed but has never recorded a successful sync. Check: agentsync daemon status",
+    };
+  }
+
+  const ageMs = Date.now() - Date.parse(state.lastSuccessAt);
+  if (daemonInstalled && ageMs > STALE_SYNC_MS) {
+    return {
+      name,
+      status: "warn",
+      detail: `Last successful sync was ${formatAge(ageMs)} ago (stale). Check: agentsync daemon status`,
+    };
+  }
+  return { name, status: "pass", detail: `Last successful sync ${formatAge(ageMs)} ago.` };
 }
 
 /**
@@ -241,9 +286,11 @@ export const doctorCommand = defineCommand({
       daemonServicePath = join(homedir(), ".config", "systemd", "user", "agentsync.service");
     }
 
+    let daemonInstalled = false;
     if (daemonServicePath) {
       try {
         await access(daemonServicePath, constants.R_OK);
+        daemonInstalled = true;
         checks.push({
           name: "Daemon service file",
           status: "pass",
@@ -257,6 +304,11 @@ export const doctorCommand = defineCommand({
         });
       }
     }
+
+    // 8. Daemon sync health from the durable state file. A backup daemon that
+    // fails silently is the worst failure mode, so surface a stale or stuck
+    // last-sync loudly here rather than only on an explicit `daemon status`.
+    checks.push(await buildDaemonHealthCheck(daemonInstalled));
 
     // Print results
     // biome-ignore lint/suspicious/noConsole: intentional CLI tabular output

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -121,6 +121,11 @@ export const DaemonStatusSchema = z.object({
   pid: z.number().int().positive(),
   consecutiveFailures: z.number().int().min(0),
   lastError: z.string().nullable(),
+  // Health fields. Optional with defaults so an older daemon's IPC response
+  // (which omits them) still validates against a newer client.
+  lastSuccessAt: z.string().nullable().default(null),
+  startedAt: z.string().nullable().default(null),
+  stuck: z.boolean().default(false),
 });
 
 /** Normalized status shape for the daemon IPC status response. */

--- a/src/core/__tests__/watcher.test.ts
+++ b/src/core/__tests__/watcher.test.ts
@@ -116,4 +116,38 @@ describe("Watcher", () => {
 
     expect(fireCount).toBe(beforeClose);
   });
+
+  // shouldSkip filters events at the watch layer (daemon passes shouldNeverSync)
+  test("shouldSkip prevents filtered paths from firing the callback", async () => {
+    const watcher = new Watcher();
+    const fired: string[] = [];
+    // Skip anything ending in `.skip`; everything else fires.
+    watcher.add(
+      tmpDir,
+      50,
+      (p) => void fired.push(p),
+      (path) => path.endsWith(".skip"),
+    );
+
+    // Re-write the kept file until the watcher delivers an event — fs.watch
+    // subscription latency under full-suite I/O contention can drop a single
+    // write, so retry rather than racing one event (matches this file's
+    // event-driven tolerance for FSEvents batching).
+    const keepPath = join(tmpDir, "keep.txt");
+    const start = Date.now();
+    while (fired.length < 1 && Date.now() - start < 6000) {
+      await writeFile(keepPath, String(Date.now()), "utf8");
+      await Bun.sleep(120);
+    }
+    expect(fired.length).toBeGreaterThanOrEqual(1);
+    const afterKeep = fired.length;
+
+    // A skipped file must not add a callback.
+    await writeFile(join(tmpDir, "noisy.skip"), "y", "utf8");
+    await Bun.sleep(300);
+    watcher.close();
+
+    expect(fired.length).toBe(afterKeep);
+    expect(fired.every((p) => !p.endsWith(".skip"))).toBe(true);
+  });
 });

--- a/src/core/watcher.ts
+++ b/src/core/watcher.ts
@@ -28,8 +28,18 @@ export class Watcher {
    * @param filePath    Absolute path to watch.
    * @param debounceMs  Minimum quiet period before firing the callback (default: 300 ms).
    * @param callback    Called with the affected path after the debounce window closes.
+   * @param shouldSkip  Optional predicate on the changed path. When it returns
+   *                    true the event is ignored at the watch layer — it does
+   *                    not reset the debounce or wake the callback. The daemon
+   *                    passes `shouldNeverSync` so high-churn paths (sessions,
+   *                    history) never trigger a push that would snapshot nothing.
    */
-  add(filePath: string, debounceMs: number, callback: WatchCallback): void {
+  add(
+    filePath: string,
+    debounceMs: number,
+    callback: WatchCallback,
+    shouldSkip?: (changedPath: string) => boolean,
+  ): void {
     if (this.watching.has(filePath)) return;
 
     // Create the entry first so the watcher callback can update it by reference,
@@ -38,6 +48,9 @@ export class Watcher {
 
     const watcher = watch(filePath, { recursive: true }, (_event, filename) => {
       const changedPath = filename ? join(filePath, filename) : filePath;
+
+      // Pre-filter never-sync / noisy paths before they reset the debounce.
+      if (shouldSkip?.(changedPath)) return;
 
       if (entry.debounceTimer !== null) {
         clearTimeout(entry.debounceTimer);

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -16,6 +16,7 @@ import { AgentPaths, resolveDaemonSocketPath } from "../../config/paths";
 import { IpcClient, IpcServer } from "../../core/ipc";
 import { Watcher } from "../../core/watcher";
 import { createAgeIdentity, createTmpDir, runGit } from "../../test-helpers/fixtures";
+import { EMPTY_DAEMON_STATE, readDaemonState, writeDaemonState } from "../state";
 
 {
   const require = createRequire(import.meta.url);
@@ -52,6 +53,7 @@ const originalProcessExit = process.exit;
 const originalVaultDir = process.env.AGENTSYNC_VAULT_DIR;
 const originalKeyPath = process.env.AGENTSYNC_KEY_PATH;
 const originalMachine = process.env.AGENTSYNC_MACHINE;
+const originalAgentsyncDir = process.env.AGENTSYNC_DIR;
 
 let tmpDir = "";
 
@@ -157,6 +159,12 @@ afterAll(() => {
   } else {
     process.env.AGENTSYNC_MACHINE = originalMachine;
   }
+
+  if (originalAgentsyncDir === undefined) {
+    delete process.env.AGENTSYNC_DIR;
+  } else {
+    process.env.AGENTSYNC_DIR = originalAgentsyncDir;
+  }
 });
 
 beforeEach(async () => {
@@ -200,6 +208,9 @@ beforeEach(async () => {
   process.env.AGENTSYNC_VAULT_DIR = vaultDir;
   process.env.AGENTSYNC_KEY_PATH = keyPath;
   process.env.AGENTSYNC_MACHINE = "daemon-machine";
+  // Isolate the durable daemon-state.json (and any desktop notification it
+  // triggers) into the tmp dir so tests never touch the real ~/.config/agentsync.
+  process.env.AGENTSYNC_DIR = tmpDir;
 
   infoLogs.length = 0;
   errorLogs.length = 0;
@@ -335,8 +346,41 @@ describe("failure tracking", () => {
     expect(status).toHaveProperty("pid");
     expect(status).toHaveProperty("consecutiveFailures");
     expect(status).toHaveProperty("lastError");
+    expect(status).toHaveProperty("lastSuccessAt");
+    expect(status).toHaveProperty("stuck");
     expect(typeof status.pid).toBe("number");
     expect(typeof status.consecutiveFailures).toBe("number");
+  });
+
+  test("a failed push persists to the durable state file", async () => {
+    await daemonModule.startDaemon();
+    await ipcHandlers.get("push")?.();
+
+    // The on-disk state must reflect the failure so `daemon status`/`doctor`
+    // can report it even after the daemon exits. The daemon persists state
+    // fire-and-forget, so poll until the write lands rather than racing it.
+    let persisted = await readDaemonState();
+    for (let i = 0; i < 40 && persisted.consecutiveFailures < 1; i++) {
+      await Bun.sleep(25);
+      persisted = await readDaemonState();
+    }
+    expect(persisted.consecutiveFailures).toBeGreaterThanOrEqual(1);
+    expect(persisted.lastError).not.toBeNull();
+    expect(persisted.lastErrorAt).not.toBeNull();
+  });
+
+  test("startup preserves a prior stuck flag across restart", async () => {
+    // Simulate a previous run that died stuck on a divergence.
+    await writeDaemonState({
+      ...EMPTY_DAEMON_STATE,
+      stuck: true,
+      lastError: "[push] Vault history diverged",
+    });
+
+    await daemonModule.startDaemon();
+    const status = (await ipcHandlers.get("status")?.()) as { stuck: boolean };
+    // A restart does not resolve a divergence, so stuck stays latched.
+    expect(status.stuck).toBe(true);
   });
 });
 

--- a/src/daemon/__tests__/state.test.ts
+++ b/src/daemon/__tests__/state.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the durable daemon-state module: the pure success/failure
+ * transitions (including the stuck latch on divergence), the duration
+ * formatter, and the read/write round-trip with degrade-to-empty on a corrupt
+ * file. No daemon process is started — the transitions are pure functions.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import {
+  applyFailure,
+  applySuccess,
+  type DaemonState,
+  EMPTY_DAEMON_STATE,
+  formatAge,
+  isDivergence,
+  readDaemonState,
+  writeDaemonState,
+} from "../state";
+
+{
+  const require = createRequire(import.meta.url);
+  // biome-ignore lint/style/useNodejsImportProtocol: deliberate alias to bypass mock cache
+  const realFsPromises = require("fs/promises") as typeof import("node:fs/promises");
+  mock.module("node:fs/promises", () => ({ ...realFsPromises, default: realFsPromises }));
+}
+
+const NOW = "2026-06-20T00:00:00.000Z";
+
+describe("daemon state transitions", () => {
+  test("isDivergence matches the GitReconciliationError divergence message", () => {
+    expect(isDivergence("Vault history diverged from 'origin/main'.")).toBe(true);
+    expect(isDivergence("network timeout")).toBe(false);
+  });
+
+  test("applySuccess clears failures and the stuck flag", () => {
+    const stuck: DaemonState = { ...EMPTY_DAEMON_STATE, consecutiveFailures: 3, stuck: true };
+    const next = applySuccess(stuck, NOW);
+    expect(next.lastSuccessAt).toBe(NOW);
+    expect(next.consecutiveFailures).toBe(0);
+    expect(next.lastError).toBeNull();
+    expect(next.stuck).toBe(false);
+  });
+
+  test("applyFailure bumps the counter and latches stuck on divergence", () => {
+    const once = applyFailure(EMPTY_DAEMON_STATE, "push", "Vault history diverged", NOW);
+    expect(once.consecutiveFailures).toBe(1);
+    expect(once.lastError).toBe("[push] Vault history diverged");
+    expect(once.stuck).toBe(true);
+
+    // A later non-divergence failure keeps stuck latched until a success.
+    const again = applyFailure(once, "push", "network timeout", NOW);
+    expect(again.consecutiveFailures).toBe(2);
+    expect(again.stuck).toBe(true);
+  });
+
+  test("applyFailure on a transient error does not set stuck", () => {
+    const next = applyFailure(EMPTY_DAEMON_STATE, "push", "network timeout", NOW);
+    expect(next.stuck).toBe(false);
+  });
+
+  test("formatAge renders coarse durations", () => {
+    expect(formatAge(5_000)).toBe("5s");
+    expect(formatAge(5 * 60_000)).toBe("5m");
+    expect(formatAge(3 * 3_600_000)).toBe("3h");
+    expect(formatAge(2 * 86_400_000)).toBe("2d");
+    expect(formatAge(Number.POSITIVE_INFINITY)).toBe("unknown");
+  });
+});
+
+describe("daemon state persistence", () => {
+  let tmpDir: string;
+  let savedDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = join(
+      process.cwd(),
+      ".agentsync-test-tmp",
+      `daemon-state-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    savedDir = process.env.AGENTSYNC_DIR;
+    process.env.AGENTSYNC_DIR = tmpDir;
+  });
+
+  afterEach(async () => {
+    if (savedDir === undefined) delete process.env.AGENTSYNC_DIR;
+    else process.env.AGENTSYNC_DIR = savedDir;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("round-trips a written state", async () => {
+    const state: DaemonState = {
+      pid: 1234,
+      startedAt: NOW,
+      lastSuccessAt: NOW,
+      lastErrorAt: null,
+      lastError: null,
+      consecutiveFailures: 0,
+      stuck: false,
+    };
+    await writeDaemonState(state);
+    expect(await readDaemonState()).toEqual(state);
+  });
+
+  test("degrades to empty state on a corrupt file", async () => {
+    writeFileSync(join(tmpDir, "daemon-state.json"), "{ not json", "utf8");
+    expect(await readDaemonState()).toEqual(EMPTY_DAEMON_STATE);
+  });
+
+  test("returns empty state when no file exists", async () => {
+    expect(await readDaemonState()).toEqual(EMPTY_DAEMON_STATE);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -12,30 +12,54 @@ import {
 import { AgentPaths } from "../config/paths";
 import { DaemonStatusSchema } from "../config/schema";
 import { IpcClient, IpcServer } from "../core/ipc";
+import { shouldNeverSync } from "../core/sanitizer";
 import { SyncQueue } from "../core/sync-queue";
 import { Watcher } from "../core/watcher";
+import {
+  applyFailure,
+  applySuccess,
+  type DaemonState,
+  EMPTY_DAEMON_STATE,
+  notifyDesktop,
+  readDaemonState,
+  writeDaemonState,
+} from "./state";
 
 /** Format daemon log timestamps consistently across lifecycle events. */
 const ts = () => new Date().toISOString();
 
-// ── Failure tracking ─────────────────────────────────────────────────────
-let consecutiveFailures = 0;
-let lastError: string | null = null;
+// While stuck (vault diverged), a watcher-driven push is RE-ENQUEUED at most
+// this often, so a divergent vault is not hammered on every keystroke. A manual
+// (IPC) push is never throttled — the user asked for it explicitly.
+const STUCK_BACKOFF_MS = 5 * 60 * 1000;
 
-/** Reset failure counters after a successful sync operation. */
+// ── Durable health state ─────────────────────────────────────────────────
+// Mirrors the on-disk daemon-state.json so `daemon status` and `doctor` can
+// report health even after the daemon exits. Initialised in startDaemon.
+let state: DaemonState = EMPTY_DAEMON_STATE;
+let lastWatchAttemptAt = 0;
+
+/** Record a successful sync: clear failures, clear stuck, persist. */
 function recordSuccess(): void {
-  consecutiveFailures = 0;
-  lastError = null;
+  state = applySuccess(state, ts());
+  void writeDaemonState(state);
 }
 
 /**
- * Increment the consecutive failure counter and capture the error message.
- * The operation type is always included in `lastError` for diagnostics.
- * `lastError` MUST NOT include key file content — only paths and error codes.
+ * Record a failed sync: bump the counter, latch `stuck` on divergence, persist,
+ * and fire ONE desktop notification on the transition into stuck — a silently
+ * stalled backup is the worst failure mode for a backup tool.
  */
 function recordFailure(op: "push", msg: string): void {
-  consecutiveFailures += 1;
-  lastError = `[${op}] ${msg}`;
+  const wasStuck = state.stuck;
+  state = applyFailure(state, op, msg, ts());
+  void writeDaemonState(state);
+  if (!wasStuck && state.stuck) {
+    notifyDesktop(
+      "AgentSync: auto-sync stuck",
+      "Vault history diverged — auto-sync is paused until you reset the vault. Run `agentsync doctor`.",
+    );
+  }
 }
 
 // ── Retry logic ──────────────────────────────────────────────────────────
@@ -49,6 +73,23 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
     return await fn();
   } catch {
     return await fn();
+  }
+}
+
+/** Run one push through the queue, recording success/failure into durable state. */
+async function runSyncOnce(): Promise<void> {
+  try {
+    const result = await withRetry(() => performPush());
+    if (result.fatal) {
+      for (const err of result.errors) {
+        log.error(`${ts()} ${err}`);
+      }
+      recordFailure("push", result.errors.join("; "));
+    } else {
+      recordSuccess();
+    }
+  } catch (err) {
+    recordFailure("push", err instanceof Error ? err.message : String(err));
   }
 }
 
@@ -78,6 +119,13 @@ export async function startDaemon(): Promise<void> {
     process.exit(1);
     return; // unreachable but satisfies TS control flow
   }
+
+  // Initialise durable state: keep prior last-success/last-error/stuck so status
+  // and doctor stay accurate across restart, but stamp this process's
+  // pid/startedAt and reset the per-session failure counter.
+  const prior = await readDaemonState();
+  state = { ...prior, pid: process.pid, startedAt: ts(), consecutiveFailures: 0 };
+  void writeDaemonState(state);
 
   const config = await loadConfig(resolveConfigPath(runtime.vaultDir));
   const socketPath = (await import("../config/paths")).resolveDaemonSocketPath();
@@ -113,31 +161,16 @@ export async function startDaemon(): Promise<void> {
   ipc.on("status", async () =>
     DaemonStatusSchema.parse({
       pid: process.pid,
-      consecutiveFailures,
-      lastError,
+      consecutiveFailures: state.consecutiveFailures,
+      lastError: state.lastError,
+      lastSuccessAt: state.lastSuccessAt,
+      startedAt: state.startedAt,
+      stuck: state.stuck,
     }),
   );
 
-  ipc.on("push", async () => {
-    return queue.enqueue(async () => {
-      try {
-        const result = await withRetry(() => performPush());
-        if (result.fatal) {
-          for (const err of result.errors) {
-            log.error(`${ts()} ${err}`);
-          }
-          recordFailure("push", result.errors.join("; "));
-        } else {
-          recordSuccess();
-        }
-        return result;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        recordFailure("push", msg);
-        throw err;
-      }
-    });
-  });
+  // A manual (IPC) push is never throttled — the user asked for it.
+  ipc.on("push", async () => queue.enqueue(runSyncOnce));
 
   await ipc.listen(socketPath);
   log.info(`${ts()} AgentSync daemon started (pid ${process.pid}, socket ${socketPath})`);
@@ -153,28 +186,22 @@ export async function startDaemon(): Promise<void> {
   if (config.agents.copilot) watchTargets.push(AgentPaths.copilot.instructionsDir);
 
   for (const target of watchTargets) {
-    watcher.add(target, debounceMs, async () => {
-      await queue
-        .enqueue(async () => {
-          try {
-            const result = await withRetry(() => performPush());
-            if (result.fatal) {
-              for (const err of result.errors) {
-                log.error(`${ts()} ${err}`);
-              }
-              recordFailure("push", result.errors.join("; "));
-            } else {
-              recordSuccess();
-            }
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            recordFailure("push", msg);
-          }
-        })
-        .catch(() => {
+    watcher.add(
+      target,
+      debounceMs,
+      async () => {
+        // Back off while stuck so a divergent vault is not hammered on every
+        // change; a manual `agentsync push` (IPC) still goes through immediately.
+        if (state.stuck && Date.now() - lastWatchAttemptAt < STUCK_BACKOFF_MS) return;
+        lastWatchAttemptAt = Date.now();
+        await queue.enqueue(runSyncOnce).catch(() => {
           // Queue closed during shutdown — safe to ignore
         });
-    });
+      },
+      // Pre-filter never-sync paths at the watch layer so high-churn dirs
+      // (sessions, history) never reset the debounce or wake a no-op push.
+      shouldNeverSync,
+    );
   }
 
   // No periodic pull and no pull IPC handler: the vault is push-only backup.

--- a/src/daemon/state.ts
+++ b/src/daemon/state.ts
@@ -1,0 +1,161 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { resolveAgentSyncHome } from "../config/paths";
+
+/**
+ * Durable daemon health state, persisted to disk so `daemon status` and
+ * `doctor` can report last-success/last-error and a stuck condition even after
+ * the daemon process has exited or crashed. The in-memory daemon mirrors this
+ * and writes it on every success/failure.
+ */
+export const DaemonStateSchema = z.object({
+  /** PID of the daemon that last wrote this file, or null when never run. */
+  pid: z.number().int().positive().nullable().default(null),
+  /** ISO timestamp the current daemon process started, or null. */
+  startedAt: z.string().datetime().nullable().default(null),
+  // Validated as ISO so a hand-edited non-date value fails the whole parse and
+  // degrades to EMPTY_DAEMON_STATE, rather than reaching Date.parse as NaN and
+  // being silently mis-reported by doctor/status.
+  /** ISO timestamp of the last successful push, or null when none has succeeded. */
+  lastSuccessAt: z.string().datetime().nullable().default(null),
+  /** ISO timestamp of the last failed push, or null. */
+  lastErrorAt: z.string().datetime().nullable().default(null),
+  /** Last failure message (paths/codes only — never key material), or null. */
+  lastError: z.string().nullable().default(null),
+  consecutiveFailures: z.number().int().min(0).default(0),
+  /**
+   * True when the vault has diverged (DIVERGED_HISTORY): the daemon cannot make
+   * progress until a human resets the vault. Set so `doctor`/`status` escalate
+   * loudly and the daemon backs off instead of hammering a doomed push.
+   */
+  stuck: z.boolean().default(false),
+});
+
+export type DaemonState = z.infer<typeof DaemonStateSchema>;
+
+/** The shape returned when no state has ever been persisted. */
+export const EMPTY_DAEMON_STATE: DaemonState = {
+  pid: null,
+  startedAt: null,
+  lastSuccessAt: null,
+  lastErrorAt: null,
+  lastError: null,
+  consecutiveFailures: 0,
+  stuck: false,
+};
+
+function statePath(): string {
+  return join(resolveAgentSyncHome(), "daemon-state.json");
+}
+
+/**
+ * Read durable daemon state. A missing, truncated, or hand-edited file degrades
+ * to {@link EMPTY_DAEMON_STATE} rather than throwing — status/doctor must never
+ * crash because the state file is unreadable.
+ */
+export async function readDaemonState(): Promise<DaemonState> {
+  try {
+    const parsed = DaemonStateSchema.safeParse(JSON.parse(await readFile(statePath(), "utf8")));
+    return parsed.success ? parsed.data : EMPTY_DAEMON_STATE;
+  } catch {
+    return EMPTY_DAEMON_STATE;
+  }
+}
+
+/**
+ * Best-effort persist of daemon state. A write failure is swallowed: losing the
+ * state file only costs status/doctor visibility, never the sync itself.
+ */
+export async function writeDaemonState(state: DaemonState): Promise<void> {
+  try {
+    await mkdir(resolveAgentSyncHome(), { recursive: true });
+    // Write to a temp file then rename: rename(2) is atomic on a single
+    // filesystem, so a crash or two overlapping writes never leave a torn
+    // half-written JSON that readDaemonState would discard.
+    const dest = statePath();
+    const tmp = `${dest}.tmp`;
+    await writeFile(tmp, JSON.stringify(state, null, 2), "utf8");
+    await rename(tmp, dest);
+  } catch {
+    // Intentionally ignored — see doc comment.
+  }
+}
+
+/**
+ * True when a push error message indicates the vault has diverged. The
+ * GitReconciliationError for DIVERGED_HISTORY always contains "diverged"; this
+ * is the marker the daemon uses to flip into the stuck/back-off state.
+ */
+export function isDivergence(message: string): boolean {
+  return /diverged/i.test(message);
+}
+
+/** Apply a successful sync: clears failures and any stuck condition. */
+export function applySuccess(state: DaemonState, nowIso: string): DaemonState {
+  return {
+    ...state,
+    lastSuccessAt: nowIso,
+    consecutiveFailures: 0,
+    lastError: null,
+    stuck: false,
+  };
+}
+
+/**
+ * Apply a failed sync: bumps the failure counter, records the message, and
+ * latches `stuck` when the failure is a divergence (a divergence does not heal
+ * on its own — only a human resetting the vault, then a success, clears it).
+ */
+export function applyFailure(
+  state: DaemonState,
+  op: string,
+  message: string,
+  nowIso: string,
+): DaemonState {
+  return {
+    ...state,
+    consecutiveFailures: state.consecutiveFailures + 1,
+    lastErrorAt: nowIso,
+    lastError: `[${op}] ${message}`,
+    stuck: state.stuck || isDivergence(message),
+  };
+}
+
+/** Render a millisecond age as a coarse human duration ("9m", "3h", "2d"). */
+export function formatAge(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "unknown";
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+/**
+ * Fire a best-effort desktop notification. Used to escalate a stuck daemon (a
+ * silent backup failure is the worst outcome for a backup tool). Never throws:
+ * a missing `osascript`/`notify-send`, or Windows where neither exists, is a
+ * silent no-op. Fire-and-forget — the daemon does not await delivery.
+ */
+export function notifyDesktop(title: string, body: string): void {
+  try {
+    if (process.platform === "darwin") {
+      Bun.spawn(
+        [
+          "osascript",
+          "-e",
+          `display notification ${JSON.stringify(body)} with title ${JSON.stringify(title)}`,
+        ],
+        { stdout: "ignore", stderr: "ignore" },
+      );
+    } else if (process.platform === "linux") {
+      Bun.spawn(["notify-send", title, body], { stdout: "ignore", stderr: "ignore" });
+    }
+    // Windows has no built-in CLI toast; skip rather than depend on PowerShell.
+  } catch {
+    // Best-effort only.
+  }
+}


### PR DESCRIPTION
## Why

For a *backup* daemon, the worst failure is a silent one. Today the daemon's failure state lived only in memory (lost on restart), there was no notification or staleness signal, a vault divergence made it retry a doomed push on every keystroke forever, and high-churn agent dirs (sessions/history) woke pushes that snapshot nothing. A user could go weeks with zero successful backups and no signal.

Fifth PR in the series (follows #184, #185, #186, #187).

## What

- **Durable health state** — the daemon persists `daemon-state.json` (last success, last error, consecutive failures, stuck flag) and updates it on every success/failure, so health survives a crash/restart.
- **`daemon status`** now reports last-successful-sync age, failures, and a **stuck** flag, and **falls back to the durable file when the daemon is down** — you can still see when sync last worked.
- **`doctor`** gains a **Daemon sync health** row: **fails** when stuck, **warns** when installed but the last success is >24h old (or never), **passes** on a recent success. A silent backup failure is now loud.
- **Divergence escalation** — on `DIVERGED_HISTORY` the daemon latches `stuck`, fires one desktop notification (osascript/notify-send, best-effort), and **backs off** watcher retries to once per 5 min instead of hammering. A manual `agentsync push` is never throttled; the next success clears it.
- **Watcher pre-filter** — never-sync paths are filtered at the watch layer, so a noisy config dir no longer resets the debounce or wakes a no-op push.

## Review fixes (caught in senior review)

Atomic temp+rename for the state file (no torn write on crash); ISO-`datetime()` validation on stored timestamps (a corrupt value degrades to empty instead of a misleading `Date.parse` NaN); isolated `AGENTSYNC_DIR` in the daemon test harness so tests never touch the real `~/.config/agentsync` or fire real notifications.

## Tests

`state.test.ts` (pure transitions incl. the stuck latch, persistence round-trip, corrupt-file degrade, formatAge); watcher `shouldSkip` filter; `doctor` health (stuck/never/not-installed/stale/recent); `daemon status` stuck-escalation, last-sync age, and **offline durable-file fallback**; daemon-index persistence-on-failure, startup-preserves-stuck, and health-field exposure. Full suite: 966 pass / 0 fail.

## CI note

`bun test` exits non-zero on the per-file coverage floor; CI treats 0-fail as success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
